### PR TITLE
Codec cleanup

### DIFF
--- a/hazelcast/protocol/codec/atomic_long_add_and_get_codec.py
+++ b/hazelcast/protocol/codec/atomic_long_add_and_get_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.atomic_long_message_type import *
 
 REQUEST_TYPE = ATOMICLONG_ADDANDGET
@@ -33,6 +31,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_long()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/atomic_long_alter_and_get_codec.py
+++ b/hazelcast/protocol/codec/atomic_long_alter_and_get_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.atomic_long_message_type import *
 
 REQUEST_TYPE = ATOMICLONG_ALTERANDGET
@@ -33,6 +31,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_long()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/atomic_long_alter_codec.py
+++ b/hazelcast/protocol/codec/atomic_long_alter_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.atomic_long_message_type import *
 
 REQUEST_TYPE = ATOMICLONG_ALTER
@@ -29,6 +27,3 @@ def encode_request(name, function):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/atomic_long_apply_codec.py
+++ b/hazelcast/protocol/codec/atomic_long_apply_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.atomic_long_message_type import *
 
 REQUEST_TYPE = ATOMICLONG_APPLY
@@ -31,10 +29,6 @@ def encode_request(name, function):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/atomic_long_compare_and_set_codec.py
+++ b/hazelcast/protocol/codec/atomic_long_compare_and_set_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.atomic_long_message_type import *
 
 REQUEST_TYPE = ATOMICLONG_COMPAREANDSET
@@ -35,6 +33,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/atomic_long_decrement_and_get_codec.py
+++ b/hazelcast/protocol/codec/atomic_long_decrement_and_get_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.atomic_long_message_type import *
 
 REQUEST_TYPE = ATOMICLONG_DECREMENTANDGET
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_long()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/atomic_long_get_and_add_codec.py
+++ b/hazelcast/protocol/codec/atomic_long_get_and_add_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.atomic_long_message_type import *
 
 REQUEST_TYPE = ATOMICLONG_GETANDADD
@@ -33,6 +31,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_long()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/atomic_long_get_and_alter_codec.py
+++ b/hazelcast/protocol/codec/atomic_long_get_and_alter_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.atomic_long_message_type import *
 
 REQUEST_TYPE = ATOMICLONG_GETANDALTER
@@ -33,6 +31,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_long()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/atomic_long_get_and_increment_codec.py
+++ b/hazelcast/protocol/codec/atomic_long_get_and_increment_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.atomic_long_message_type import *
 
 REQUEST_TYPE = ATOMICLONG_GETANDINCREMENT
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_long()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/atomic_long_get_and_set_codec.py
+++ b/hazelcast/protocol/codec/atomic_long_get_and_set_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.atomic_long_message_type import *
 
 REQUEST_TYPE = ATOMICLONG_GETANDSET
@@ -33,6 +31,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_long()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/atomic_long_get_codec.py
+++ b/hazelcast/protocol/codec/atomic_long_get_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.atomic_long_message_type import *
 
 REQUEST_TYPE = ATOMICLONG_GET
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_long()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/atomic_long_increment_and_get_codec.py
+++ b/hazelcast/protocol/codec/atomic_long_increment_and_get_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.atomic_long_message_type import *
 
 REQUEST_TYPE = ATOMICLONG_INCREMENTANDGET
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_long()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/atomic_long_set_codec.py
+++ b/hazelcast/protocol/codec/atomic_long_set_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.atomic_long_message_type import *
 
 REQUEST_TYPE = ATOMICLONG_SET
@@ -29,6 +27,3 @@ def encode_request(name, new_value):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/atomic_reference_alter_and_get_codec.py
+++ b/hazelcast/protocol/codec/atomic_reference_alter_and_get_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.atomic_reference_message_type import *
 
 REQUEST_TYPE = ATOMICREFERENCE_ALTERANDGET
@@ -31,10 +29,6 @@ def encode_request(name, function):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/atomic_reference_alter_codec.py
+++ b/hazelcast/protocol/codec/atomic_reference_alter_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.atomic_reference_message_type import *
 
 REQUEST_TYPE = ATOMICREFERENCE_ALTER
@@ -29,6 +27,3 @@ def encode_request(name, function):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/atomic_reference_apply_codec.py
+++ b/hazelcast/protocol/codec/atomic_reference_apply_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.atomic_reference_message_type import *
 
 REQUEST_TYPE = ATOMICREFERENCE_APPLY
@@ -31,10 +29,6 @@ def encode_request(name, function):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/atomic_reference_clear_codec.py
+++ b/hazelcast/protocol/codec/atomic_reference_clear_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.atomic_reference_message_type import *
 
 REQUEST_TYPE = ATOMICREFERENCE_CLEAR
@@ -27,6 +25,3 @@ def encode_request(name):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/atomic_reference_compare_and_set_codec.py
+++ b/hazelcast/protocol/codec/atomic_reference_compare_and_set_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.atomic_reference_message_type import *
 
 REQUEST_TYPE = ATOMICREFERENCE_COMPAREANDSET
@@ -43,6 +41,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/atomic_reference_contains_codec.py
+++ b/hazelcast/protocol/codec/atomic_reference_contains_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.atomic_reference_message_type import *
 
 REQUEST_TYPE = ATOMICREFERENCE_CONTAINS
@@ -37,6 +35,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/atomic_reference_get_and_alter_codec.py
+++ b/hazelcast/protocol/codec/atomic_reference_get_and_alter_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.atomic_reference_message_type import *
 
 REQUEST_TYPE = ATOMICREFERENCE_GETANDALTER
@@ -31,10 +29,6 @@ def encode_request(name, function):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/atomic_reference_get_and_set_codec.py
+++ b/hazelcast/protocol/codec/atomic_reference_get_and_set_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.atomic_reference_message_type import *
 
 REQUEST_TYPE = ATOMICREFERENCE_GETANDSET
@@ -35,10 +33,6 @@ def encode_request(name, new_value):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/atomic_reference_get_codec.py
+++ b/hazelcast/protocol/codec/atomic_reference_get_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.atomic_reference_message_type import *
 
 REQUEST_TYPE = ATOMICREFERENCE_GET
@@ -29,7 +27,6 @@ def encode_request(name):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters

--- a/hazelcast/protocol/codec/atomic_reference_is_null_codec.py
+++ b/hazelcast/protocol/codec/atomic_reference_is_null_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.atomic_reference_message_type import *
 
 REQUEST_TYPE = ATOMICREFERENCE_ISNULL
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/atomic_reference_set_and_get_codec.py
+++ b/hazelcast/protocol/codec/atomic_reference_set_and_get_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.atomic_reference_message_type import *
 
 REQUEST_TYPE = ATOMICREFERENCE_SETANDGET
@@ -35,10 +33,6 @@ def encode_request(name, new_value):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/atomic_reference_set_codec.py
+++ b/hazelcast/protocol/codec/atomic_reference_set_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.atomic_reference_message_type import *
 
 REQUEST_TYPE = ATOMICREFERENCE_SET
@@ -33,6 +31,3 @@ def encode_request(name, new_value):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/client_add_distributed_object_listener_codec.py
+++ b/hazelcast/protocol/codec/client_add_distributed_object_listener_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.client_message_type import *
 from hazelcast.protocol.event_response_const import *
 
@@ -34,12 +32,11 @@ def decode_response(client_message, to_object=None):
     return parameters
 
 
-def handle(client_message, handle_event_distributedobject = None, to_object=None):
+def handle(client_message, handle_event_distributed_object=None, to_object=None):
     """ Event handler """
     message_type = client_message.get_message_type()
-    if message_type == EVENT_DISTRIBUTEDOBJECT and handle_event_distributedobject is not None:
+    if message_type == EVENT_DISTRIBUTEDOBJECT and handle_event_distributed_object is not None:
         name = client_message.read_str()
         service_name = client_message.read_str()
         event_type = client_message.read_str()
-        handle_event_distributedobject(name=name, service_name=service_name, event_type=event_type)
-
+        handle_event_distributed_object(name=name, service_name=service_name, event_type=event_type)

--- a/hazelcast/protocol/codec/client_add_membership_listener_codec.py
+++ b/hazelcast/protocol/codec/client_add_membership_listener_codec.py
@@ -1,7 +1,6 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
 from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.client_message_type import *
 from hazelcast.protocol.event_response_const import *
 from hazelcast.six.moves import range
@@ -35,26 +34,25 @@ def decode_response(client_message, to_object=None):
     return parameters
 
 
-def handle(client_message, handle_event_member = None, handle_event_memberlist = None, handle_event_memberattributechange = None, to_object=None):
+def handle(client_message, handle_event_member=None, handle_event_member_list=None, handle_event_member_attribute_change=None, to_object=None):
     """ Event handler """
     message_type = client_message.get_message_type()
     if message_type == EVENT_MEMBER and handle_event_member is not None:
         member = MemberCodec.decode(client_message, to_object)
         event_type = client_message.read_int()
         handle_event_member(member=member, event_type=event_type)
-    if message_type == EVENT_MEMBERLIST and handle_event_memberlist is not None:
+    if message_type == EVENT_MEMBERLIST and handle_event_member_list is not None:
         members_size = client_message.read_int()
         members = []
-        for members_index in range(0, members_size):
+        for _ in range(0, members_size):
             members_item = MemberCodec.decode(client_message, to_object)
             members.append(members_item)
-        handle_event_memberlist(members=members)
-    if message_type == EVENT_MEMBERATTRIBUTECHANGE and handle_event_memberattributechange is not None:
+        handle_event_member_list(members=members)
+    if message_type == EVENT_MEMBERATTRIBUTECHANGE and handle_event_member_attribute_change is not None:
         uuid = client_message.read_str()
         key = client_message.read_str()
         operation_type = client_message.read_int()
-        value=None
+        value = None
         if not client_message.read_bool():
             value = client_message.read_str()
-        handle_event_memberattributechange(uuid=uuid, key=key, operation_type=operation_type, value=value)
-
+        handle_event_member_attribute_change(uuid=uuid, key=key, operation_type=operation_type, value=value)

--- a/hazelcast/protocol/codec/client_add_partition_lost_listener_codec.py
+++ b/hazelcast/protocol/codec/client_add_partition_lost_listener_codec.py
@@ -1,7 +1,6 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
 from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.client_message_type import *
 from hazelcast.protocol.event_response_const import *
 
@@ -34,14 +33,13 @@ def decode_response(client_message, to_object=None):
     return parameters
 
 
-def handle(client_message, handle_event_partitionlost = None, to_object=None):
+def handle(client_message, handle_event_partition_lost=None, to_object=None):
     """ Event handler """
     message_type = client_message.get_message_type()
-    if message_type == EVENT_PARTITIONLOST and handle_event_partitionlost is not None:
+    if message_type == EVENT_PARTITIONLOST and handle_event_partition_lost is not None:
         partition_id = client_message.read_int()
         lost_backup_count = client_message.read_int()
-        source=None
+        source = None
         if not client_message.read_bool():
             source = AddressCodec.decode(client_message, to_object)
-        handle_event_partitionlost(partition_id=partition_id, lost_backup_count=lost_backup_count, source=source)
-
+        handle_event_partition_lost(partition_id=partition_id, lost_backup_count=lost_backup_count, source=source)

--- a/hazelcast/protocol/codec/client_authentication_codec.py
+++ b/hazelcast/protocol/codec/client_authentication_codec.py
@@ -1,7 +1,6 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
 from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.client_message_type import *
 
 REQUEST_TYPE = CLIENT_AUTHENTICATION
@@ -50,17 +49,11 @@ def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(status=None, address=None, uuid=None, owner_uuid=None, serialization_version=None)
     parameters['status'] = client_message.read_byte()
-    address=None
     if not client_message.read_bool():
         parameters['address'] = AddressCodec.decode(client_message, to_object)
-    uuid=None
     if not client_message.read_bool():
         parameters['uuid'] = client_message.read_str()
-    owner_uuid=None
     if not client_message.read_bool():
         parameters['owner_uuid'] = client_message.read_str()
     parameters['serialization_version'] = client_message.read_byte()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/client_authentication_custom_codec.py
+++ b/hazelcast/protocol/codec/client_authentication_custom_codec.py
@@ -1,7 +1,6 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
 from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.client_message_type import *
 
 REQUEST_TYPE = CLIENT_AUTHENTICATIONCUSTOM
@@ -48,17 +47,11 @@ def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(status=None, address=None, uuid=None, owner_uuid=None, serialization_version=None)
     parameters['status'] = client_message.read_byte()
-    address=None
     if not client_message.read_bool():
         parameters['address'] = AddressCodec.decode(client_message, to_object)
-    uuid=None
     if not client_message.read_bool():
         parameters['uuid'] = client_message.read_str()
-    owner_uuid=None
     if not client_message.read_bool():
         parameters['owner_uuid'] = client_message.read_str()
     parameters['serialization_version'] = client_message.read_byte()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/client_create_proxy_codec.py
+++ b/hazelcast/protocol/codec/client_create_proxy_codec.py
@@ -1,7 +1,6 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
 from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.client_message_type import *
 
 REQUEST_TYPE = CLIENT_CREATEPROXY
@@ -31,6 +30,3 @@ def encode_request(name, service_name, target):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/client_destroy_proxy_codec.py
+++ b/hazelcast/protocol/codec/client_destroy_proxy_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.client_message_type import *
 
 REQUEST_TYPE = CLIENT_DESTROYPROXY
@@ -29,6 +27,3 @@ def encode_request(name, service_name):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/client_get_distributed_objects_codec.py
+++ b/hazelcast/protocol/codec/client_get_distributed_objects_codec.py
@@ -1,4 +1,3 @@
-from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
 from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
@@ -30,11 +29,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
-        response_item = DistributedObjectInfoCodec.decode(client_message, to_object)
+    for _ in range(0, response_size):
+        response_item = DistributedObjectInfoCodec.decode(client_message)
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/client_get_partitions_codec.py
+++ b/hazelcast/protocol/codec/client_get_partitions_codec.py
@@ -1,7 +1,5 @@
-from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
 from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.client_message_type import *
 from hazelcast.six.moves import range
 
@@ -30,16 +28,13 @@ def decode_response(client_message, to_object=None):
     parameters = dict(partitions=None)
     partitions_size = client_message.read_int()
     partitions = {}
-    for partitions_index in range(0,partitions_size):
+    for _ in range(0, partitions_size):
         partitions_key = AddressCodec.decode(client_message, to_object)
         partitions_val_size = client_message.read_int()
         partitions_val = []
-        for partitions_val_index in range(0, partitions_val_size):
+        for _ in range(0, partitions_val_size):
             partitions_val_item = client_message.read_int()
             partitions_val.append(partitions_val_item)
         partitions[partitions_key] = partitions_val
     parameters['partitions'] = partitions
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/client_ping_codec.py
+++ b/hazelcast/protocol/codec/client_ping_codec.py
@@ -1,7 +1,4 @@
-from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.client_message_type import *
 
 REQUEST_TYPE = CLIENT_PING
@@ -25,6 +22,3 @@ def encode_request():
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/client_remove_all_listeners_codec.py
+++ b/hazelcast/protocol/codec/client_remove_all_listeners_codec.py
@@ -1,7 +1,4 @@
-from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.client_message_type import *
 
 REQUEST_TYPE = CLIENT_REMOVEALLLISTENERS
@@ -25,6 +22,3 @@ def encode_request():
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/client_remove_distributed_object_listener_codec.py
+++ b/hazelcast/protocol/codec/client_remove_distributed_object_listener_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.client_message_type import *
 
 REQUEST_TYPE = CLIENT_REMOVEDISTRIBUTEDOBJECTLISTENER
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/client_remove_partition_lost_listener_codec.py
+++ b/hazelcast/protocol/codec/client_remove_partition_lost_listener_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.client_message_type import *
 
 REQUEST_TYPE = CLIENT_REMOVEPARTITIONLOSTLISTENER
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/condition_await_codec.py
+++ b/hazelcast/protocol/codec/condition_await_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.condition_message_type import *
 
 REQUEST_TYPE = CONDITION_AWAIT
@@ -37,6 +35,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/condition_before_await_codec.py
+++ b/hazelcast/protocol/codec/condition_before_await_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.condition_message_type import *
 
 REQUEST_TYPE = CONDITION_BEFOREAWAIT
@@ -31,6 +29,3 @@ def encode_request(name, thread_id, lock_name):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/condition_signal_all_codec.py
+++ b/hazelcast/protocol/codec/condition_signal_all_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.condition_message_type import *
 
 REQUEST_TYPE = CONDITION_SIGNALALL
@@ -31,6 +29,3 @@ def encode_request(name, thread_id, lock_name):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/condition_signal_codec.py
+++ b/hazelcast/protocol/codec/condition_signal_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.condition_message_type import *
 
 REQUEST_TYPE = CONDITION_SIGNAL
@@ -31,6 +29,3 @@ def encode_request(name, thread_id, lock_name):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/count_down_latch_await_codec.py
+++ b/hazelcast/protocol/codec/count_down_latch_await_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.count_down_latch_message_type import *
 
 REQUEST_TYPE = COUNTDOWNLATCH_AWAIT
@@ -33,6 +31,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/count_down_latch_count_down_codec.py
+++ b/hazelcast/protocol/codec/count_down_latch_count_down_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.count_down_latch_message_type import *
 
 REQUEST_TYPE = COUNTDOWNLATCH_COUNTDOWN
@@ -27,6 +25,3 @@ def encode_request(name):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/count_down_latch_get_count_codec.py
+++ b/hazelcast/protocol/codec/count_down_latch_get_count_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.count_down_latch_message_type import *
 
 REQUEST_TYPE = COUNTDOWNLATCH_GETCOUNT
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_int()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/count_down_latch_try_set_count_codec.py
+++ b/hazelcast/protocol/codec/count_down_latch_try_set_count_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.count_down_latch_message_type import *
 
 REQUEST_TYPE = COUNTDOWNLATCH_TRYSETCOUNT
@@ -33,6 +31,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/executor_service_cancel_on_address_codec.py
+++ b/hazelcast/protocol/codec/executor_service_cancel_on_address_codec.py
@@ -1,7 +1,6 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
 from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.executor_service_message_type import *
 
 REQUEST_TYPE = EXECUTORSERVICE_CANCELONADDRESS
@@ -35,6 +34,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/executor_service_cancel_on_partition_codec.py
+++ b/hazelcast/protocol/codec/executor_service_cancel_on_partition_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.executor_service_message_type import *
 
 REQUEST_TYPE = EXECUTORSERVICE_CANCELONPARTITION
@@ -35,6 +33,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/executor_service_is_shutdown_codec.py
+++ b/hazelcast/protocol/codec/executor_service_is_shutdown_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.executor_service_message_type import *
 
 REQUEST_TYPE = EXECUTORSERVICE_ISSHUTDOWN
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/executor_service_shutdown_codec.py
+++ b/hazelcast/protocol/codec/executor_service_shutdown_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.executor_service_message_type import *
 
 REQUEST_TYPE = EXECUTORSERVICE_SHUTDOWN
@@ -27,6 +25,3 @@ def encode_request(name):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/executor_service_submit_to_address_codec.py
+++ b/hazelcast/protocol/codec/executor_service_submit_to_address_codec.py
@@ -1,7 +1,6 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
 from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.executor_service_message_type import *
 
 REQUEST_TYPE = EXECUTORSERVICE_SUBMITTOADDRESS
@@ -35,10 +34,6 @@ def encode_request(name, uuid, callable, address):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/executor_service_submit_to_partition_codec.py
+++ b/hazelcast/protocol/codec/executor_service_submit_to_partition_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.executor_service_message_type import *
 
 REQUEST_TYPE = EXECUTORSERVICE_SUBMITTOPARTITION
@@ -35,10 +33,6 @@ def encode_request(name, uuid, callable, partition_id):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/list_add_all_codec.py
+++ b/hazelcast/protocol/codec/list_add_all_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.list_message_type import *
 
 REQUEST_TYPE = LIST_ADDALL
@@ -37,6 +35,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/list_add_all_with_index_codec.py
+++ b/hazelcast/protocol/codec/list_add_all_with_index_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.list_message_type import *
 
 REQUEST_TYPE = LIST_ADDALLWITHINDEX
@@ -39,6 +37,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/list_add_codec.py
+++ b/hazelcast/protocol/codec/list_add_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.list_message_type import *
 
 REQUEST_TYPE = LIST_ADD
@@ -33,6 +31,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/list_add_listener_codec.py
+++ b/hazelcast/protocol/codec/list_add_listener_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.list_message_type import *
 from hazelcast.protocol.event_response_const import *
 
@@ -38,14 +36,13 @@ def decode_response(client_message, to_object=None):
     return parameters
 
 
-def handle(client_message, handle_event_item = None, to_object=None):
+def handle(client_message, handle_event_item=None, to_object=None):
     """ Event handler """
     message_type = client_message.get_message_type()
     if message_type == EVENT_ITEM and handle_event_item is not None:
-        item=None
+        item = None
         if not client_message.read_bool():
             item = client_message.read_data()
         uuid = client_message.read_str()
         event_type = client_message.read_int()
         handle_event_item(item=item, uuid=uuid, event_type=event_type)
-

--- a/hazelcast/protocol/codec/list_add_with_index_codec.py
+++ b/hazelcast/protocol/codec/list_add_with_index_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.list_message_type import *
 
 REQUEST_TYPE = LIST_ADDWITHINDEX
@@ -31,6 +29,3 @@ def encode_request(name, index, value):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/list_clear_codec.py
+++ b/hazelcast/protocol/codec/list_clear_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.list_message_type import *
 
 REQUEST_TYPE = LIST_CLEAR
@@ -27,6 +25,3 @@ def encode_request(name):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/list_compare_and_remove_all_codec.py
+++ b/hazelcast/protocol/codec/list_compare_and_remove_all_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.list_message_type import *
 
 REQUEST_TYPE = LIST_COMPAREANDREMOVEALL
@@ -37,6 +35,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/list_compare_and_retain_all_codec.py
+++ b/hazelcast/protocol/codec/list_compare_and_retain_all_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.list_message_type import *
 
 REQUEST_TYPE = LIST_COMPAREANDRETAINALL
@@ -37,6 +35,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/list_contains_all_codec.py
+++ b/hazelcast/protocol/codec/list_contains_all_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.list_message_type import *
 
 REQUEST_TYPE = LIST_CONTAINSALL
@@ -37,6 +35,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/list_contains_codec.py
+++ b/hazelcast/protocol/codec/list_contains_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.list_message_type import *
 
 REQUEST_TYPE = LIST_CONTAINS
@@ -33,6 +31,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/list_get_all_codec.py
+++ b/hazelcast/protocol/codec/list_get_all_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.list_message_type import *
 from hazelcast.six.moves import range
@@ -32,11 +31,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = client_message.read_data()
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/list_get_codec.py
+++ b/hazelcast/protocol/codec/list_get_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.list_message_type import *
 
 REQUEST_TYPE = LIST_GET
@@ -31,10 +29,6 @@ def encode_request(name, index):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/list_index_of_codec.py
+++ b/hazelcast/protocol/codec/list_index_of_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.list_message_type import *
 
 REQUEST_TYPE = LIST_INDEXOF
@@ -33,6 +31,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_int()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/list_is_empty_codec.py
+++ b/hazelcast/protocol/codec/list_is_empty_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.list_message_type import *
 
 REQUEST_TYPE = LIST_ISEMPTY
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/list_iterator_codec.py
+++ b/hazelcast/protocol/codec/list_iterator_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.list_message_type import *
 from hazelcast.six.moves import range
@@ -32,11 +31,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = client_message.read_data()
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/list_last_index_of_codec.py
+++ b/hazelcast/protocol/codec/list_last_index_of_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.list_message_type import *
 
 REQUEST_TYPE = LIST_LASTINDEXOF
@@ -33,6 +31,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_int()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/list_list_iterator_codec.py
+++ b/hazelcast/protocol/codec/list_list_iterator_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.list_message_type import *
 from hazelcast.six.moves import range
@@ -34,11 +33,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = client_message.read_data()
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/list_remove_codec.py
+++ b/hazelcast/protocol/codec/list_remove_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.list_message_type import *
 
 REQUEST_TYPE = LIST_REMOVE
@@ -33,6 +31,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/list_remove_listener_codec.py
+++ b/hazelcast/protocol/codec/list_remove_listener_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.list_message_type import *
 
 REQUEST_TYPE = LIST_REMOVELISTENER
@@ -27,12 +25,4 @@ def encode_request(name, registration_id):
     client_message.update_frame_length()
     return client_message
 
-
-def decode_response(client_message, to_object=None):
-    """ Decode response from client message"""
-    parameters = dict(response=None)
-    parameters['response'] = client_message.read_bool()
-    return parameters
-
-
-
+# Empty decode_response because response is not used to determine the return value.

--- a/hazelcast/protocol/codec/list_remove_with_index_codec.py
+++ b/hazelcast/protocol/codec/list_remove_with_index_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.list_message_type import *
 
 REQUEST_TYPE = LIST_REMOVEWITHINDEX
@@ -31,10 +29,6 @@ def encode_request(name, index):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/list_set_codec.py
+++ b/hazelcast/protocol/codec/list_set_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.list_message_type import *
 
 REQUEST_TYPE = LIST_SET
@@ -33,10 +31,6 @@ def encode_request(name, index, value):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/list_size_codec.py
+++ b/hazelcast/protocol/codec/list_size_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.list_message_type import *
 
 REQUEST_TYPE = LIST_SIZE
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_int()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/list_sub_codec.py
+++ b/hazelcast/protocol/codec/list_sub_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.list_message_type import *
 from hazelcast.six.moves import range
@@ -36,11 +35,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = client_message.read_data()
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/lock_force_unlock_codec.py
+++ b/hazelcast/protocol/codec/lock_force_unlock_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.lock_message_type import *
 
 REQUEST_TYPE = LOCK_FORCEUNLOCK
@@ -29,6 +27,3 @@ def encode_request(name, reference_id):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/lock_get_lock_count_codec.py
+++ b/hazelcast/protocol/codec/lock_get_lock_count_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.lock_message_type import *
 
 REQUEST_TYPE = LOCK_GETLOCKCOUNT
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_int()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/lock_get_remaining_lease_time_codec.py
+++ b/hazelcast/protocol/codec/lock_get_remaining_lease_time_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.lock_message_type import *
 
 REQUEST_TYPE = LOCK_GETREMAININGLEASETIME
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_long()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/lock_is_locked_by_current_thread_codec.py
+++ b/hazelcast/protocol/codec/lock_is_locked_by_current_thread_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.lock_message_type import *
 
 REQUEST_TYPE = LOCK_ISLOCKEDBYCURRENTTHREAD
@@ -33,6 +31,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/lock_is_locked_codec.py
+++ b/hazelcast/protocol/codec/lock_is_locked_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.lock_message_type import *
 
 REQUEST_TYPE = LOCK_ISLOCKED
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/lock_lock_codec.py
+++ b/hazelcast/protocol/codec/lock_lock_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.lock_message_type import *
 
 REQUEST_TYPE = LOCK_LOCK
@@ -33,6 +31,3 @@ def encode_request(name, lease_time, thread_id, reference_id):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/lock_try_lock_codec.py
+++ b/hazelcast/protocol/codec/lock_try_lock_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.lock_message_type import *
 
 REQUEST_TYPE = LOCK_TRYLOCK
@@ -39,6 +37,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/lock_unlock_codec.py
+++ b/hazelcast/protocol/codec/lock_unlock_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.lock_message_type import *
 
 REQUEST_TYPE = LOCK_UNLOCK
@@ -31,6 +29,3 @@ def encode_request(name, thread_id, reference_id):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/map_add_entry_listener_codec.py
+++ b/hazelcast/protocol/codec/map_add_entry_listener_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 from hazelcast.protocol.event_response_const import *
 
@@ -40,24 +38,23 @@ def decode_response(client_message, to_object=None):
     return parameters
 
 
-def handle(client_message, handle_event_entry = None, to_object=None):
+def handle(client_message, handle_event_entry=None, to_object=None):
     """ Event handler """
     message_type = client_message.get_message_type()
     if message_type == EVENT_ENTRY and handle_event_entry is not None:
-        key=None
+        key = None
         if not client_message.read_bool():
             key = client_message.read_data()
-        value=None
+        value = None
         if not client_message.read_bool():
             value = client_message.read_data()
-        old_value=None
+        old_value = None
         if not client_message.read_bool():
             old_value = client_message.read_data()
-        merging_value=None
+        merging_value = None
         if not client_message.read_bool():
             merging_value = client_message.read_data()
         event_type = client_message.read_int()
         uuid = client_message.read_str()
         number_of_affected_entries = client_message.read_int()
         handle_event_entry(key=key, value=value, old_value=old_value, merging_value=merging_value, event_type=event_type, uuid=uuid, number_of_affected_entries=number_of_affected_entries)
-

--- a/hazelcast/protocol/codec/map_add_entry_listener_to_key_codec.py
+++ b/hazelcast/protocol/codec/map_add_entry_listener_to_key_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 from hazelcast.protocol.event_response_const import *
 
@@ -42,24 +40,23 @@ def decode_response(client_message, to_object=None):
     return parameters
 
 
-def handle(client_message, handle_event_entry = None, to_object=None):
+def handle(client_message, handle_event_entry=None, to_object=None):
     """ Event handler """
     message_type = client_message.get_message_type()
     if message_type == EVENT_ENTRY and handle_event_entry is not None:
-        key=None
+        key = None
         if not client_message.read_bool():
             key = client_message.read_data()
-        value=None
+        value = None
         if not client_message.read_bool():
             value = client_message.read_data()
-        old_value=None
+        old_value = None
         if not client_message.read_bool():
             old_value = client_message.read_data()
-        merging_value=None
+        merging_value = None
         if not client_message.read_bool():
             merging_value = client_message.read_data()
         event_type = client_message.read_int()
         uuid = client_message.read_str()
         number_of_affected_entries = client_message.read_int()
         handle_event_entry(key=key, value=value, old_value=old_value, merging_value=merging_value, event_type=event_type, uuid=uuid, number_of_affected_entries=number_of_affected_entries)
-

--- a/hazelcast/protocol/codec/map_add_entry_listener_to_key_with_predicate_codec.py
+++ b/hazelcast/protocol/codec/map_add_entry_listener_to_key_with_predicate_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 from hazelcast.protocol.event_response_const import *
 
@@ -44,24 +42,23 @@ def decode_response(client_message, to_object=None):
     return parameters
 
 
-def handle(client_message, handle_event_entry = None, to_object=None):
+def handle(client_message, handle_event_entry=None, to_object=None):
     """ Event handler """
     message_type = client_message.get_message_type()
     if message_type == EVENT_ENTRY and handle_event_entry is not None:
-        key=None
+        key = None
         if not client_message.read_bool():
             key = client_message.read_data()
-        value=None
+        value = None
         if not client_message.read_bool():
             value = client_message.read_data()
-        old_value=None
+        old_value = None
         if not client_message.read_bool():
             old_value = client_message.read_data()
-        merging_value=None
+        merging_value = None
         if not client_message.read_bool():
             merging_value = client_message.read_data()
         event_type = client_message.read_int()
         uuid = client_message.read_str()
         number_of_affected_entries = client_message.read_int()
         handle_event_entry(key=key, value=value, old_value=old_value, merging_value=merging_value, event_type=event_type, uuid=uuid, number_of_affected_entries=number_of_affected_entries)
-

--- a/hazelcast/protocol/codec/map_add_entry_listener_with_predicate_codec.py
+++ b/hazelcast/protocol/codec/map_add_entry_listener_with_predicate_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 from hazelcast.protocol.event_response_const import *
 
@@ -42,24 +40,23 @@ def decode_response(client_message, to_object=None):
     return parameters
 
 
-def handle(client_message, handle_event_entry = None, to_object=None):
+def handle(client_message, handle_event_entry=None, to_object=None):
     """ Event handler """
     message_type = client_message.get_message_type()
     if message_type == EVENT_ENTRY and handle_event_entry is not None:
-        key=None
+        key = None
         if not client_message.read_bool():
             key = client_message.read_data()
-        value=None
+        value = None
         if not client_message.read_bool():
             value = client_message.read_data()
-        old_value=None
+        old_value = None
         if not client_message.read_bool():
             old_value = client_message.read_data()
-        merging_value=None
+        merging_value = None
         if not client_message.read_bool():
             merging_value = client_message.read_data()
         event_type = client_message.read_int()
         uuid = client_message.read_str()
         number_of_affected_entries = client_message.read_int()
         handle_event_entry(key=key, value=value, old_value=old_value, merging_value=merging_value, event_type=event_type, uuid=uuid, number_of_affected_entries=number_of_affected_entries)
-

--- a/hazelcast/protocol/codec/map_add_index_codec.py
+++ b/hazelcast/protocol/codec/map_add_index_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_ADDINDEX
@@ -31,6 +29,3 @@ def encode_request(name, attribute, ordered):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/map_add_interceptor_codec.py
+++ b/hazelcast/protocol/codec/map_add_interceptor_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_ADDINTERCEPTOR
@@ -33,6 +31,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_str()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_add_near_cache_entry_listener_codec.py
+++ b/hazelcast/protocol/codec/map_add_near_cache_entry_listener_codec.py
@@ -37,18 +37,18 @@ def decode_response(client_message, to_object=None):
     return parameters
 
 
-def handle(client_message, handle_event_imapinvalidation=None, handle_event_imapbatchinvalidation=None, to_object=None):
+def handle(client_message, handle_event_imap_invalidation=None, handle_event_imap_batch_invalidation=None, to_object=None):
     """ Event handler """
     message_type = client_message.get_message_type()
-    if message_type == EVENT_IMAPINVALIDATION and handle_event_imapinvalidation is not None:
+    if message_type == EVENT_IMAPINVALIDATION and handle_event_imap_invalidation is not None:
         key = None
         if not client_message.read_bool():
             key = client_message.read_data()
-        handle_event_imapinvalidation(key=key)
-    if message_type == EVENT_IMAPBATCHINVALIDATION and handle_event_imapbatchinvalidation is not None:
+        handle_event_imap_invalidation(key=key)
+    if message_type == EVENT_IMAPBATCHINVALIDATION and handle_event_imap_batch_invalidation is not None:
         keys_size = client_message.read_int()
         keys = []
-        for keys_index in range(0, keys_size):
+        for _ in range(0, keys_size):
             keys_item = client_message.read_data()
             keys.append(keys_item)
-        handle_event_imapbatchinvalidation(keys=keys)
+        handle_event_imap_batch_invalidation(keys=keys)

--- a/hazelcast/protocol/codec/map_add_partition_lost_listener_codec.py
+++ b/hazelcast/protocol/codec/map_add_partition_lost_listener_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 from hazelcast.protocol.event_response_const import *
 
@@ -36,11 +34,10 @@ def decode_response(client_message, to_object=None):
     return parameters
 
 
-def handle(client_message, handle_event_mappartitionlost = None, to_object=None):
+def handle(client_message, handle_event_map_partition_lost=None, to_object=None):
     """ Event handler """
     message_type = client_message.get_message_type()
-    if message_type == EVENT_MAPPARTITIONLOST and handle_event_mappartitionlost is not None:
+    if message_type == EVENT_MAPPARTITIONLOST and handle_event_map_partition_lost is not None:
         partition_id = client_message.read_int()
         uuid = client_message.read_str()
-        handle_event_mappartitionlost(partition_id=partition_id, uuid=uuid)
-
+        handle_event_map_partition_lost(partition_id=partition_id, uuid=uuid)

--- a/hazelcast/protocol/codec/map_clear_codec.py
+++ b/hazelcast/protocol/codec/map_clear_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_CLEAR
@@ -27,6 +25,3 @@ def encode_request(name):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/map_clear_near_cache_codec.py
+++ b/hazelcast/protocol/codec/map_clear_near_cache_codec.py
@@ -1,7 +1,6 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
 from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_CLEARNEARCACHE
@@ -29,6 +28,3 @@ def encode_request(name, target):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/map_contains_key_codec.py
+++ b/hazelcast/protocol/codec/map_contains_key_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_CONTAINSKEY
@@ -35,6 +33,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_contains_value_codec.py
+++ b/hazelcast/protocol/codec/map_contains_value_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_CONTAINSVALUE
@@ -33,6 +31,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_delete_codec.py
+++ b/hazelcast/protocol/codec/map_delete_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_DELETE
@@ -31,6 +29,3 @@ def encode_request(name, key, thread_id):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/map_entries_with_paging_predicate_codec.py
+++ b/hazelcast/protocol/codec/map_entries_with_paging_predicate_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 from hazelcast.six.moves import range
@@ -34,11 +33,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = (client_message.read_data(), client_message.read_data())
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_entries_with_predicate_codec.py
+++ b/hazelcast/protocol/codec/map_entries_with_predicate_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 from hazelcast.six.moves import range
@@ -34,7 +33,7 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = (client_message.read_data(), client_message.read_data())
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)

--- a/hazelcast/protocol/codec/map_entry_set_codec.py
+++ b/hazelcast/protocol/codec/map_entry_set_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 from hazelcast.six.moves import range
@@ -32,11 +31,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = (client_message.read_data(), client_message.read_data())
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_evict_all_codec.py
+++ b/hazelcast/protocol/codec/map_evict_all_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_EVICTALL
@@ -27,6 +25,3 @@ def encode_request(name):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/map_evict_codec.py
+++ b/hazelcast/protocol/codec/map_evict_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_EVICT
@@ -35,6 +33,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_execute_on_all_keys_codec.py
+++ b/hazelcast/protocol/codec/map_execute_on_all_keys_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 from hazelcast.six.moves import range
@@ -34,11 +33,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = (client_message.read_data(), client_message.read_data())
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_execute_on_key_codec.py
+++ b/hazelcast/protocol/codec/map_execute_on_key_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_EXECUTEONKEY
@@ -35,10 +33,6 @@ def encode_request(name, entry_processor, key, thread_id):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_execute_on_keys_codec.py
+++ b/hazelcast/protocol/codec/map_execute_on_keys_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 from hazelcast.six.moves import range
@@ -40,11 +39,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = (client_message.read_data(), client_message.read_data())
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_execute_with_predicate_codec.py
+++ b/hazelcast/protocol/codec/map_execute_with_predicate_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 from hazelcast.six.moves import range
@@ -36,11 +35,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = (client_message.read_data(), client_message.read_data())
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_flush_codec.py
+++ b/hazelcast/protocol/codec/map_flush_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_FLUSH
@@ -27,6 +25,3 @@ def encode_request(name):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/map_force_unlock_codec.py
+++ b/hazelcast/protocol/codec/map_force_unlock_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_FORCEUNLOCK
@@ -31,6 +29,3 @@ def encode_request(name, key, reference_id):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/map_get_all_codec.py
+++ b/hazelcast/protocol/codec/map_get_all_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 from hazelcast.six.moves import range
@@ -38,11 +37,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = (client_message.read_data(), client_message.read_data())
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_get_codec.py
+++ b/hazelcast/protocol/codec/map_get_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_GET
@@ -33,10 +31,6 @@ def encode_request(name, key, thread_id):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_get_entry_view_codec.py
+++ b/hazelcast/protocol/codec/map_get_entry_view_codec.py
@@ -1,7 +1,6 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
 from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_GETENTRYVIEW
@@ -33,10 +32,6 @@ def encode_request(name, key, thread_id):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = EntryViewCodec.decode(client_message, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_is_empty_codec.py
+++ b/hazelcast/protocol/codec/map_is_empty_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_ISEMPTY
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_is_locked_codec.py
+++ b/hazelcast/protocol/codec/map_is_locked_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_ISLOCKED
@@ -33,6 +31,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_key_set_codec.py
+++ b/hazelcast/protocol/codec/map_key_set_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 from hazelcast.six.moves import range
@@ -32,11 +31,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = client_message.read_data()
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_key_set_with_paging_predicate_codec.py
+++ b/hazelcast/protocol/codec/map_key_set_with_paging_predicate_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 from hazelcast.six.moves import range
@@ -34,11 +33,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = client_message.read_data()
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_key_set_with_predicate_codec.py
+++ b/hazelcast/protocol/codec/map_key_set_with_predicate_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 from hazelcast.six.moves import range
@@ -34,11 +33,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = client_message.read_data()
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_load_all_codec.py
+++ b/hazelcast/protocol/codec/map_load_all_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_LOADALL
@@ -29,6 +27,3 @@ def encode_request(name, replace_existing_values):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/map_load_given_keys_codec.py
+++ b/hazelcast/protocol/codec/map_load_given_keys_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_LOADGIVENKEYS
@@ -35,6 +33,3 @@ def encode_request(name, keys, replace_existing_values):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/map_lock_codec.py
+++ b/hazelcast/protocol/codec/map_lock_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_LOCK
@@ -35,6 +33,3 @@ def encode_request(name, key, thread_id, ttl, reference_id):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/map_put_all_codec.py
+++ b/hazelcast/protocol/codec/map_put_all_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 from hazelcast import six
 
@@ -36,6 +34,3 @@ def encode_request(name, entries):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/map_put_codec.py
+++ b/hazelcast/protocol/codec/map_put_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_PUT
@@ -37,10 +35,6 @@ def encode_request(name, key, value, thread_id, ttl):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_put_if_absent_codec.py
+++ b/hazelcast/protocol/codec/map_put_if_absent_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_PUTIFABSENT
@@ -37,10 +35,6 @@ def encode_request(name, key, value, thread_id, ttl):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_put_transient_codec.py
+++ b/hazelcast/protocol/codec/map_put_transient_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_PUTTRANSIENT
@@ -35,6 +33,3 @@ def encode_request(name, key, value, thread_id, ttl):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/map_remove_codec.py
+++ b/hazelcast/protocol/codec/map_remove_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_REMOVE
@@ -33,10 +31,6 @@ def encode_request(name, key, thread_id):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_remove_entry_listener_codec.py
+++ b/hazelcast/protocol/codec/map_remove_entry_listener_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_REMOVEENTRYLISTENER
@@ -27,12 +25,4 @@ def encode_request(name, registration_id):
     client_message.update_frame_length()
     return client_message
 
-
-def decode_response(client_message, to_object=None):
-    """ Decode response from client message"""
-    parameters = dict(response=None)
-    parameters['response'] = client_message.read_bool()
-    return parameters
-
-
-
+# Empty decode_response because response is not used to determine the return value.

--- a/hazelcast/protocol/codec/map_remove_if_same_codec.py
+++ b/hazelcast/protocol/codec/map_remove_if_same_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_REMOVEIFSAME
@@ -37,6 +35,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_remove_interceptor_codec.py
+++ b/hazelcast/protocol/codec/map_remove_interceptor_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_REMOVEINTERCEPTOR
@@ -33,6 +31,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_remove_partition_lost_listener_codec.py
+++ b/hazelcast/protocol/codec/map_remove_partition_lost_listener_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_REMOVEPARTITIONLOSTLISTENER
@@ -33,6 +31,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_replace_codec.py
+++ b/hazelcast/protocol/codec/map_replace_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_REPLACE
@@ -35,10 +33,6 @@ def encode_request(name, key, value, thread_id):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_replace_if_same_codec.py
+++ b/hazelcast/protocol/codec/map_replace_if_same_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_REPLACEIFSAME
@@ -39,6 +37,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_set_codec.py
+++ b/hazelcast/protocol/codec/map_set_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_SET
@@ -35,6 +33,3 @@ def encode_request(name, key, value, thread_id, ttl):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/map_size_codec.py
+++ b/hazelcast/protocol/codec/map_size_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_SIZE
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_int()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_try_lock_codec.py
+++ b/hazelcast/protocol/codec/map_try_lock_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_TRYLOCK
@@ -41,6 +39,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_try_put_codec.py
+++ b/hazelcast/protocol/codec/map_try_put_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_TRYPUT
@@ -39,6 +37,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_try_remove_codec.py
+++ b/hazelcast/protocol/codec/map_try_remove_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_TRYREMOVE
@@ -37,6 +35,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_unlock_codec.py
+++ b/hazelcast/protocol/codec/map_unlock_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_UNLOCK
@@ -33,6 +31,3 @@ def encode_request(name, key, thread_id, reference_id):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/map_values_codec.py
+++ b/hazelcast/protocol/codec/map_values_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 from hazelcast.six.moves import range
@@ -32,11 +31,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = client_message.read_data()
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_values_with_paging_predicate_codec.py
+++ b/hazelcast/protocol/codec/map_values_with_paging_predicate_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 from hazelcast.six.moves import range
@@ -34,11 +33,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = (client_message.read_data(), client_message.read_data())
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/map_values_with_predicate_codec.py
+++ b/hazelcast/protocol/codec/map_values_with_predicate_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.map_message_type import *
 from hazelcast.six.moves import range
@@ -34,11 +33,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = client_message.read_data()
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/multi_map_add_entry_listener_codec.py
+++ b/hazelcast/protocol/codec/multi_map_add_entry_listener_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.multi_map_message_type import *
 from hazelcast.protocol.event_response_const import *
 
@@ -38,24 +36,23 @@ def decode_response(client_message, to_object=None):
     return parameters
 
 
-def handle(client_message, handle_event_entry = None, to_object=None):
+def handle(client_message, handle_event_entry=None, to_object=None):
     """ Event handler """
     message_type = client_message.get_message_type()
     if message_type == EVENT_ENTRY and handle_event_entry is not None:
-        key=None
+        key = None
         if not client_message.read_bool():
             key = client_message.read_data()
-        value=None
+        value = None
         if not client_message.read_bool():
             value = client_message.read_data()
-        old_value=None
+        old_value = None
         if not client_message.read_bool():
             old_value = client_message.read_data()
-        merging_value=None
+        merging_value = None
         if not client_message.read_bool():
             merging_value = client_message.read_data()
         event_type = client_message.read_int()
         uuid = client_message.read_str()
         number_of_affected_entries = client_message.read_int()
         handle_event_entry(key=key, value=value, old_value=old_value, merging_value=merging_value, event_type=event_type, uuid=uuid, number_of_affected_entries=number_of_affected_entries)
-

--- a/hazelcast/protocol/codec/multi_map_add_entry_listener_to_key_codec.py
+++ b/hazelcast/protocol/codec/multi_map_add_entry_listener_to_key_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.multi_map_message_type import *
 from hazelcast.protocol.event_response_const import *
 
@@ -40,20 +38,20 @@ def decode_response(client_message, to_object=None):
     return parameters
 
 
-def handle(client_message, handle_event_entry = None, to_object=None):
+def handle(client_message, handle_event_entry=None, to_object=None):
     """ Event handler """
     message_type = client_message.get_message_type()
     if message_type == EVENT_ENTRY and handle_event_entry is not None:
-        key=None
+        key = None
         if not client_message.read_bool():
             key = client_message.read_data()
-        value=None
+        value = None
         if not client_message.read_bool():
             value = client_message.read_data()
-        old_value=None
+        old_value = None
         if not client_message.read_bool():
             old_value = client_message.read_data()
-        merging_value=None
+        merging_value = None
         if not client_message.read_bool():
             merging_value = client_message.read_data()
         event_type = client_message.read_int()

--- a/hazelcast/protocol/codec/multi_map_clear_codec.py
+++ b/hazelcast/protocol/codec/multi_map_clear_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.multi_map_message_type import *
 
 REQUEST_TYPE = MULTIMAP_CLEAR
@@ -27,6 +25,3 @@ def encode_request(name):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/multi_map_contains_entry_codec.py
+++ b/hazelcast/protocol/codec/multi_map_contains_entry_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.multi_map_message_type import *
 
 REQUEST_TYPE = MULTIMAP_CONTAINSENTRY
@@ -37,6 +35,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/multi_map_contains_key_codec.py
+++ b/hazelcast/protocol/codec/multi_map_contains_key_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.multi_map_message_type import *
 
 REQUEST_TYPE = MULTIMAP_CONTAINSKEY
@@ -35,6 +33,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/multi_map_contains_value_codec.py
+++ b/hazelcast/protocol/codec/multi_map_contains_value_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.multi_map_message_type import *
 
 REQUEST_TYPE = MULTIMAP_CONTAINSVALUE
@@ -33,6 +31,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/multi_map_entry_set_codec.py
+++ b/hazelcast/protocol/codec/multi_map_entry_set_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.multi_map_message_type import *
 from hazelcast.six.moves import range
@@ -32,11 +31,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = (client_message.read_data(), client_message.read_data())
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/multi_map_force_unlock_codec.py
+++ b/hazelcast/protocol/codec/multi_map_force_unlock_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.multi_map_message_type import *
 
 REQUEST_TYPE = MULTIMAP_FORCEUNLOCK
@@ -31,6 +29,3 @@ def encode_request(name, key, reference_id):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/multi_map_get_codec.py
+++ b/hazelcast/protocol/codec/multi_map_get_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.multi_map_message_type import *
 from hazelcast.six.moves import range
@@ -36,11 +35,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = client_message.read_data()
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/multi_map_is_locked_codec.py
+++ b/hazelcast/protocol/codec/multi_map_is_locked_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.multi_map_message_type import *
 
 REQUEST_TYPE = MULTIMAP_ISLOCKED
@@ -33,6 +31,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/multi_map_key_set_codec.py
+++ b/hazelcast/protocol/codec/multi_map_key_set_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.multi_map_message_type import *
 from hazelcast.six.moves import range
@@ -32,11 +31,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = client_message.read_data()
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/multi_map_lock_codec.py
+++ b/hazelcast/protocol/codec/multi_map_lock_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.multi_map_message_type import *
 
 REQUEST_TYPE = MULTIMAP_LOCK
@@ -35,6 +33,3 @@ def encode_request(name, key, thread_id, ttl, reference_id):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/multi_map_put_codec.py
+++ b/hazelcast/protocol/codec/multi_map_put_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.multi_map_message_type import *
 
 REQUEST_TYPE = MULTIMAP_PUT
@@ -37,6 +35,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/multi_map_remove_codec.py
+++ b/hazelcast/protocol/codec/multi_map_remove_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.multi_map_message_type import *
 from hazelcast.six.moves import range
@@ -36,7 +35,7 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = client_message.read_data()
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)

--- a/hazelcast/protocol/codec/multi_map_remove_entry_codec.py
+++ b/hazelcast/protocol/codec/multi_map_remove_entry_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.multi_map_message_type import *
 
 REQUEST_TYPE = MULTIMAP_REMOVEENTRY
@@ -37,6 +35,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/multi_map_remove_entry_listener_codec.py
+++ b/hazelcast/protocol/codec/multi_map_remove_entry_listener_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.multi_map_message_type import *
 
 REQUEST_TYPE = MULTIMAP_REMOVEENTRYLISTENER
@@ -27,12 +25,4 @@ def encode_request(name, registration_id):
     client_message.update_frame_length()
     return client_message
 
-
-def decode_response(client_message, to_object=None):
-    """ Decode response from client message"""
-    parameters = dict(response=None)
-    parameters['response'] = client_message.read_bool()
-    return parameters
-
-
-
+# Empty decode_response because response is not used to determine the return value.

--- a/hazelcast/protocol/codec/multi_map_size_codec.py
+++ b/hazelcast/protocol/codec/multi_map_size_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.multi_map_message_type import *
 
 REQUEST_TYPE = MULTIMAP_SIZE
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_int()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/multi_map_try_lock_codec.py
+++ b/hazelcast/protocol/codec/multi_map_try_lock_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.multi_map_message_type import *
 
 REQUEST_TYPE = MULTIMAP_TRYLOCK
@@ -41,6 +39,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/multi_map_unlock_codec.py
+++ b/hazelcast/protocol/codec/multi_map_unlock_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.multi_map_message_type import *
 
 REQUEST_TYPE = MULTIMAP_UNLOCK
@@ -33,6 +31,3 @@ def encode_request(name, key, thread_id, reference_id):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/multi_map_value_count_codec.py
+++ b/hazelcast/protocol/codec/multi_map_value_count_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.multi_map_message_type import *
 
 REQUEST_TYPE = MULTIMAP_VALUECOUNT
@@ -35,6 +33,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_int()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/multi_map_values_codec.py
+++ b/hazelcast/protocol/codec/multi_map_values_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.multi_map_message_type import *
 from hazelcast.six.moves import range
@@ -32,11 +31,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = client_message.read_data()
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/queue_add_all_codec.py
+++ b/hazelcast/protocol/codec/queue_add_all_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.queue_message_type import *
 
 REQUEST_TYPE = QUEUE_ADDALL
@@ -37,6 +35,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/queue_add_listener_codec.py
+++ b/hazelcast/protocol/codec/queue_add_listener_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.queue_message_type import *
 from hazelcast.protocol.event_response_const import *
 
@@ -38,14 +36,13 @@ def decode_response(client_message, to_object=None):
     return parameters
 
 
-def handle(client_message, handle_event_item = None, to_object=None):
+def handle(client_message, handle_event_item=None, to_object=None):
     """ Event handler """
     message_type = client_message.get_message_type()
     if message_type == EVENT_ITEM and handle_event_item is not None:
-        item=None
+        item = None
         if not client_message.read_bool():
             item = client_message.read_data()
         uuid = client_message.read_str()
         event_type = client_message.read_int()
         handle_event_item(item=item, uuid=uuid, event_type=event_type)
-

--- a/hazelcast/protocol/codec/queue_clear_codec.py
+++ b/hazelcast/protocol/codec/queue_clear_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.queue_message_type import *
 
 REQUEST_TYPE = QUEUE_CLEAR
@@ -27,6 +25,3 @@ def encode_request(name):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/queue_compare_and_remove_all_codec.py
+++ b/hazelcast/protocol/codec/queue_compare_and_remove_all_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.queue_message_type import *
 
 REQUEST_TYPE = QUEUE_COMPAREANDREMOVEALL
@@ -37,6 +35,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/queue_compare_and_retain_all_codec.py
+++ b/hazelcast/protocol/codec/queue_compare_and_retain_all_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.queue_message_type import *
 
 REQUEST_TYPE = QUEUE_COMPAREANDRETAINALL
@@ -37,6 +35,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/queue_contains_all_codec.py
+++ b/hazelcast/protocol/codec/queue_contains_all_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.queue_message_type import *
 
 REQUEST_TYPE = QUEUE_CONTAINSALL
@@ -37,6 +35,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/queue_contains_codec.py
+++ b/hazelcast/protocol/codec/queue_contains_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.queue_message_type import *
 
 REQUEST_TYPE = QUEUE_CONTAINS
@@ -33,6 +31,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/queue_drain_to_codec.py
+++ b/hazelcast/protocol/codec/queue_drain_to_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.queue_message_type import *
 from hazelcast.six.moves import range
@@ -32,11 +31,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = client_message.read_data()
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/queue_drain_to_max_size_codec.py
+++ b/hazelcast/protocol/codec/queue_drain_to_max_size_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.queue_message_type import *
 from hazelcast.six.moves import range
@@ -34,11 +33,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = client_message.read_data()
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/queue_is_empty_codec.py
+++ b/hazelcast/protocol/codec/queue_is_empty_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.queue_message_type import *
 
 REQUEST_TYPE = QUEUE_ISEMPTY
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/queue_iterator_codec.py
+++ b/hazelcast/protocol/codec/queue_iterator_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.queue_message_type import *
 from hazelcast.six.moves import range
@@ -32,11 +31,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = client_message.read_data()
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/queue_offer_codec.py
+++ b/hazelcast/protocol/codec/queue_offer_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.queue_message_type import *
 
 REQUEST_TYPE = QUEUE_OFFER
@@ -35,6 +33,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/queue_peek_codec.py
+++ b/hazelcast/protocol/codec/queue_peek_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.queue_message_type import *
 
 REQUEST_TYPE = QUEUE_PEEK
@@ -29,10 +27,6 @@ def encode_request(name):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/queue_poll_codec.py
+++ b/hazelcast/protocol/codec/queue_poll_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.queue_message_type import *
 
 REQUEST_TYPE = QUEUE_POLL
@@ -31,10 +29,6 @@ def encode_request(name, timeout_millis):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/queue_put_codec.py
+++ b/hazelcast/protocol/codec/queue_put_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.queue_message_type import *
 
 REQUEST_TYPE = QUEUE_PUT
@@ -29,6 +27,3 @@ def encode_request(name, value):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/queue_remaining_capacity_codec.py
+++ b/hazelcast/protocol/codec/queue_remaining_capacity_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.queue_message_type import *
 
 REQUEST_TYPE = QUEUE_REMAININGCAPACITY
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_int()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/queue_remove_codec.py
+++ b/hazelcast/protocol/codec/queue_remove_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.queue_message_type import *
 
 REQUEST_TYPE = QUEUE_REMOVE
@@ -33,6 +31,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/queue_remove_listener_codec.py
+++ b/hazelcast/protocol/codec/queue_remove_listener_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.queue_message_type import *
 
 REQUEST_TYPE = QUEUE_REMOVELISTENER
@@ -27,12 +25,4 @@ def encode_request(name, registration_id):
     client_message.update_frame_length()
     return client_message
 
-
-def decode_response(client_message, to_object=None):
-    """ Decode response from client message"""
-    parameters = dict(response=None)
-    parameters['response'] = client_message.read_bool()
-    return parameters
-
-
-
+# Empty decode_response because response is not used to determine the return value.

--- a/hazelcast/protocol/codec/queue_size_codec.py
+++ b/hazelcast/protocol/codec/queue_size_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.queue_message_type import *
 
 REQUEST_TYPE = QUEUE_SIZE
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_int()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/queue_take_codec.py
+++ b/hazelcast/protocol/codec/queue_take_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.queue_message_type import *
 
 REQUEST_TYPE = QUEUE_TAKE
@@ -29,10 +27,6 @@ def encode_request(name):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/replicated_map_add_entry_listener_codec.py
+++ b/hazelcast/protocol/codec/replicated_map_add_entry_listener_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.replicated_map_message_type import *
 from hazelcast.protocol.event_response_const import *
 
@@ -36,24 +34,23 @@ def decode_response(client_message, to_object=None):
     return parameters
 
 
-def handle(client_message, handle_event_entry = None, to_object=None):
+def handle(client_message, handle_event_entry=None, to_object=None):
     """ Event handler """
     message_type = client_message.get_message_type()
     if message_type == EVENT_ENTRY and handle_event_entry is not None:
-        key=None
+        key = None
         if not client_message.read_bool():
             key = client_message.read_data()
-        value=None
+        value = None
         if not client_message.read_bool():
             value = client_message.read_data()
-        old_value=None
+        old_value = None
         if not client_message.read_bool():
             old_value = client_message.read_data()
-        merging_value=None
+        merging_value = None
         if not client_message.read_bool():
             merging_value = client_message.read_data()
         event_type = client_message.read_int()
         uuid = client_message.read_str()
         number_of_affected_entries = client_message.read_int()
         handle_event_entry(key=key, value=value, old_value=old_value, merging_value=merging_value, event_type=event_type, uuid=uuid, number_of_affected_entries=number_of_affected_entries)
-

--- a/hazelcast/protocol/codec/replicated_map_add_entry_listener_to_key_codec.py
+++ b/hazelcast/protocol/codec/replicated_map_add_entry_listener_to_key_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.replicated_map_message_type import *
 from hazelcast.protocol.event_response_const import *
 
@@ -38,24 +36,23 @@ def decode_response(client_message, to_object=None):
     return parameters
 
 
-def handle(client_message, handle_event_entry = None, to_object=None):
+def handle(client_message, handle_event_entry=None, to_object=None):
     """ Event handler """
     message_type = client_message.get_message_type()
     if message_type == EVENT_ENTRY and handle_event_entry is not None:
-        key=None
+        key = None
         if not client_message.read_bool():
             key = client_message.read_data()
-        value=None
+        value = None
         if not client_message.read_bool():
             value = client_message.read_data()
-        old_value=None
+        old_value = None
         if not client_message.read_bool():
             old_value = client_message.read_data()
-        merging_value=None
+        merging_value = None
         if not client_message.read_bool():
             merging_value = client_message.read_data()
         event_type = client_message.read_int()
         uuid = client_message.read_str()
         number_of_affected_entries = client_message.read_int()
         handle_event_entry(key=key, value=value, old_value=old_value, merging_value=merging_value, event_type=event_type, uuid=uuid, number_of_affected_entries=number_of_affected_entries)
-

--- a/hazelcast/protocol/codec/replicated_map_add_entry_listener_to_key_with_predicate_codec.py
+++ b/hazelcast/protocol/codec/replicated_map_add_entry_listener_to_key_with_predicate_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.replicated_map_message_type import *
 from hazelcast.protocol.event_response_const import *
 
@@ -40,24 +38,23 @@ def decode_response(client_message, to_object=None):
     return parameters
 
 
-def handle(client_message, handle_event_entry = None, to_object=None):
+def handle(client_message, handle_event_entry=None, to_object=None):
     """ Event handler """
     message_type = client_message.get_message_type()
     if message_type == EVENT_ENTRY and handle_event_entry is not None:
-        key=None
+        key = None
         if not client_message.read_bool():
             key = client_message.read_data()
-        value=None
+        value = None
         if not client_message.read_bool():
             value = client_message.read_data()
-        old_value=None
+        old_value = None
         if not client_message.read_bool():
             old_value = client_message.read_data()
-        merging_value=None
+        merging_value = None
         if not client_message.read_bool():
             merging_value = client_message.read_data()
         event_type = client_message.read_int()
         uuid = client_message.read_str()
         number_of_affected_entries = client_message.read_int()
         handle_event_entry(key=key, value=value, old_value=old_value, merging_value=merging_value, event_type=event_type, uuid=uuid, number_of_affected_entries=number_of_affected_entries)
-

--- a/hazelcast/protocol/codec/replicated_map_add_entry_listener_with_predicate_codec.py
+++ b/hazelcast/protocol/codec/replicated_map_add_entry_listener_with_predicate_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.replicated_map_message_type import *
 from hazelcast.protocol.event_response_const import *
 
@@ -38,24 +36,23 @@ def decode_response(client_message, to_object=None):
     return parameters
 
 
-def handle(client_message, handle_event_entry = None, to_object=None):
+def handle(client_message, handle_event_entry=None, to_object=None):
     """ Event handler """
     message_type = client_message.get_message_type()
     if message_type == EVENT_ENTRY and handle_event_entry is not None:
-        key=None
+        key = None
         if not client_message.read_bool():
             key = client_message.read_data()
-        value=None
+        value = None
         if not client_message.read_bool():
             value = client_message.read_data()
-        old_value=None
+        old_value = None
         if not client_message.read_bool():
             old_value = client_message.read_data()
-        merging_value=None
+        merging_value = None
         if not client_message.read_bool():
             merging_value = client_message.read_data()
         event_type = client_message.read_int()
         uuid = client_message.read_str()
         number_of_affected_entries = client_message.read_int()
         handle_event_entry(key=key, value=value, old_value=old_value, merging_value=merging_value, event_type=event_type, uuid=uuid, number_of_affected_entries=number_of_affected_entries)
-

--- a/hazelcast/protocol/codec/replicated_map_add_near_cache_entry_listener_codec.py
+++ b/hazelcast/protocol/codec/replicated_map_add_near_cache_entry_listener_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.replicated_map_message_type import *
 from hazelcast.protocol.event_response_const import *
 
@@ -38,20 +36,20 @@ def decode_response(client_message, to_object=None):
     return parameters
 
 
-def handle(client_message, handle_event_entry = None, to_object=None):
+def handle(client_message, handle_event_entry=None, to_object=None):
     """ Event handler """
     message_type = client_message.get_message_type()
     if message_type == EVENT_ENTRY and handle_event_entry is not None:
-        key=None
+        key = None
         if not client_message.read_bool():
             key = client_message.read_data()
-        value=None
+        value = None
         if not client_message.read_bool():
             value = client_message.read_data()
-        old_value=None
+        old_value = None
         if not client_message.read_bool():
             old_value = client_message.read_data()
-        merging_value=None
+        merging_value = None
         if not client_message.read_bool():
             merging_value = client_message.read_data()
         event_type = client_message.read_int()

--- a/hazelcast/protocol/codec/replicated_map_clear_codec.py
+++ b/hazelcast/protocol/codec/replicated_map_clear_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.replicated_map_message_type import *
 
 REQUEST_TYPE = REPLICATEDMAP_CLEAR
@@ -27,6 +25,3 @@ def encode_request(name):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/replicated_map_contains_key_codec.py
+++ b/hazelcast/protocol/codec/replicated_map_contains_key_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.replicated_map_message_type import *
 
 REQUEST_TYPE = REPLICATEDMAP_CONTAINSKEY
@@ -33,6 +31,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/replicated_map_contains_value_codec.py
+++ b/hazelcast/protocol/codec/replicated_map_contains_value_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.replicated_map_message_type import *
 
 REQUEST_TYPE = REPLICATEDMAP_CONTAINSVALUE
@@ -33,6 +31,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/replicated_map_entry_set_codec.py
+++ b/hazelcast/protocol/codec/replicated_map_entry_set_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.replicated_map_message_type import *
 from hazelcast.six.moves import range
@@ -32,11 +31,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = (client_message.read_data(), client_message.read_data())
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/replicated_map_get_codec.py
+++ b/hazelcast/protocol/codec/replicated_map_get_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.replicated_map_message_type import *
 
 REQUEST_TYPE = REPLICATEDMAP_GET
@@ -31,10 +29,6 @@ def encode_request(name, key):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/replicated_map_is_empty_codec.py
+++ b/hazelcast/protocol/codec/replicated_map_is_empty_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.replicated_map_message_type import *
 
 REQUEST_TYPE = REPLICATEDMAP_ISEMPTY
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/replicated_map_key_set_codec.py
+++ b/hazelcast/protocol/codec/replicated_map_key_set_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.replicated_map_message_type import *
 from hazelcast.six.moves import range
@@ -32,11 +31,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = client_message.read_data()
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/replicated_map_put_all_codec.py
+++ b/hazelcast/protocol/codec/replicated_map_put_all_codec.py
@@ -1,9 +1,8 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.replicated_map_message_type import *
 from hazelcast import six
+
 REQUEST_TYPE = REPLICATEDMAP_PUTALL
 RESPONSE_TYPE = 100
 RETRYABLE = False
@@ -34,6 +33,3 @@ def encode_request(name, entries):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/replicated_map_put_codec.py
+++ b/hazelcast/protocol/codec/replicated_map_put_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.replicated_map_message_type import *
 
 REQUEST_TYPE = REPLICATEDMAP_PUT
@@ -35,10 +33,6 @@ def encode_request(name, key, value, ttl):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/replicated_map_remove_codec.py
+++ b/hazelcast/protocol/codec/replicated_map_remove_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.replicated_map_message_type import *
 
 REQUEST_TYPE = REPLICATEDMAP_REMOVE
@@ -31,10 +29,6 @@ def encode_request(name, key):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/replicated_map_remove_entry_listener_codec.py
+++ b/hazelcast/protocol/codec/replicated_map_remove_entry_listener_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.replicated_map_message_type import *
 
 REQUEST_TYPE = REPLICATEDMAP_REMOVEENTRYLISTENER
@@ -27,12 +25,5 @@ def encode_request(name, registration_id):
     client_message.update_frame_length()
     return client_message
 
-
-def decode_response(client_message, to_object=None):
-    """ Decode response from client message"""
-    parameters = dict(response=None)
-    parameters['response'] = client_message.read_bool()
-    return parameters
-
-
+# Empty decode_response because response is not used to determine the return value.
 

--- a/hazelcast/protocol/codec/replicated_map_size_codec.py
+++ b/hazelcast/protocol/codec/replicated_map_size_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.replicated_map_message_type import *
 
 REQUEST_TYPE = REPLICATEDMAP_SIZE

--- a/hazelcast/protocol/codec/replicated_map_values_codec.py
+++ b/hazelcast/protocol/codec/replicated_map_values_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.replicated_map_message_type import *
 from hazelcast.six.moves import range
@@ -32,7 +31,7 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = client_message.read_data()
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)

--- a/hazelcast/protocol/codec/ringbuffer_add_all_codec.py
+++ b/hazelcast/protocol/codec/ringbuffer_add_all_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.ringbuffer_message_type import *
 
 REQUEST_TYPE = RINGBUFFER_ADDALL
@@ -39,6 +37,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_long()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/ringbuffer_add_codec.py
+++ b/hazelcast/protocol/codec/ringbuffer_add_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.ringbuffer_message_type import *
 
 REQUEST_TYPE = RINGBUFFER_ADD
@@ -35,6 +33,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_long()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/ringbuffer_capacity_codec.py
+++ b/hazelcast/protocol/codec/ringbuffer_capacity_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.ringbuffer_message_type import *
 
 REQUEST_TYPE = RINGBUFFER_CAPACITY
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_long()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/ringbuffer_head_sequence_codec.py
+++ b/hazelcast/protocol/codec/ringbuffer_head_sequence_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.ringbuffer_message_type import *
 
 REQUEST_TYPE = RINGBUFFER_HEADSEQUENCE
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_long()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/ringbuffer_read_many_codec.py
+++ b/hazelcast/protocol/codec/ringbuffer_read_many_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.ringbuffer_message_type import *
 from hazelcast.six.moves import range
@@ -45,11 +44,8 @@ def decode_response(client_message, to_object=None):
     parameters['read_count'] = client_message.read_int()
     items_size = client_message.read_int()
     items = []
-    for items_index in range(0, items_size):
+    for _ in range(0, items_size):
         items_item = client_message.read_data()
         items.append(items_item)
     parameters['items'] = ImmutableLazyDataList(items, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/ringbuffer_read_one_codec.py
+++ b/hazelcast/protocol/codec/ringbuffer_read_one_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.ringbuffer_message_type import *
 
 REQUEST_TYPE = RINGBUFFER_READONE
@@ -31,10 +29,6 @@ def encode_request(name, sequence):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/ringbuffer_remaining_capacity_codec.py
+++ b/hazelcast/protocol/codec/ringbuffer_remaining_capacity_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.ringbuffer_message_type import *
 
 REQUEST_TYPE = RINGBUFFER_REMAININGCAPACITY
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_long()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/ringbuffer_size_codec.py
+++ b/hazelcast/protocol/codec/ringbuffer_size_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.ringbuffer_message_type import *
 
 REQUEST_TYPE = RINGBUFFER_SIZE
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_long()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/ringbuffer_tail_sequence_codec.py
+++ b/hazelcast/protocol/codec/ringbuffer_tail_sequence_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.ringbuffer_message_type import *
 
 REQUEST_TYPE = RINGBUFFER_TAILSEQUENCE
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_long()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/semaphore_acquire_codec.py
+++ b/hazelcast/protocol/codec/semaphore_acquire_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.semaphore_message_type import *
 
 REQUEST_TYPE = SEMAPHORE_ACQUIRE
@@ -29,6 +27,3 @@ def encode_request(name, permits):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/semaphore_available_permits_codec.py
+++ b/hazelcast/protocol/codec/semaphore_available_permits_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.semaphore_message_type import *
 
 REQUEST_TYPE = SEMAPHORE_AVAILABLEPERMITS
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_int()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/semaphore_drain_permits_codec.py
+++ b/hazelcast/protocol/codec/semaphore_drain_permits_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.semaphore_message_type import *
 
 REQUEST_TYPE = SEMAPHORE_DRAINPERMITS
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_int()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/semaphore_init_codec.py
+++ b/hazelcast/protocol/codec/semaphore_init_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.semaphore_message_type import *
 
 REQUEST_TYPE = SEMAPHORE_INIT
@@ -33,6 +31,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/semaphore_reduce_permits_codec.py
+++ b/hazelcast/protocol/codec/semaphore_reduce_permits_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.semaphore_message_type import *
 
 REQUEST_TYPE = SEMAPHORE_REDUCEPERMITS
@@ -29,6 +27,3 @@ def encode_request(name, reduction):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/semaphore_release_codec.py
+++ b/hazelcast/protocol/codec/semaphore_release_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.semaphore_message_type import *
 
 REQUEST_TYPE = SEMAPHORE_RELEASE
@@ -29,6 +27,3 @@ def encode_request(name, permits):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/semaphore_try_acquire_codec.py
+++ b/hazelcast/protocol/codec/semaphore_try_acquire_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.semaphore_message_type import *
 
 REQUEST_TYPE = SEMAPHORE_TRYACQUIRE
@@ -35,6 +33,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/set_add_all_codec.py
+++ b/hazelcast/protocol/codec/set_add_all_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.set_message_type import *
 
 REQUEST_TYPE = SET_ADDALL
@@ -37,6 +35,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/set_add_codec.py
+++ b/hazelcast/protocol/codec/set_add_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.set_message_type import *
 
 REQUEST_TYPE = SET_ADD
@@ -33,6 +31,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/set_add_listener_codec.py
+++ b/hazelcast/protocol/codec/set_add_listener_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.set_message_type import *
 from hazelcast.protocol.event_response_const import *
 
@@ -38,14 +36,13 @@ def decode_response(client_message, to_object=None):
     return parameters
 
 
-def handle(client_message, handle_event_item = None, to_object=None):
+def handle(client_message, handle_event_item=None, to_object=None):
     """ Event handler """
     message_type = client_message.get_message_type()
     if message_type == EVENT_ITEM and handle_event_item is not None:
-        item=None
+        item = None
         if not client_message.read_bool():
             item = client_message.read_data()
         uuid = client_message.read_str()
         event_type = client_message.read_int()
         handle_event_item(item=item, uuid=uuid, event_type=event_type)
-

--- a/hazelcast/protocol/codec/set_clear_codec.py
+++ b/hazelcast/protocol/codec/set_clear_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.set_message_type import *
 
 REQUEST_TYPE = SET_CLEAR
@@ -27,6 +25,3 @@ def encode_request(name):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/set_compare_and_remove_all_codec.py
+++ b/hazelcast/protocol/codec/set_compare_and_remove_all_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.set_message_type import *
 
 REQUEST_TYPE = SET_COMPAREANDREMOVEALL
@@ -37,6 +35,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/set_compare_and_retain_all_codec.py
+++ b/hazelcast/protocol/codec/set_compare_and_retain_all_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.set_message_type import *
 
 REQUEST_TYPE = SET_COMPAREANDRETAINALL
@@ -37,6 +35,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/set_contains_all_codec.py
+++ b/hazelcast/protocol/codec/set_contains_all_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.set_message_type import *
 
 REQUEST_TYPE = SET_CONTAINSALL
@@ -37,6 +35,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/set_contains_codec.py
+++ b/hazelcast/protocol/codec/set_contains_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.set_message_type import *
 
 REQUEST_TYPE = SET_CONTAINS
@@ -33,6 +31,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/set_get_all_codec.py
+++ b/hazelcast/protocol/codec/set_get_all_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.set_message_type import *
 from hazelcast.six.moves import range
@@ -32,11 +31,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = client_message.read_data()
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/set_is_empty_codec.py
+++ b/hazelcast/protocol/codec/set_is_empty_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.set_message_type import *
 
 REQUEST_TYPE = SET_ISEMPTY
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/set_remove_codec.py
+++ b/hazelcast/protocol/codec/set_remove_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.set_message_type import *
 
 REQUEST_TYPE = SET_REMOVE
@@ -33,6 +31,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/set_remove_listener_codec.py
+++ b/hazelcast/protocol/codec/set_remove_listener_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.set_message_type import *
 
 REQUEST_TYPE = SET_REMOVELISTENER
@@ -27,12 +25,5 @@ def encode_request(name, registration_id):
     client_message.update_frame_length()
     return client_message
 
-
-def decode_response(client_message, to_object=None):
-    """ Decode response from client message"""
-    parameters = dict(response=None)
-    parameters['response'] = client_message.read_bool()
-    return parameters
-
-
+# Empty decode_response because response is not used to determine the return value.
 

--- a/hazelcast/protocol/codec/set_size_codec.py
+++ b/hazelcast/protocol/codec/set_size_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.set_message_type import *
 
 REQUEST_TYPE = SET_SIZE
@@ -31,6 +29,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_int()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/topic_add_message_listener_codec.py
+++ b/hazelcast/protocol/codec/topic_add_message_listener_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.topic_message_type import *
 from hazelcast.protocol.event_response_const import *
 
@@ -36,7 +34,7 @@ def decode_response(client_message, to_object=None):
     return parameters
 
 
-def handle(client_message, handle_event_topic = None, to_object=None):
+def handle(client_message, handle_event_topic=None, to_object=None):
     """ Event handler """
     message_type = client_message.get_message_type()
     if message_type == EVENT_TOPIC and handle_event_topic is not None:
@@ -44,4 +42,3 @@ def handle(client_message, handle_event_topic = None, to_object=None):
         publish_time = client_message.read_long()
         uuid = client_message.read_str()
         handle_event_topic(item=item, publish_time=publish_time, uuid=uuid)
-

--- a/hazelcast/protocol/codec/topic_publish_codec.py
+++ b/hazelcast/protocol/codec/topic_publish_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.topic_message_type import *
 
 REQUEST_TYPE = TOPIC_PUBLISH
@@ -29,6 +27,3 @@ def encode_request(name, message):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/topic_remove_message_listener_codec.py
+++ b/hazelcast/protocol/codec/topic_remove_message_listener_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.topic_message_type import *
 
 REQUEST_TYPE = TOPIC_REMOVEMESSAGELISTENER
@@ -27,12 +25,5 @@ def encode_request(name, registration_id):
     client_message.update_frame_length()
     return client_message
 
-
-def decode_response(client_message, to_object=None):
-    """ Decode response from client message"""
-    parameters = dict(response=None)
-    parameters['response'] = client_message.read_bool()
-    return parameters
-
-
+# Empty decode_response because response is not used to determine the return value.
 

--- a/hazelcast/protocol/codec/transaction_commit_codec.py
+++ b/hazelcast/protocol/codec/transaction_commit_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transaction_message_type import *
 
 REQUEST_TYPE = TRANSACTION_COMMIT
@@ -29,6 +27,3 @@ def encode_request(transaction_id, thread_id):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/transaction_create_codec.py
+++ b/hazelcast/protocol/codec/transaction_create_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transaction_message_type import *
 
 REQUEST_TYPE = TRANSACTION_CREATE
@@ -37,6 +35,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_str()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/transaction_rollback_codec.py
+++ b/hazelcast/protocol/codec/transaction_rollback_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transaction_message_type import *
 
 REQUEST_TYPE = TRANSACTION_ROLLBACK
@@ -29,6 +27,3 @@ def encode_request(transaction_id, thread_id):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/transactional_list_add_codec.py
+++ b/hazelcast/protocol/codec/transactional_list_add_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_list_message_type import *
 
 REQUEST_TYPE = TRANSACTIONALLIST_ADD
@@ -37,6 +35,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/transactional_list_remove_codec.py
+++ b/hazelcast/protocol/codec/transactional_list_remove_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_list_message_type import *
 
 REQUEST_TYPE = TRANSACTIONALLIST_REMOVE
@@ -37,6 +35,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/transactional_list_size_codec.py
+++ b/hazelcast/protocol/codec/transactional_list_size_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_list_message_type import *
 
 REQUEST_TYPE = TRANSACTIONALLIST_SIZE
@@ -35,6 +33,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_int()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/transactional_map_contains_key_codec.py
+++ b/hazelcast/protocol/codec/transactional_map_contains_key_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_map_message_type import *
 
 REQUEST_TYPE = TRANSACTIONALMAP_CONTAINSKEY
@@ -37,6 +35,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/transactional_map_delete_codec.py
+++ b/hazelcast/protocol/codec/transactional_map_delete_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_map_message_type import *
 
 REQUEST_TYPE = TRANSACTIONALMAP_DELETE
@@ -33,6 +31,3 @@ def encode_request(name, txn_id, thread_id, key):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/transactional_map_get_codec.py
+++ b/hazelcast/protocol/codec/transactional_map_get_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_map_message_type import *
 
 REQUEST_TYPE = TRANSACTIONALMAP_GET
@@ -35,10 +33,6 @@ def encode_request(name, txn_id, thread_id, key):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/transactional_map_get_for_update_codec.py
+++ b/hazelcast/protocol/codec/transactional_map_get_for_update_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_map_message_type import *
 
 REQUEST_TYPE = TRANSACTIONALMAP_GETFORUPDATE
@@ -35,10 +33,6 @@ def encode_request(name, txn_id, thread_id, key):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/transactional_map_is_empty_codec.py
+++ b/hazelcast/protocol/codec/transactional_map_is_empty_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_map_message_type import *
 
 REQUEST_TYPE = TRANSACTIONALMAP_ISEMPTY
@@ -35,6 +33,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/transactional_map_key_set_codec.py
+++ b/hazelcast/protocol/codec/transactional_map_key_set_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_map_message_type import *
 from hazelcast.six.moves import range
@@ -36,11 +35,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = client_message.read_data()
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/transactional_map_key_set_with_predicate_codec.py
+++ b/hazelcast/protocol/codec/transactional_map_key_set_with_predicate_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_map_message_type import *
 from hazelcast.six.moves import range
@@ -38,11 +37,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = client_message.read_data()
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/transactional_map_put_codec.py
+++ b/hazelcast/protocol/codec/transactional_map_put_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_map_message_type import *
 
 REQUEST_TYPE = TRANSACTIONALMAP_PUT
@@ -39,7 +37,6 @@ def encode_request(name, txn_id, thread_id, key, value, ttl):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters

--- a/hazelcast/protocol/codec/transactional_map_put_if_absent_codec.py
+++ b/hazelcast/protocol/codec/transactional_map_put_if_absent_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_map_message_type import *
 
 REQUEST_TYPE = TRANSACTIONALMAP_PUTIFABSENT
@@ -37,7 +35,6 @@ def encode_request(name, txn_id, thread_id, key, value):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters

--- a/hazelcast/protocol/codec/transactional_map_remove_codec.py
+++ b/hazelcast/protocol/codec/transactional_map_remove_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_map_message_type import *
 
 REQUEST_TYPE = TRANSACTIONALMAP_REMOVE
@@ -35,7 +33,6 @@ def encode_request(name, txn_id, thread_id, key):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters

--- a/hazelcast/protocol/codec/transactional_map_remove_if_same_codec.py
+++ b/hazelcast/protocol/codec/transactional_map_remove_if_same_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_map_message_type import *
 
 REQUEST_TYPE = TRANSACTIONALMAP_REMOVEIFSAME
@@ -39,6 +37,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/transactional_map_replace_codec.py
+++ b/hazelcast/protocol/codec/transactional_map_replace_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_map_message_type import *
 
 REQUEST_TYPE = TRANSACTIONALMAP_REPLACE
@@ -37,10 +35,6 @@ def encode_request(name, txn_id, thread_id, key, value):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/transactional_map_replace_if_same_codec.py
+++ b/hazelcast/protocol/codec/transactional_map_replace_if_same_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_map_message_type import *
 
 REQUEST_TYPE = TRANSACTIONALMAP_REPLACEIFSAME
@@ -41,6 +39,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/transactional_map_set_codec.py
+++ b/hazelcast/protocol/codec/transactional_map_set_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_map_message_type import *
 
 REQUEST_TYPE = TRANSACTIONALMAP_SET
@@ -35,6 +33,3 @@ def encode_request(name, txn_id, thread_id, key, value):
 
 
 # Empty decode_response(client_message), this message has no parameters to decode
-
-
-

--- a/hazelcast/protocol/codec/transactional_map_size_codec.py
+++ b/hazelcast/protocol/codec/transactional_map_size_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_map_message_type import *
 
 REQUEST_TYPE = TRANSACTIONALMAP_SIZE
@@ -35,6 +33,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_int()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/transactional_map_values_codec.py
+++ b/hazelcast/protocol/codec/transactional_map_values_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_map_message_type import *
 from hazelcast.six.moves import range
@@ -36,11 +35,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = client_message.read_data()
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/transactional_map_values_with_predicate_codec.py
+++ b/hazelcast/protocol/codec/transactional_map_values_with_predicate_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_map_message_type import *
 from hazelcast.six.moves import range
@@ -38,11 +37,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = client_message.read_data()
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/transactional_multi_map_get_codec.py
+++ b/hazelcast/protocol/codec/transactional_multi_map_get_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_multi_map_message_type import *
 from hazelcast.six.moves import range
@@ -38,7 +37,7 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = client_message.read_data()
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)

--- a/hazelcast/protocol/codec/transactional_multi_map_put_codec.py
+++ b/hazelcast/protocol/codec/transactional_multi_map_put_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_multi_map_message_type import *
 
 REQUEST_TYPE = TRANSACTIONALMULTIMAP_PUT
@@ -39,6 +37,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/transactional_multi_map_remove_codec.py
+++ b/hazelcast/protocol/codec/transactional_multi_map_remove_codec.py
@@ -1,6 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
 from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_multi_map_message_type import *
 from hazelcast.six.moves import range
@@ -38,11 +37,8 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     response_size = client_message.read_int()
     response = []
-    for response_index in range(0, response_size):
+    for _ in range(0, response_size):
         response_item = client_message.read_data()
         response.append(response_item)
     parameters['response'] = ImmutableLazyDataList(response, to_object)
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/transactional_multi_map_remove_entry_codec.py
+++ b/hazelcast/protocol/codec/transactional_multi_map_remove_entry_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_multi_map_message_type import *
 
 REQUEST_TYPE = TRANSACTIONALMULTIMAP_REMOVEENTRY
@@ -39,6 +37,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/transactional_multi_map_size_codec.py
+++ b/hazelcast/protocol/codec/transactional_multi_map_size_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_multi_map_message_type import *
 
 REQUEST_TYPE = TRANSACTIONALMULTIMAP_SIZE
@@ -35,6 +33,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_int()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/transactional_multi_map_value_count_codec.py
+++ b/hazelcast/protocol/codec/transactional_multi_map_value_count_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_multi_map_message_type import *
 
 REQUEST_TYPE = TRANSACTIONALMULTIMAP_VALUECOUNT
@@ -37,6 +35,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_int()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/transactional_queue_offer_codec.py
+++ b/hazelcast/protocol/codec/transactional_queue_offer_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_queue_message_type import *
 
 REQUEST_TYPE = TRANSACTIONALQUEUE_OFFER
@@ -39,6 +37,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/transactional_queue_peek_codec.py
+++ b/hazelcast/protocol/codec/transactional_queue_peek_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_queue_message_type import *
 
 REQUEST_TYPE = TRANSACTIONALQUEUE_PEEK
@@ -35,10 +33,6 @@ def encode_request(name, txn_id, thread_id, timeout):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/transactional_queue_poll_codec.py
+++ b/hazelcast/protocol/codec/transactional_queue_poll_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_queue_message_type import *
 
 REQUEST_TYPE = TRANSACTIONALQUEUE_POLL
@@ -35,10 +33,6 @@ def encode_request(name, txn_id, thread_id, timeout):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/transactional_queue_size_codec.py
+++ b/hazelcast/protocol/codec/transactional_queue_size_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_queue_message_type import *
 
 REQUEST_TYPE = TRANSACTIONALQUEUE_SIZE
@@ -35,6 +33,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_int()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/transactional_queue_take_codec.py
+++ b/hazelcast/protocol/codec/transactional_queue_take_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_queue_message_type import *
 
 REQUEST_TYPE = TRANSACTIONALQUEUE_TAKE
@@ -33,10 +31,6 @@ def encode_request(name, txn_id, thread_id):
 def decode_response(client_message, to_object=None):
     """ Decode response from client message"""
     parameters = dict(response=None)
-    response=None
     if not client_message.read_bool():
         parameters['response'] = to_object(client_message.read_data())
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/transactional_set_add_codec.py
+++ b/hazelcast/protocol/codec/transactional_set_add_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_set_message_type import *
 
 REQUEST_TYPE = TRANSACTIONALSET_ADD
@@ -37,6 +35,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/transactional_set_remove_codec.py
+++ b/hazelcast/protocol/codec/transactional_set_remove_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_set_message_type import *
 
 REQUEST_TYPE = TRANSACTIONALSET_REMOVE
@@ -37,6 +35,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_bool()
     return parameters
-
-
-

--- a/hazelcast/protocol/codec/transactional_set_size_codec.py
+++ b/hazelcast/protocol/codec/transactional_set_size_codec.py
@@ -1,7 +1,5 @@
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import ClientMessage
-from hazelcast.protocol.custom_codec import *
-from hazelcast.util import ImmutableLazyDataList
 from hazelcast.protocol.codec.transactional_set_message_type import *
 
 REQUEST_TYPE = TRANSACTIONALSET_SIZE
@@ -35,6 +33,3 @@ def decode_response(client_message, to_object=None):
     parameters = dict(response=None)
     parameters['response'] = client_message.read_int()
     return parameters
-
-
-


### PR DESCRIPTION
This PR removes unused import statements, unused local variables and blank lines at the end of codecs. It also removes decode_response methods of *_remove_listener codecs since the member's response is discarded and we simply return a boolean value based on a pop operation on a local dict.  (See [stop_listening](https://github.com/hazelcast/hazelcast-python-client/blob/master/hazelcast/invocation.py#L87))