### PR TITLE
ApiDoc for Queue and Transactional Proxies

### DIFF
--- a/hazelcast/proxy/queue.py
+++ b/hazelcast/proxy/queue.py
@@ -31,7 +31,18 @@ class Full(Exception):
 
 
 class Queue(PartitionSpecificProxy):
+    """
+    Concurrent, blocking, distributed, observable queue. Queue is not a partitioned data-structure. All of the Queue
+    content is stored in a single machine (and in the backup). Queue will not scale by adding more members
+    in the cluster.
+    """
     def add(self, item):
+        """
+        Adds the specified item to this queue if there is available space.
+
+        :param item: (object), the specified item.
+        :return: (bool), ``true`` if element is successfully added, ``false`` otherwise.
+        """
         def result_fnc(f):
             if f.result():
                 return True
@@ -40,6 +51,12 @@ class Queue(PartitionSpecificProxy):
         return self.offer(item).continue_with(result_fnc)
 
     def add_all(self, items):
+        """
+        Adds the elements in the specified collection to this queue.
+
+        :param items: (Collection), collection which includes the items to be added.
+        :return: (bool), ``true`` if this queue is changed after call, ``false`` otherwise.
+        """
         check_not_none(items, "Value can't be None")
         data_items = []
         for item in items:
@@ -48,6 +65,14 @@ class Queue(PartitionSpecificProxy):
         return self._encode_invoke(queue_add_all_codec, data_list=data_items)
 
     def add_listener(self, include_value=False, item_added_func=None, item_removed_func=None):
+        """
+        Adds an item listener for this queue. Listener will be notified for all queue add/remove events.
+
+        :param include_value: (bool), whether received events include the updated item or not (optional).
+        :param item_added_func: Function to be called when an item is added to this set (optional).
+        :param item_removed_func: Function to be called when an item is deleted from this set (optional).
+        :return: (str), a registration id which is used as a key to remove the listener.
+        """
         request = queue_add_listener_codec.encode_request(self.name, include_value, False)
 
         def handle_event_item(item, uuid, event_type):
@@ -68,14 +93,29 @@ class Queue(PartitionSpecificProxy):
                                      self.partition_key)
 
     def clear(self):
+        """
+        Clears this queue. Queue will be empty after this call.
+        """
         return self._encode_invoke(queue_clear_codec)
 
     def contains(self, item):
+        """
+        Determines whether this queue contains the specified item or not.
+
+        :param item: (object), the specified item to be searched.
+        :return: (bool), ``true`` if the specified item exists in this queue, ``false`` otherwise.
+        """
         check_not_none(item, "Item can't be None")
         item_data = self._to_data(item)
         return self._encode_invoke(queue_contains_codec, value=item_data)
 
     def contains_all(self, items):
+        """
+        Determines whether this queue contains all of the items in the specified collection or not.
+
+        :param items: (Collection), the specified collection which includes the items to be searched.
+        :return: (bool), ``true`` if all of the items in the specified collection exist in this queue, ``false`` otherwise.
+        """
         check_not_none(items, "Items can't be None")
         data_items = []
         for item in items:
@@ -84,6 +124,19 @@ class Queue(PartitionSpecificProxy):
         return self._encode_invoke(queue_contains_all_codec, data_list=data_items)
 
     def drain_to(self, list, max_size=-1):
+        """
+        Transfers all available items to the given `list`_ and removes these items from this queue. If a max_size is
+        specified, it transfers at most the given number of items. In case of a failure, an item can exist in both
+        collections or none of them.
+
+        This operation may be more efficient than polling elements repeatedly and putting into collection.
+
+        :param list: (`list`_), the list where the items in this queue will be transferred.
+        :param max_size: (int), the maximum number items to transfer (optional).
+        :return: (int), number of transferred items.
+
+        .. _list: https://docs.python.org/2/library/functions.html#list
+        """
         def drain_result(f):
             resp = f.result()
             list.extend(resp)
@@ -93,36 +146,93 @@ class Queue(PartitionSpecificProxy):
             drain_result)
 
     def iterator(self):
+        """
+        Returns all of the items in this queue.
+
+        :return: (Sequence), collection of items in this queue.
+        """
         return self._encode_invoke(queue_iterator_codec)
 
     def is_empty(self):
+        """
+        Determines whether this set is empty or not.
+
+        :return: (bool), ``true`` if this queue is empty, ``false`` otherwise.
+        """
         return self._encode_invoke(queue_is_empty_codec)
 
     def offer(self, item, timeout=0):
+        """
+        Inserts the specified element into this queue if it is possible to do so immediately without violating capacity
+        restrictions. Returns ``true`` upon success. If there is no space currently available:
+            * If a timeout is provided, it waits until this timeout elapses and returns the result.
+            * If a timeout is not provided, returns ``false`` immediately.
+
+        :param item: (object), the item to be added.
+        :param timeout: (long), maximum time in seconds to wait for addition (optional).
+        :return: (bool), ``true`` if the element was added to this queue, ``false`` otherwise.
+        """
         check_not_none(item, "Value can't be None")
         element_data = self._to_data(item)
         return self._encode_invoke(queue_offer_codec, value=element_data, timeout_millis=to_millis(timeout))
 
     def peek(self):
+        """
+        Retrieves the head of queue without removing it from the queue. If the queue is empty, returns ``None``.
+
+        :return: (object), the head of this queue, or ``None`` if this queue is empty.
+        """
         return self._encode_invoke(queue_peek_codec)
 
     def poll(self, timeout=0):
+        """
+        Retrieves and removes the head of this queue, if this queue is empty:
+            * If a timeout is provided, it waits until this timeout elapses and returns the result.
+            * If a timeout is not provided, returns ``None``.
+
+        :param timeout: (long), maximum time in seconds to wait for addition (optional).
+        :return: (object), the head of this queue, or ``None`` if this queue is empty or specified timeout elapses before an
+        item is added to the queue.
+        """
         return self._encode_invoke(queue_poll_codec, timeout_millis=to_millis(timeout))
 
     def put(self, item):
+        """
+        Adds the specified element into this queue. If there is no space, it waits until necessary space becomes
+        available.
+
+        :param item: (object), the specified item.
+        """
         check_not_none(item, "Value can't be None")
         element_data = self._to_data(item)
         return self._encode_invoke(queue_put_codec, value=element_data)
 
     def remaining_capacity(self):
+        """
+        Returns the remaining capacity of this queue.
+
+        :return: (int), remaining capacity of this queue.
+        """
         return self._encode_invoke(queue_remaining_capacity_codec)
 
     def remove(self, item):
+        """
+        Removes the specified element from the queue if it exists.
+
+        :param item: (object), the specified element to be removed.
+        :return: (bool), ``true`` if the specified element exists in this queue.
+        """
         check_not_none(item, "Value can't be None")
         item_data = self._to_data(item)
         return self._encode_invoke(queue_remove_codec, value=item_data)
 
     def remove_all(self, items):
+        """
+        Removes all of the elements of the specified collection from this queue.
+
+        :param items: (Collection), the specified collection.
+        :return: (bool), ``true`` if the call changed this queue, ``false`` otherwise.
+        """
         check_not_none(items, "Value can't be None")
         data_items = []
         for item in items:
@@ -131,9 +241,22 @@ class Queue(PartitionSpecificProxy):
         return self._encode_invoke(queue_compare_and_remove_all_codec, data_list=data_items)
 
     def remove_listener(self, registration_id):
+        """
+        Removes the specified item listener. Returns silently if the specified listener was not added before.
+
+        :param registration_id: (str), id of the listener to be deleted.
+        :return: (bool), ``true`` if the item listener is removed, ``false`` otherwise.
+        """
         return self._stop_listening(registration_id, lambda i: queue_remove_listener_codec.encode_request(self.name, i))
 
     def retain_all(self, items):
+        """
+        Removes the items which are not contained in the specified collection. In other words, only the items that
+        are contained in the specified collection will be retained.
+
+        :param items: (Collection), collection which includes the elements to be retained in this set.
+        :return: (bool), ``true`` if this queue changed as a result of the call.
+        """
         check_not_none(items, "Value can't be None")
         data_items = []
         for item in items:
@@ -142,7 +265,19 @@ class Queue(PartitionSpecificProxy):
         return self._encode_invoke(queue_compare_and_retain_all_codec, data_list=data_items)
 
     def size(self):
+        """
+        Returns the number of elements in this collection. If the size is greater than sys.maxint, it returns
+        sys.maxint.
+
+        :return: (int), size of the queue.
+        """
         return self._encode_invoke(queue_size_codec)
 
     def take(self):
+        """
+        Retrieves and removes the head of this queue, if necessary, waits until an item becomes available.
+
+        :return: (object), the head of this queue.
+        """
+
         return self._encode_invoke(queue_take_codec)

--- a/hazelcast/proxy/transactional_list.py
+++ b/hazelcast/proxy/transactional_list.py
@@ -5,13 +5,33 @@ from hazelcast.util import check_not_none
 
 
 class TransactionalList(TransactionalProxy):
+    """
+    Transactional implementation of :class:`~hazelcast.proxy.list.List`.
+    """
     def add(self, item):
+        """
+        Transactional implementation of :func:`List.add(item) <hazelcast.proxy.list.List.add>`
+
+        :param item: (object), the new item to be added.
+        :return: (bool), ``true`` if the item is added successfully, ``false`` otherwise.
+        """
         check_not_none(item, "item can't be none")
         return self._encode_invoke(transactional_list_add_codec, item=self._to_data(item))
 
     def remove(self, item):
+        """
+        Transactional implementation of :func:`List.remove(item) <hazelcast.proxy.list.List.remove>`
+
+        :param item: (object), the specified item to be removed.
+        :return: (bool), ``true`` if the item is removed successfully, ``false`` otherwise.
+        """
         check_not_none(item, "item can't be none")
         return self._encode_invoke(transactional_list_remove_codec, item=self._to_data(item))
 
     def size(self):
+        """
+        Transactional implementation of :func:`List.size() <hazelcast.proxy.list.List.size>`
+
+        :return: (int), the size of the list.
+        """
         return self._encode_invoke(transactional_list_size_codec)

--- a/hazelcast/proxy/transactional_map.py
+++ b/hazelcast/proxy/transactional_map.py
@@ -9,49 +9,139 @@ from hazelcast.util import check_not_none, to_millis
 
 
 class TransactionalMap(TransactionalProxy):
+    """
+    Transactional implementation of :class:`~hazelcast.proxy.map.Map`.
+    """
     def contains_key(self, key):
+        """
+        Transactional implementation of :func:`Map.contains_key(key) <hazelcast.proxy.map.Map.contains_key>`
+
+        :param key: (object), the specified key.
+        :return: (bool), ``true`` if this map contains an entry for the specified key, ``false`` otherwise.
+        """
         check_not_none(key, "key can't be none")
         return self._encode_invoke(transactional_map_contains_key_codec, key=self._to_data(key))
 
     def get(self, key):
+        """
+        Transactional implementation of :func:`Map.get(key) <hazelcast.proxy.map.Map.get>`
+
+        :param key: (object), the specified key.
+        :return: (object), the value for the specified key.
+        """
         check_not_none(key, "key can't be none")
         return self._encode_invoke(transactional_map_get_codec, key=self._to_data(key))
 
     def get_for_update(self, key):
+        """
+        Locks the key and then gets and returns the value to which the specified key is mapped. Lock will be released at
+        the end of the transaction (either commit or rollback).
+
+        :param key: (object), the specified key.
+        :return: (object), the value for the specified key.
+
+        .. seealso::
+            :func:`Map.get(key) <hazelcast.proxy.map.Map.get>`
+        """
         check_not_none(key, "key can't be none")
         return self._encode_invoke(transactional_map_get_for_update_codec, key=self._to_data(key))
 
     def size(self):
+        """
+        Transactional implementation of :func:`Map.size() <hazelcast.proxy.map.Map.size>`
+
+        :return: (int), number of entries in this map.
+        """
         return self._encode_invoke(transactional_map_size_codec)
 
     def is_empty(self):
+        """
+        Transactional implementation of :func:`Map.is_empty() <hazelcast.proxy.map.Map.is_empty>`
+
+        :return: (bool), ``true`` if this map contains no key-value mappings, ``false`` otherwise.
+        """
+
         return self._encode_invoke(transactional_map_is_empty_codec)
 
     def put(self, key, value, ttl=-1):
+        """
+        Transactional implementation of :func:`Map.put(key, value, ttl) <hazelcast.proxy.map.Map.put>`
+
+        The object to be put will be accessible only in the current transaction context till the transaction is
+        committed.
+
+        :param key: (object), the specified key.
+        :param value: (object), the value to associate with the key.
+        :param ttl: (int), maximum time in seconds for this entry to stay (optional).
+        :return: (object), previous value associated with key or ``None`` if there was no mapping for key.
+        """
         check_not_none(key, "key can't be none")
         check_not_none(value, "value can't be none")
         return self._encode_invoke(transactional_map_put_codec, key=self._to_data(key),
                                    value=self._to_data(value), ttl=to_millis(ttl))
 
     def put_if_absent(self, key, value):
+        """
+        Transactional implementation of :func:`Map.put_if_absent(key, value)
+        <hazelcast.proxy.map.Map.put_if_absent>`
+
+        The object to be put will be accessible only in the current transaction context till the transaction is
+        committed.
+
+        :param key: (object), key of the entry.
+        :param value: (object), value of the entry.
+        :param ttl:  (int), maximum time in seconds for this entry to stay in the map (optional).
+        :return: (object), old value of the entry.
+        """
         check_not_none(key, "key can't be none")
         check_not_none(value, "value can't be none")
         return self._encode_invoke(transactional_map_put_if_absent_codec, key=self._to_data(key),
                                    value=self._to_data(value))
 
     def set(self, key, value):
+        """
+        Transactional implementation of :func:`Map.set(key, value) <hazelcast.proxy.map.Map.set>`
+
+        The object to be set will be accessible only in the current transaction context till the transaction is
+        committed.
+
+        :param key: (object), key of the entry.
+        :param value: (object), value of the entry.
+        """
         check_not_none(key, "key can't be none")
         check_not_none(value, "value can't be none")
         return self._encode_invoke(transactional_map_set_codec, key=self._to_data(key),
                                    value=self._to_data(value))
 
     def replace(self, key, value):
+        """
+        Transactional implementation of :func:`Map.replace(key, value) <hazelcast.proxy.map.Map.replace>`
+
+        The object to be replaced will be accessible only in the current transaction context till the transaction is
+        committed.
+
+        :param key: (object), the specified key.
+        :param value: (object), the value to replace the previous value.
+        :return: (object), previous value associated with key, or ``None`` if there was no mapping for key.
+        """
         check_not_none(key, "key can't be none")
         check_not_none(value, "value can't be none")
         return self._encode_invoke(transactional_map_replace_codec, key=self._to_data(key),
                                    value=self._to_data(value))
 
     def replace_if_same(self, key, old_value, new_value):
+        """
+        Transactional implementation of :func:`Map.replace_if_same(key, old_value, new_value)
+        <hazelcast.proxy.map.Map.replace_if_same>`
+
+        The object to be replaced will be accessible only in the current transaction context till the transaction is
+        committed.
+
+        :param key: (object), the specified key.
+        :param old_value: (object), replace the key value if it is the old value.
+        :param new_value: (object), the new value to replace the old value.
+        :return: (bool), ``true`` if the value was replaced, ``false`` otherwise.
+        """
         check_not_none(key, "key can't be none")
         check_not_none(old_value, "old_value can't be none")
         check_not_none(new_value, "new_value can't be none")
@@ -59,26 +149,74 @@ class TransactionalMap(TransactionalProxy):
                                    old_value=self._to_data(old_value), new_value=self._to_data(new_value))
 
     def remove(self, key):
+        """
+        Transactional implementation of :func:`Map.remove(key) <hazelcast.proxy.map.Map.remove>`
+
+        The object to be removed will be removed from only the current transaction context until the transaction is
+        committed.
+
+        :param key: (object), key of the mapping to be deleted.
+        :return: (object), the previous value associated with key, or ``None`` if there was no mapping for key.
+        """
         check_not_none(key, "key can't be none")
         return self._encode_invoke(transactional_map_remove_codec, key=self._to_data(key))
 
     def remove_if_same(self, key, value):
+        """
+        Transactional implementation of :func:`Map.remove_if_same(key, value)
+        <hazelcast.proxy.map.Map.remove_if_same>`
+
+        The object to be removed will be removed from only the current transaction context until the transaction is
+        committed.
+
+        :param key: (object), the specified key.
+        :param value: (object), remove the key if it has this value.
+        :return: (bool), ``true`` if the value was removed, ``false`` otherwise.
+        """
+
         check_not_none(key, "key can't be none")
         check_not_none(value, "value can't be none")
         return self._encode_invoke(transactional_map_remove_if_same_codec, key=self._to_data(key),
                                    value=self._to_data(value))
 
     def delete(self, key):
+        """
+        Transactional implementation of :func:`Map.delete(key) <hazelcast.proxy.map.Map.delete>`
+
+        The object to be deleted will be removed from only the current transaction context until the transaction is
+        committed.
+
+        :param key: (object), key of the mapping to be deleted.
+        """
         check_not_none(key, "key can't be none")
         return self._encode_invoke(transactional_map_delete_codec, key=self._to_data(key))
 
     def key_set(self, predicate=None):
+        """
+        Transactional implementation of :func:`Map.key_set(predicate) <hazelcast.proxy.map.Map.key_set>`
+
+        :param predicate: (Predicate), predicate to filter the entries (optional).
+        :return: (Sequence), a list of the clone of the keys.
+
+        .. seealso::
+            :class:`~hazelcast.serialization.predicate.Predicate` for more info about predicates.
+        """
+
         if predicate:
             return self._encode_invoke(transactional_map_key_set_with_predicate_codec,
                                        predicate=self._to_data(predicate))
         return self._encode_invoke(transactional_map_key_set_codec)
 
     def values(self, predicate=None):
+        """
+        Transactional implementation of :func:`Map.values(predicate) <hazelcast.proxy.map.Map.values>`
+
+        :param predicate: (Predicate), predicate to filter the entries (optional).
+        :return: (Sequence), a list of clone of the values contained in this map.
+
+        .. seealso::
+            :class:`~hazelcast.serialization.predicate.Predicate` for more info about predicates.
+        """
         if predicate:
             return self._encode_invoke(transactional_map_values_with_predicate_codec,
                                        predicate=self._to_data(predicate))

--- a/hazelcast/proxy/transactional_multi_map.py
+++ b/hazelcast/proxy/transactional_multi_map.py
@@ -6,29 +6,73 @@ from hazelcast.util import check_not_none
 
 
 class TransactionalMultiMap(TransactionalProxy):
+    """
+    Transactional implementation of :class:`~hazelcast.proxy.multi_map.MultiMap`.
+    """
     def put(self, key, value):
+        """
+        Transactional implementation of :func:`MultiMap.put(key, value) <hazelcast.proxy.multi_map.MultiMap.put>`
+
+        :param key: (object), the key to be stored.
+        :param value: (object), the value to be stored.
+        :return: (bool), ``true`` if the size of the multimap is increased, ``false`` if the multimap already contains the
+        key-value tuple.
+        """
         check_not_none(key, "key can't be none")
         check_not_none(value, "value can't be none")
         return self._encode_invoke(transactional_multi_map_put_codec, key=self._to_data(key),
                                    value=self._to_data(value))
 
     def get(self, key):
+        """
+        Transactional implementation of :func:`MultiMap.get(key) <hazelcast.proxy.multi_map.MultiMap.get>`
+
+        :param key: (object), the key whose associated values are returned.
+        :return: (Sequence), the collection of the values associated with the key.
+        """
         check_not_none(key, "key can't be none")
         return self._encode_invoke(transactional_multi_map_get_codec, key=self._to_data(key))
 
     def remove(self, key, value):
+        """
+        Transactional implementation of :func:`MultiMap.remove(key, value)
+        <hazelcast.proxy.multi_map.MultiMap.remove>`
+
+        :param key: (object), the key of the entry to remove.
+        :param value: (object), the value of the entry to remove.
+        :return:
+        """
         check_not_none(key, "key can't be none")
         check_not_none(value, "value can't be none")
         return self._encode_invoke(transactional_multi_map_remove_entry_codec, key=self._to_data(key),
                                    value=self._to_data(value))
 
     def remove_all(self, key):
+        """
+        Transactional implementation of :func:`MultiMap.remove_all(key)
+        <hazelcast.proxy.multi_map.MultiMap.remove_all>`
+
+        :param key: (object), the key of the entries to remove.
+        :return: (list), the collection of the values associated with the key.
+        """
         check_not_none(key, "key can't be none")
         return self._encode_invoke(transactional_multi_map_remove_codec, key=self._to_data(key))
 
     def value_count(self, key):
+        """
+        Transactional implementation of :func:`MultiMap.value_count(key)
+        <hazelcast.proxy.multi_map.MultiMap.value_count>`
+
+        :param key: (object), the key whose number of values is to be returned.
+        :return: (int), the number of values matching the given key in the multimap.
+        """
         check_not_none(key, "key can't be none")
         return self._encode_invoke(transactional_multi_map_value_count_codec, key=self._to_data(key))
 
     def size(self):
+        """
+        Transactional implementation of :func:`MultiMap.size() <hazelcast.proxy.multi_map.MultiMap.size>`
+
+        :return: (int), the number of key-value tuples in the multimap.
+        """
         return self._encode_invoke(transactional_multi_map_size_codec)

--- a/hazelcast/proxy/transactional_queue.py
+++ b/hazelcast/proxy/transactional_queue.py
@@ -5,19 +5,53 @@ from hazelcast.util import check_not_none, to_millis
 
 
 class TransactionalQueue(TransactionalProxy):
+    """
+    Transactional implementation of :class:`~hazelcast.proxy.queue.Queue`.
+    """
     def offer(self, item, timeout=0):
+        """
+        Transactional implementation of :func:`Queue.offer(item, timeout) <hazelcast.proxy.queue.Queue.offer>`
+
+        :param item: (object), the item to be added.
+        :param timeout: (long), maximum time in seconds to wait for addition (optional).
+        :return: (bool), ``true`` if the element was added to this queue, ``false`` otherwise.
+        """
         check_not_none(item, "item can't be none")
         return self._encode_invoke(transactional_queue_offer_codec, item=self._to_data(item),
                                    timeout=to_millis(timeout))
 
     def take(self):
+        """
+        Transactional implementation of :func:`Queue.take() <hazelcast.proxy.queue.Queue.take>`
+
+        :return: (object), the head of this queue.
+        """
         return self._encode_invoke(transactional_queue_take_codec)
 
     def poll(self, timeout=0):
+        """
+        Transactional implementation of :func:`Queue.poll(timeout) <hazelcast.proxy.queue.Queue.poll>`
+
+        :param timeout: (long), maximum time in seconds to wait for addition (optional).
+        :return: (object), the head of this queue, or ``None`` if this queue is empty or specified timeout elapses before an
+        item is added to the queue.
+        """
         return self._encode_invoke(transactional_queue_poll_codec, timeout=to_millis(timeout))
 
     def peek(self, timeout=0):
+        """
+        Transactional implementation of :func:`Queue.peek(timeout) <hazelcast.proxy.queue.Queue.peek>`
+
+        :param timeout: (long), maximum time in seconds to wait for addition (optional).
+        :return: (object), the head of this queue, or ``None`` if this queue is empty or specified timeout elapses before an
+        item is added to the queue.
+        """
         return self._encode_invoke(transactional_queue_peek_codec, timeout=to_millis(timeout))
 
     def size(self):
+        """
+        Transactional implementation of :func:`Queue.size() <hazelcast.proxy.queue.Queue.size>`
+
+        :return: (int), size of the queue.
+        """
         return self._encode_invoke(transactional_queue_size_codec)

--- a/hazelcast/proxy/transactional_set.py
+++ b/hazelcast/proxy/transactional_set.py
@@ -5,13 +5,33 @@ from hazelcast.util import check_not_none
 
 
 class TransactionalSet(TransactionalProxy):
+    """
+    Transactional implementation of :class:`~hazelcast.proxy.set.Set`.
+    """
     def add(self, item):
+        """
+        Transactional implementation of :func:`Set.add(item) <hazelcast.proxy.set.Set.add>`
+
+        :param item: (object), the new item to be added.
+        :return: (bool), ``true`` if item is added successfully, ``false`` otherwise.
+        """
         check_not_none(item, "item can't be none")
         return self._encode_invoke(transactional_set_add_codec, item=self._to_data(item))
 
     def remove(self, item):
+        """
+        Transactional implementation of :func:`Set.remove(item) <hazelcast.proxy.set.Set.remove>`
+
+        :param item: (object), the specified item to be deleted.
+        :return: (bool), ``true`` if item is remove successfully, ``false`` otherwise.
+        """
         check_not_none(item, "item can't be none")
         return self._encode_invoke(transactional_set_remove_codec, item=self._to_data(item))
 
     def size(self):
+        """
+        Transactional implementation of :func:`Set.size() <hazelcast.proxy.set.Set.size>`
+
+        :return: (int), size of the set.
+        """
         return self._encode_invoke(transactional_set_size_codec)


### PR DESCRIPTION
ApiDoc added to

- queue.py
- transactional_map.py
- transactional_set.py
- transactional_list.py
- transactional_queue.py
- transactional_multi_map.py with Python Sphinx format.

add_listener method of queue class is refactored for indicating parameters which are functions.