### PR TITLE
Refactor for addEntryListener methods of Map/MultiMap/ReplicatedMap

### DIFF
--- a/examples/main.py
+++ b/examples/main.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
     def item_removed(event):
         print("item_removed", event)
 
-    print(my_map.add_entry_listener(include_value=True, added=item_added, removed=item_removed))
+    print(my_map.add_entry_listener(include_value=True, added_func=item_added, removed_func=item_removed))
 
     print("map.size", my_map.size().result())
     key = random.random()

--- a/tests/proxy/map_test.py
+++ b/tests/proxy/map_test.py
@@ -31,7 +31,7 @@ class MapTest(SingleMemberTestCase):
 
     def test_add_entry_listener_item_added(self):
         collector = event_collector()
-        self.map.add_entry_listener(include_value=True, added=collector)
+        self.map.add_entry_listener(include_value=True, added_func=collector)
         self.map.put('key', 'value')
 
         def assert_event():
@@ -43,7 +43,7 @@ class MapTest(SingleMemberTestCase):
 
     def test_add_entry_listener_item_removed(self):
         collector = event_collector()
-        self.map.add_entry_listener(include_value=True, removed=collector)
+        self.map.add_entry_listener(include_value=True, removed_func=collector)
         self.map.put('key', 'value')
         self.map.remove('key')
 
@@ -56,7 +56,7 @@ class MapTest(SingleMemberTestCase):
 
     def test_add_entry_listener_item_updated(self):
         collector = event_collector()
-        self.map.add_entry_listener(include_value=True, updated=collector)
+        self.map.add_entry_listener(include_value=True, updated_func=collector)
         self.map.put('key', 'value')
         self.map.put('key', 'new_value')
 
@@ -70,7 +70,7 @@ class MapTest(SingleMemberTestCase):
 
     def test_add_entry_listener_item_expired(self):
         collector = event_collector()
-        self.map.add_entry_listener(include_value=True, expired=collector)
+        self.map.add_entry_listener(include_value=True, expired_func=collector)
         self.map.put('key', 'value', ttl=0.1)
 
         def assert_event():
@@ -82,7 +82,7 @@ class MapTest(SingleMemberTestCase):
 
     def test_add_entry_listener_with_key(self):
         collector = event_collector()
-        self.map.add_entry_listener(key='key1', include_value=True, added=collector)
+        self.map.add_entry_listener(key='key1', include_value=True, added_func=collector)
         self.map.put('key2', 'value2')
         self.map.put('key1', 'value1')
 
@@ -95,7 +95,7 @@ class MapTest(SingleMemberTestCase):
 
     def test_add_entry_listener_with_predicate(self):
         collector = event_collector()
-        self.map.add_entry_listener(predicate=SqlPredicate("this == value1"), include_value=True, added=collector)
+        self.map.add_entry_listener(predicate=SqlPredicate("this == value1"), include_value=True, added_func=collector)
         self.map.put('key2', 'value2')
         self.map.put('key1', 'value1')
 
@@ -108,7 +108,7 @@ class MapTest(SingleMemberTestCase):
 
     def test_add_entry_listener_with_key_and_predicate(self):
         collector = event_collector()
-        self.map.add_entry_listener(key='key1', predicate=SqlPredicate("this == value3"), include_value=True, added=collector)
+        self.map.add_entry_listener(key='key1', predicate=SqlPredicate("this == value3"), include_value=True, added_func=collector)
         self.map.put('key2', 'value2')
         self.map.put('key1', 'value1')
         self.map.remove('key1')
@@ -349,7 +349,7 @@ class MapTest(SingleMemberTestCase):
 
     def test_remove_entry_listener(self):
         collector = event_collector()
-        id = self.map.add_entry_listener(added=collector)
+        id = self.map.add_entry_listener(added_func=collector)
 
         self.map.put('key', 'value')
         self.assertTrueEventually(lambda: self.assertEqual(len(collector.events), 1))

--- a/tests/proxy/multi_map_test.py
+++ b/tests/proxy/multi_map_test.py
@@ -18,7 +18,7 @@ class MultiMapTest(SingleMemberTestCase):
 
     def test_add_entry_listener_item_added(self):
         collector = event_collector()
-        self.multi_map.add_entry_listener(include_value=True, added=collector)
+        self.multi_map.add_entry_listener(include_value=True, added_func=collector)
         self.multi_map.put('key', 'value')
 
         def assert_event():
@@ -30,7 +30,7 @@ class MultiMapTest(SingleMemberTestCase):
 
     def test_add_entry_listener_item_removed(self):
         collector = event_collector()
-        self.multi_map.add_entry_listener(include_value=True, removed=collector)
+        self.multi_map.add_entry_listener(include_value=True, removed_func=collector)
         self.multi_map.put('key', 'value')
         self.multi_map.remove('key', 'value')
 
@@ -43,7 +43,7 @@ class MultiMapTest(SingleMemberTestCase):
 
     def test_add_entry_listener_clear_all(self):
         collector = event_collector()
-        self.multi_map.add_entry_listener(include_value=True, clear_all=collector)
+        self.multi_map.add_entry_listener(include_value=True, clear_all_func=collector)
         self.multi_map.put('key', 'value')
         self.multi_map.clear()
 
@@ -56,7 +56,7 @@ class MultiMapTest(SingleMemberTestCase):
 
     def test_add_entry_listener_with_key(self):
         collector = event_collector()
-        id = self.multi_map.add_entry_listener(key='key1', include_value=True, added=collector)
+        id = self.multi_map.add_entry_listener(key='key1', include_value=True, added_func=collector)
         self.multi_map.put('key2', 'value2')
         self.multi_map.put('key1', 'value1')
 
@@ -161,7 +161,7 @@ class MultiMapTest(SingleMemberTestCase):
 
     def test_remove_entry_listener(self):
         collector = event_collector()
-        id = self.multi_map.add_entry_listener(added=collector)
+        id = self.multi_map.add_entry_listener(added_func=collector)
 
         self.multi_map.put('key', 'value')
         self.assertTrueEventually(lambda: self.assertEqual(len(collector.events), 1))

--- a/tests/proxy/replicated_map_test.py
+++ b/tests/proxy/replicated_map_test.py
@@ -15,7 +15,7 @@ class ReplicatedMapTest(SingleMemberTestCase):
 
     def test_add_entry_listener_item_added(self):
         collector = event_collector()
-        self.replicated_map.add_entry_listener(added=collector)
+        self.replicated_map.add_entry_listener(added_func=collector)
         self.replicated_map.put('key', 'value')
 
         def assert_event():
@@ -27,7 +27,7 @@ class ReplicatedMapTest(SingleMemberTestCase):
 
     def test_add_entry_listener_item_removed(self):
         collector = event_collector()
-        self.replicated_map.add_entry_listener(removed=collector)
+        self.replicated_map.add_entry_listener(removed_func=collector)
         self.replicated_map.put('key', 'value')
         self.replicated_map.remove('key')
 
@@ -40,7 +40,7 @@ class ReplicatedMapTest(SingleMemberTestCase):
 
     def test_add_entry_listener_item_updated(self):
         collector = event_collector()
-        self.replicated_map.add_entry_listener(updated=collector)
+        self.replicated_map.add_entry_listener(updated_func=collector)
         self.replicated_map.put('key', 'value')
         self.replicated_map.put('key', 'new_value')
 
@@ -54,7 +54,7 @@ class ReplicatedMapTest(SingleMemberTestCase):
 
     def test_add_entry_listener_item_evicted(self):
         collector = event_collector()
-        self.replicated_map.add_entry_listener(evicted=collector)
+        self.replicated_map.add_entry_listener(evicted_func=collector)
         self.replicated_map.put('key', 'value', ttl=1)
 
         def assert_event():
@@ -66,7 +66,7 @@ class ReplicatedMapTest(SingleMemberTestCase):
 
     def test_add_entry_listener_with_key(self):
         collector = event_collector()
-        id = self.replicated_map.add_entry_listener(key='key1', added=collector)
+        id = self.replicated_map.add_entry_listener(key='key1', added_func=collector)
         self.replicated_map.put('key2', 'value2')
         self.replicated_map.put('key1', 'value1')
 
@@ -79,7 +79,7 @@ class ReplicatedMapTest(SingleMemberTestCase):
 
     def test_add_entry_listener_with_predicate(self):
         collector = event_collector()
-        self.replicated_map.add_entry_listener(predicate=SqlPredicate("this == value1"), added=collector)
+        self.replicated_map.add_entry_listener(predicate=SqlPredicate("this == value1"), added_func=collector)
         self.replicated_map.put('key2', 'value2')
         self.replicated_map.put('key1', 'value1')
 
@@ -92,7 +92,7 @@ class ReplicatedMapTest(SingleMemberTestCase):
 
     def test_add_entry_listener_with_key_and_predicate(self):
         collector = event_collector()
-        self.replicated_map.add_entry_listener(key='key1', predicate=SqlPredicate("this == value3"), added=collector)
+        self.replicated_map.add_entry_listener(key='key1', predicate=SqlPredicate("this == value3"), added_func=collector)
         self.replicated_map.put('key2', 'value2')
         self.replicated_map.put('key1', 'value1')
         self.replicated_map.remove('key1')
@@ -107,7 +107,7 @@ class ReplicatedMapTest(SingleMemberTestCase):
 
     def test_add_entry_listener_clear_all(self):
         collector = event_collector()
-        self.replicated_map.add_entry_listener(clear_all=collector)
+        self.replicated_map.add_entry_listener(clear_all_func=collector)
         self.replicated_map.put('key', 'value')
         self.replicated_map.clear()
 
@@ -180,7 +180,7 @@ class ReplicatedMapTest(SingleMemberTestCase):
 
     def test_remove_entry_listener(self):
         collector = event_collector()
-        id = self.replicated_map.add_entry_listener(added=collector)
+        id = self.replicated_map.add_entry_listener(added_func=collector)
 
         self.replicated_map.put('key', 'value')
         self.assertTrueEventually(lambda: self.assertEqual(len(collector.events), 1))

--- a/tests/reconnect_test.py
+++ b/tests/reconnect_test.py
@@ -62,7 +62,7 @@ class ReconnectTest(HazelcastTestCase):
         map = client.get_map("map")
 
         collector = event_collector()
-        reg_id = map.add_entry_listener(added=collector)
+        reg_id = map.add_entry_listener(added_func=collector)
         self.logger.info("Registered listener with id %s", reg_id)
         member.shutdown()
         sleep(3)


### PR DESCRIPTION
Refactor (continue) is done for indicating parameters which are functions.

First part of this refactor is: https://github.com/hazelcast/hazelcast-python-client/pull/19
