### PR TITLE
Resolved KeyError: when handling invalidations in MapFeatNearCache 

### DIFF
--- a/hazelcast/protocol/codec/map_add_near_cache_entry_listener_codec.py
+++ b/hazelcast/protocol/codec/map_add_near_cache_entry_listener_codec.py
@@ -45,12 +45,12 @@ def handle(client_message, handle_event_imapinvalidation = None, handle_event_im
         key=None
         if not client_message.read_bool():
             key = client_message.read_data()
-        handle_event_imapinvalidation(key=key)
+        handle_event_imapinvalidation(key)
     if message_type == EVENT_IMAPBATCHINVALIDATION and handle_event_imapbatchinvalidation is not None:
         keys_size = client_message.read_int()
         keys = []
         for keys_index in xrange(0, keys_size):
             keys_item = client_message.read_data()
             keys.append(keys_item)
-        handle_event_imapbatchinvalidation(keys=keys)
+        handle_event_imapbatchinvalidation(keys)
 

--- a/hazelcast/proxy/map.py
+++ b/hazelcast/proxy/map.py
@@ -465,11 +465,19 @@ class MapFeatNearCache(Map):
         if key_data is None:
             self._near_cache.clear()
         else:
-            del self._near_cache[key_data]
+            try:
+                del self._near_cache[key_data]
+            except KeyError:
+                # There is nothing to invalidate
+                pass
 
     def _handle_batch_invalidation(self, key_data_list):
         for key_data in key_data_list:
-            del self._near_cache[key_data]
+            try:
+                del self._near_cache[key_data]
+            except KeyError:
+                # There is nothing to invalidate
+                pass
 
     def _invalidate_cache(self, key_data):
         try:


### PR DESCRIPTION
Added try/except blocks (following the checks from other methods) to resolve the runtime `KeyError` when an invalidating key doesn't exist in the NearCache.

This PR follows PR #31 