### PR TITLE
reactor Timer ordering

### DIFF
--- a/hazelcast/reactor.py
+++ b/hazelcast/reactor.py
@@ -6,8 +6,10 @@ import socket
 import sys
 import threading
 import time
-from hazelcast.six.moves import queue
 from collections import deque
+from functools import total_ordering
+
+from hazelcast.six.moves import queue
 
 from hazelcast.connection import Connection, BUFFER_SIZE
 from hazelcast.exception import HazelcastError
@@ -191,6 +193,7 @@ class AsyncoreConnection(Connection, asyncore.dispatcher):
             self._connection_closed_callback(self, cause)
 
 
+@total_ordering
 class Timer(object):
     canceled = False
 
@@ -198,6 +201,12 @@ class Timer(object):
         self.end = end
         self.timer_ended_cb = timer_ended_cb
         self.timer_canceled_cb = timer_canceled_cb
+
+    def __eq__(self, other):
+        return self.end == other.end
+
+    def __ne__(self, other):
+        return not (self == other)
 
     def __lt__(self, other):
         return self.end < other.end

--- a/hazelcast/reactor.py
+++ b/hazelcast/reactor.py
@@ -6,8 +6,10 @@ import socket
 import sys
 import threading
 import time
-from hazelcast.six.moves import queue
 from collections import deque
+from functools import total_ordering
+
+from hazelcast.six.moves import queue
 
 from hazelcast.connection import Connection, BUFFER_SIZE
 from hazelcast.exception import HazelcastError
@@ -191,6 +193,7 @@ class AsyncoreConnection(Connection, asyncore.dispatcher):
             self._connection_closed_callback(self, cause)
 
 
+@total_ordering
 class Timer(object):
     canceled = False
 
@@ -198,6 +201,15 @@ class Timer(object):
         self.end = end
         self.timer_ended_cb = timer_ended_cb
         self.timer_canceled_cb = timer_canceled_cb
+
+    def __eq__(self, other):
+        return self.end == other.end
+
+    def __ne__(self, other):
+        return not (self == other)
+
+    def __lt__(self, other):
+        return self.end < other.end
 
     def cancel(self):
         self.canceled = True

--- a/hazelcast/reactor.py
+++ b/hazelcast/reactor.py
@@ -6,10 +6,8 @@ import socket
 import sys
 import threading
 import time
-from collections import deque
-from functools import total_ordering
-
 from hazelcast.six.moves import queue
+from collections import deque
 
 from hazelcast.connection import Connection, BUFFER_SIZE
 from hazelcast.exception import HazelcastError
@@ -193,7 +191,6 @@ class AsyncoreConnection(Connection, asyncore.dispatcher):
             self._connection_closed_callback(self, cause)
 
 
-@total_ordering
 class Timer(object):
     canceled = False
 
@@ -201,12 +198,6 @@ class Timer(object):
         self.end = end
         self.timer_ended_cb = timer_ended_cb
         self.timer_canceled_cb = timer_canceled_cb
-
-    def __eq__(self, other):
-        return self.end == other.end
-
-    def __ne__(self, other):
-        return not (self == other)
 
     def __lt__(self, other):
         return self.end < other.end


### PR DESCRIPTION
Hi,

Mostly my script is hanging when working on blocking map immediately after Hazlecast client created.
Below stack trace:

ERROR:Reactor:Error in Reactor Thread
Traceback (most recent call last):
  File "C:\Tools\Python36\lib\site-packages\hazelcast\reactor.py", line 38, in _loop
    self._check_timers()
  File "C:\Tools\Python36\lib\site-packages\hazelcast\reactor.py", line 60, in _check_timers
    self._timers.get_nowait()
  File "C:\Tools\Python36\lib\queue.py", line 192, in get_nowait
    return self.get(block=False)
  File "C:\Tools\Python36\lib\queue.py", line 174, in get
    item = self._get()
  File "C:\Tools\Python36\lib\queue.py", line 230, in _get
    return heappop(self.queue)
TypeError: '<' not supported between instances of 'Timer' and 'Timer'

When using pause time.sleep(1) before map consuming script works perfectly.

I think that the reason is reactor initialization, that stores Timers in queue.PriorityQueue() but Timer class is not comparable.
So I have added total ordering from functools and it works without problems.

Regards,
MM