### PR TITLE
Setting up tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py27,py36
+
+[testenv]
+whitelist_externals = /bin/sh
+commands =
+    sh run-tests.sh {posargs}


### PR DESCRIPTION
Added `tox.ini` to be able to run tests in multiple environments.

The command `tox -e py27` runs the tests in Python 2.7 environment whereas `tox -e py36` runs in 3.6 version of Python.

The argument `--local` can be passed to `tox` command as `tox -e py27 -- --local`

As we're at starting point I've added just py27 and py36. We should ideally add more versions which we can do as we go along.