### PR TITLE
fix pop behaviour of connection manager

### DIFF
--- a/hazelcast/connection.py
+++ b/hazelcast/connection.py
@@ -130,7 +130,10 @@ class ConnectionManager(object):
             self.logger.info("Authenticated with %s", f.result())
             with self._new_connection_mutex:
                 self.connections[connection.endpoint] = f.result()
-                self._pending_connections.pop(address)
+                try:
+                    self._pending_connections.pop(address)
+                except KeyError:
+                    pass
             for on_connection_opened, _ in self._connection_listeners:
                 if on_connection_opened:
                     on_connection_opened(f.resul())
@@ -147,7 +150,10 @@ class ConnectionManager(object):
     def _connection_closed(self, connection, cause):
         # if connection was authenticated, fire event
         if connection.endpoint:
-            self.connections.pop(connection.endpoint)
+            try:
+                self.connections.pop(connection.endpoint)
+            except KeyError:
+                pass
             for _, on_connection_closed in self._connection_listeners:
                 if on_connection_closed:
                     on_connection_closed(connection, cause)


### PR DESCRIPTION
When client authenticates with the same address more than once,  [connections](https://github.com/hazelcast/hazelcast-python-client/blob/master/hazelcast/connection.py#L36) and [_pending_connections](https://github.com/hazelcast/hazelcast-python-client/blob/master/hazelcast/connection.py#L37) dictionaries of the connection manager are updated with the latests address-future pair as it should be. However, when on_auth or _connection_closed methods are called for each connection, these methods try to pop the same address from these dictionaries more than once which results in a KeyError.

We should try to pop the address but when KeyError happens we should simply pass since that address is already removed from these dictionaries by the previous method calls.