### PR TITLE
Pull down the reactor loop wake up time from 10 sec to 1 sec

### DIFF
--- a/hazelcast/reactor.py
+++ b/hazelcast/reactor.py
@@ -34,7 +34,7 @@ class AsyncoreReactor(object):
         Future._threading_locals.is_reactor_thread = True
         while self._is_live:
             try:
-                asyncore.loop(count=1000, timeout=0.01, map=self._map)
+                asyncore.loop(count=10, timeout=0.01, map=self._map)
                 self._check_timers()
             except select.error as err:
                 # TODO: parse error type to catch only error "9"


### PR DESCRIPTION
This changes user configured intervals like heartbeat to be able
to work with smallest 1 seconds intervals.

Before that setting a value lower than 10 seconds was not working.

fixes https://github.com/hazelcast/hazelcast-python-client/issues/61