### PR TITLE
authenticate manager should send uuid's if available.

### DIFF
--- a/hazelcast/cluster.py
+++ b/hazelcast/cluster.py
@@ -126,7 +126,7 @@ class ClusterService(object):
     def _authenticate_manager(self, connection):
         request = client_authentication_codec.encode_request(
             username=self._config.group_config.name, password=self._config.group_config.password,
-            uuid=None, owner_uuid=None, is_owner_connection=True, client_type=CLIENT_TYPE,
+            uuid=self.uuid, owner_uuid=self.owner_uuid, is_owner_connection=True, client_type=CLIENT_TYPE,
             serialization_version=SERIALIZATION_VERSION)
 
         def callback(f):

--- a/hazelcast/connection.py
+++ b/hazelcast/connection.py
@@ -260,7 +260,7 @@ class Connection(object):
         self._connection_closed_callback = connection_closed_callback
         self._builder = ClientMessageBuilder(message_callback)
         self._read_buffer = ""
-        self.last_read = 0
+        self.last_read = time.time()
 
     def live(self):
         """


### PR DESCRIPTION
authenticate manager should send uuid's if available. 
Initialise lastRead time of connection in connection constructor so that it will not be immediately closed down by heartbeat mechanism

fixes https://github.com/hazelcast/hazelcast-python-client/issues/59
fixes https://github.com/hazelcast/hazelcast-python-client/issues/60