### PR TITLE
Refactor for add_listener method in set_test, queue_test and list_test

### DIFF
--- a/tests/proxy/list_test.py
+++ b/tests/proxy/list_test.py
@@ -9,7 +9,7 @@ class ListTest(SingleMemberTestCase):
 
     def test_add_entry_listener_item_added(self):
         collector = event_collector()
-        self.list.add_listener(include_value=False, item_added=collector)
+        self.list.add_listener(include_value=False, item_added_func=collector)
         self.list.add('item-value')
 
         def assert_event():
@@ -22,7 +22,7 @@ class ListTest(SingleMemberTestCase):
 
     def test_add_entry_listener_item_added_include_value(self):
         collector = event_collector()
-        self.list.add_listener(include_value=True, item_added=collector)
+        self.list.add_listener(include_value=True, item_added_func=collector)
         self.list.add('item-value')
 
         def assert_event():
@@ -35,7 +35,7 @@ class ListTest(SingleMemberTestCase):
 
     def test_add_entry_listener_item_removed(self):
         collector = event_collector()
-        self.list.add_listener(include_value=False, item_removed=collector)
+        self.list.add_listener(include_value=False, item_removed_func=collector)
         self.list.add('item-value')
         self.list.remove('item-value')
 
@@ -49,7 +49,7 @@ class ListTest(SingleMemberTestCase):
 
     def test_add_entry_listener_item_removed_include_value(self):
         collector = event_collector()
-        self.list.add_listener(include_value=True, item_removed=collector)
+        self.list.add_listener(include_value=True, item_removed_func=collector)
         self.list.add('item-value')
         self.list.remove('item-value')
 
@@ -63,7 +63,7 @@ class ListTest(SingleMemberTestCase):
 
     def test_remove_entry_listener_item_added(self):
         collector = event_collector()
-        reg_id = self.list.add_listener(include_value=False, item_added=collector)
+        reg_id = self.list.add_listener(include_value=False, item_added_func=collector)
         self.list.remove_listener(reg_id)
         self.list.add('item-value')
 

--- a/tests/proxy/queue_test.py
+++ b/tests/proxy/queue_test.py
@@ -18,7 +18,7 @@ class QueueTest(SingleMemberTestCase):
 
     def test_add_entry_listener_item_added(self):
         collector = event_collector()
-        self.queue.add_listener(include_value=False, item_added=collector)
+        self.queue.add_listener(include_value=False, item_added_func=collector)
         self.queue.add('item-value')
 
         def assert_event():
@@ -31,7 +31,7 @@ class QueueTest(SingleMemberTestCase):
 
     def test_add_entry_listener_item_added_include_value(self):
         collector = event_collector()
-        self.queue.add_listener(include_value=True, item_added=collector)
+        self.queue.add_listener(include_value=True, item_added_func=collector)
         self.queue.add('item-value')
 
         def assert_event():
@@ -44,7 +44,7 @@ class QueueTest(SingleMemberTestCase):
 
     def test_add_entry_listener_item_removed(self):
         collector = event_collector()
-        self.queue.add_listener(include_value=False, item_removed=collector)
+        self.queue.add_listener(include_value=False, item_removed_func=collector)
         self.queue.add('item-value')
         self.queue.remove('item-value')
 
@@ -58,7 +58,7 @@ class QueueTest(SingleMemberTestCase):
 
     def test_add_entry_listener_item_removed_include_value(self):
         collector = event_collector()
-        self.queue.add_listener(include_value=True, item_removed=collector)
+        self.queue.add_listener(include_value=True, item_removed_func=collector)
         self.queue.add('item-value')
         self.queue.remove('item-value')
 
@@ -72,7 +72,7 @@ class QueueTest(SingleMemberTestCase):
 
     def test_remove_entry_listener_item_added(self):
         collector = event_collector()
-        reg_id = self.queue.add_listener(include_value=False, item_added=collector)
+        reg_id = self.queue.add_listener(include_value=False, item_added_func=collector)
         self.queue.remove_listener(reg_id)
         self.queue.add('item-value')
 

--- a/tests/proxy/set_test.py
+++ b/tests/proxy/set_test.py
@@ -9,7 +9,7 @@ class SetTest(SingleMemberTestCase):
 
     def test_add_entry_listener_item_added(self):
         collector = event_collector()
-        self.set.add_listener(include_value=False, item_added=collector)
+        self.set.add_listener(include_value=False, item_added_func=collector)
         self.set.add('item-value')
 
         def assert_event():
@@ -22,7 +22,7 @@ class SetTest(SingleMemberTestCase):
 
     def test_add_entry_listener_item_added_include_value(self):
         collector = event_collector()
-        self.set.add_listener(include_value=True, item_added=collector)
+        self.set.add_listener(include_value=True, item_added_func=collector)
         self.set.add('item-value')
 
         def assert_event():
@@ -35,7 +35,7 @@ class SetTest(SingleMemberTestCase):
 
     def test_add_entry_listener_item_removed(self):
         collector = event_collector()
-        self.set.add_listener(include_value=False, item_removed=collector)
+        self.set.add_listener(include_value=False, item_removed_func=collector)
         self.set.add('item-value')
         self.set.remove('item-value')
 
@@ -49,7 +49,7 @@ class SetTest(SingleMemberTestCase):
 
     def test_add_entry_listener_item_removed_include_value(self):
         collector = event_collector()
-        self.set.add_listener(include_value=True, item_removed=collector)
+        self.set.add_listener(include_value=True, item_removed_func=collector)
         self.set.add('item-value')
         self.set.remove('item-value')
 
@@ -63,7 +63,7 @@ class SetTest(SingleMemberTestCase):
 
     def test_remove_entry_listener_item_added(self):
         collector = event_collector()
-        reg_id = self.set.add_listener(include_value=False, item_added=collector)
+        reg_id = self.set.add_listener(include_value=False, item_added_func=collector)
         self.set.remove_listener(reg_id)
         self.set.add('item-value')
 


### PR DESCRIPTION
Refactor (continue) is done for indicating parameters which are functions.

First part of this refactor is: https://github.com/hazelcast/hazelcast-python-client/pull/21 , https://github.com/hazelcast/hazelcast-python-client/pull/24 and https://github.com/hazelcast/hazelcast-python-client/pull/25