### PR TITLE
server should not close clients when client only listens

### DIFF
--- a/hazelcast/connection.py
+++ b/hazelcast/connection.py
@@ -225,13 +225,13 @@ class Heartbeat(object):
                     self.logger.warning(
                         "Heartbeat: Did not hear back after %ss from %s" % (time_since_last_read, connection))
                     self._on_heartbeat_stopped(connection)
+            else:
+                if not connection.heartbeating:
+                    self._on_heartbeat_restored(connection)
 
             if time_since_last_write > self._heartbeat_interval:
                 request = client_ping_codec.encode_request()
                 self._client.invoker.invoke_on_connection(request, connection, ignore_heartbeat=True)
-            else:
-                if not connection.heartbeating:
-                    self._on_heartbeat_restored(connection)
 
     def _on_heartbeat_restored(self, connection):
         self.logger.info("Heartbeat: Heartbeat restored for connection %s" % connection)

--- a/hazelcast/connection.py
+++ b/hazelcast/connection.py
@@ -219,13 +219,14 @@ class Heartbeat(object):
         now = time.time()
         for connection in list(self._client.connection_manager.connections.values()):
             time_since_last_read = now - connection.last_read
+            time_since_last_write = now - connection.last_write
             if time_since_last_read > self._heartbeat_timeout:
                 if connection.heartbeating:
                     self.logger.warning(
                         "Heartbeat: Did not hear back after %ss from %s" % (time_since_last_read, connection))
                     self._on_heartbeat_stopped(connection)
 
-            if time_since_last_read > self._heartbeat_interval:
+            if time_since_last_write > self._heartbeat_interval:
                 request = client_ping_codec.encode_request()
                 self._client.invoker.invoke_on_connection(request, connection, ignore_heartbeat=True)
             else:
@@ -264,6 +265,7 @@ class Connection(object):
         self._builder = ClientMessageBuilder(message_callback)
         self._read_buffer = b""
         self.last_read = time.time()
+        self.last_write = 0
 
     def live(self):
         """

--- a/hazelcast/reactor.py
+++ b/hazelcast/reactor.py
@@ -150,6 +150,7 @@ class AsyncoreConnection(Connection, asyncore.dispatcher):
             except IndexError:
                 return
             sent = self.send(data)
+            self.last_write = time.time()
             self.sent_protocol_bytes = True
             if sent < len(data):
                 self._write_queue.appendleft(data[sent:])
@@ -175,6 +176,7 @@ class AsyncoreConnection(Connection, asyncore.dispatcher):
         if len(self._write_queue) == 0 and self._write_lock.acquire(False):
             try:
                 sent = self.send(data)
+                self.last_write = time.time()
                 if sent < len(data):
                     self.logger.info("adding to queue")
                     self._write_queue.appendleft(data[sent:])

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1,0 +1,54 @@
+import time
+import logging
+
+from tests.base import HazelcastTestCase
+from hazelcast.config import ClientConfig, PROPERTY_HEARTBEAT_INTERVAL
+from hazelcast.client import HazelcastClient
+from hazelcast.lifecycle import LIFECYCLE_STATE_DISCONNECTED
+
+
+class ClientTest(HazelcastTestCase):
+    def test_client_only_listens(self):
+        rc = self.create_rc()
+        client_heartbeat_seconds = 8
+
+        cluster_config = """<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
+           xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <properties>
+                <property name="hazelcast.client.max.no.heartbeat.seconds">{}</property>
+            </properties>
+        </hazelcast>""".format(client_heartbeat_seconds)
+        cluster = self.create_cluster(rc, cluster_config)
+        member = cluster.start_member()
+
+        client_config = ClientConfig()
+        client_config._properties[PROPERTY_HEARTBEAT_INTERVAL] = 1000
+
+        client1 = HazelcastClient(client_config)
+        is_client_disconnected = [False]
+
+        def lifecycle_listener(event, flag=is_client_disconnected):
+            if event == LIFECYCLE_STATE_DISCONNECTED:
+                flag[0] = True
+
+        client1.lifecycle.add_listener(lifecycle_listener)
+        client2 = HazelcastClient()
+
+        key = "topic-name"
+        topic = client1.get_topic(key).blocking()
+
+        def message_listener(e):
+            pass
+        
+        topic.add_listener(message_listener)
+
+        client2topic = client2.get_topic(key)
+        begin = time.time()
+
+        while (time.time() - begin) < 2 * client_heartbeat_seconds:
+            client2topic.publish("message")
+
+        self.assertFalse(is_client_disconnected[0])
+
+        rc.exit()

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1,7 +1,7 @@
 import time
 
 from tests.base import HazelcastTestCase
-from hazelcast.config import ClientConfig, PROPERTY_HEARTBEAT_INTERVAL
+from hazelcast.config import ClientConfig, ClientProperties
 from hazelcast.client import HazelcastClient
 from hazelcast.lifecycle import LIFECYCLE_STATE_DISCONNECTED
 
@@ -22,7 +22,7 @@ class ClientTest(HazelcastTestCase):
         member = cluster.start_member()
 
         client_config = ClientConfig()
-        client_config._properties[PROPERTY_HEARTBEAT_INTERVAL] = 1000
+        client_config.set_property(ClientProperties.HEARTBEAT_INTERVAL.name, 1000)
 
         client1 = HazelcastClient(client_config)
 

--- a/tests/heartbeat_test.py
+++ b/tests/heartbeat_test.py
@@ -1,0 +1,104 @@
+from hazelcast import HazelcastClient
+from hazelcast.core import Address
+from tests.base import HazelcastTestCase
+from hazelcast.config import ClientConfig, PROPERTY_HEARTBEAT_INTERVAL, PROPERTY_HEARTBEAT_TIMEOUT
+from tests.util import configure_logging
+
+
+class HeartbeatTest(HazelcastTestCase):
+    @classmethod
+    def setUpClass(cls):
+        configure_logging()
+        cls.rc = cls.create_rc()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.rc.exit()
+
+    def setUp(self):
+        self.cluster = self.create_cluster(self.rc)
+
+    def tearDown(self):
+        self.rc.shutdownCluster(self.cluster.id)
+
+    def test_heartbeat_stopped(self):
+        member = self.rc.startMember(self.cluster.id)
+        config = ClientConfig()
+
+        config._properties[PROPERTY_HEARTBEAT_INTERVAL] = 500
+        config._properties[PROPERTY_HEARTBEAT_TIMEOUT] = 2000
+
+        client = HazelcastClient(config)
+
+        client.cluster.add_listener(member_added=lambda m: client.connection_manager.get_or_connect(m.address))
+
+        def heartbeat_stopped_collector():
+            connections = []
+
+            def connection_collector(c):
+                connections.append(c)
+
+            connection_collector.connections = connections
+            return connection_collector
+
+        collector = heartbeat_stopped_collector()
+
+        client.heartbeat.add_listener(on_heartbeat_stopped=collector)
+
+        member2 = self.rc.startMember(self.cluster.id)
+        self.simulate_heartbeat_lost(client, Address(member2.host, member2.port), 2)
+
+        def assert_connection():
+            self.assertTrue(len(collector.connections) > 0)
+            connection = collector.connections[0]
+            self.assertEqual(connection._address, (member2.host, member2.port))
+
+        self.assertTrueEventually(assert_connection)
+        client.shutdown()
+
+    def test_heartbeat_restored(self):
+        member = self.rc.startMember(self.cluster.id)
+        config = ClientConfig()
+
+        config._properties[PROPERTY_HEARTBEAT_INTERVAL] = 500
+        config._properties[PROPERTY_HEARTBEAT_TIMEOUT] = 2000
+
+        client = HazelcastClient(config)
+
+        def member_added_func(m):
+
+            def connection_callback(f):
+                conn = f.result()
+                self.simulate_heartbeat_lost(client, Address(conn._address[0], conn._address[1]), 2)
+
+            client.connection_manager.get_or_connect(m.address).add_done_callback(connection_callback)
+
+        client.cluster.add_listener(member_added=member_added_func)
+
+        def heartbeat_restored_collector():
+            connections = []
+
+            def connection_collector(c):
+                connections.append(c)
+
+            connection_collector.connections = connections
+            return connection_collector
+
+        collector = heartbeat_restored_collector()
+
+        client.heartbeat.add_listener(on_heartbeat_restored=collector)
+
+        member2 = self.rc.startMember(self.cluster.id)
+
+        def assert_event():
+            self.assertTrue(len(collector.connections) > 0)
+            connection = collector.connections[0]
+            self.assertEqual(connection._address, (member2.host, member2.port))
+
+        self.assertTrueEventually(assert_event)
+        client.shutdown()
+
+    @staticmethod
+    def simulate_heartbeat_lost(client, address, timeout):
+        client.connection_manager.connections[address].last_read -= timeout
+        client.connection_manager.connections[address].last_write += timeout

--- a/tests/reconnect_test.py
+++ b/tests/reconnect_test.py
@@ -32,10 +32,12 @@ class ReconnectTest(HazelcastTestCase):
             self.create_client(config)
 
     def test_start_client_before_member(self):
-        Thread(target=self.cluster.start_member).start()
+        t = Thread(target=self.cluster.start_member)
+        t.start()
         config = ClientConfig()
         config.network_config.connection_attempt_limit = 10
         self.create_client(config)
+        t.join()
 
     def test_restart_member(self):
         member = self.cluster.start_member()


### PR DESCRIPTION
Client was not sending Ping to server when last read time is up-to-date. When server constantly pushes events to client, client does not send any ping to server. And consequently, server closes client because it does not send any ping. Client logic has changed so that it send pings if there is no outgoing packages recently, rather than looking at incoming packages.

fixes #108


