### PR TITLE
prevent busy waiting of reactor thread

### DIFF
--- a/hazelcast/connection.py
+++ b/hazelcast/connection.py
@@ -219,10 +219,10 @@ class Connection(object):
 
     def write(self, data):
         # must be implemented by subclass
-        pass
+        raise NotImplementedError
 
     def close(self, cause):
-        pass
+        raise NotImplementedError
 
     def __repr__(self):
         return "Connection(address=%s, id=%s)" % (self._address, self.id)

--- a/tests/base.py
+++ b/tests/base.py
@@ -77,6 +77,9 @@ class HazelcastTestCase(unittest.TestCase):
         self.assertEqual(event.old_value, old_value)
         self.assertEqual(event.number_of_affected_entries, number_of_affected_entries)
 
+    def set_logging_level(self, level):
+        logging.getLogger().setLevel(level)
+
     def start_new_thread(self, target):
         t = Thread(target=target)
         t.start()


### PR DESCRIPTION
Prevent busy waiting of reactor by checking for writes when there is something
in the queue to write. To decrease latency, directly write to socket if
queue is empty.