### PR TITLE
remove the statement that sets partitions to empty dict

### DIFF
--- a/hazelcast/partition.py
+++ b/hazelcast/partition.py
@@ -105,8 +105,6 @@ class PartitionService(object):
 
     def process_partition_response(self, message):
         partitions = client_get_partitions_codec.decode_response(message)["partitions"]
-        # TODO: needs sync
-        self.partitions = {}
         for addr, partition_list in six.iteritems(partitions):
             for partition in partition_list:
                 self.partitions[partition] = addr


### PR DESCRIPTION
when partitions dict of partition service is set to empty dict, it may be used by other methods while still being updated by the for loop. This causes get_partition_owner to return None address and results in an exception as described in #76 

fixes #76