### PR TITLE
implement client lock idempotence

### DIFF
--- a/hazelcast/client.py
+++ b/hazelcast/client.py
@@ -13,6 +13,7 @@ from hazelcast.proxy import ProxyManager, MAP_SERVICE, QUEUE_SERVICE, LIST_SERVI
 from hazelcast.reactor import AsyncoreReactor
 from hazelcast.serialization import SerializationServiceV1
 from hazelcast.transaction import TWO_PHASE, TransactionManager
+from hazelcast.util import LockReferenceIdGenerator
 
 
 class HazelcastClient(object):
@@ -36,6 +37,7 @@ class HazelcastClient(object):
         self.load_balancer = RandomLoadBalancer(self.cluster)
         self.serialization_service = SerializationServiceV1(serialization_config=self.config.serialization_config)
         self.transaction_manager = TransactionManager(self)
+        self.lock_reference_id_generator = LockReferenceIdGenerator()
         self._start()
 
     def _start(self):

--- a/hazelcast/protocol/codec/lock_force_unlock_codec.py
+++ b/hazelcast/protocol/codec/lock_force_unlock_codec.py
@@ -6,22 +6,24 @@ from hazelcast.protocol.codec.lock_message_type import *
 
 REQUEST_TYPE = LOCK_FORCEUNLOCK
 RESPONSE_TYPE = 100
-RETRYABLE = False
+RETRYABLE = True
 
 
-def calculate_size(name):
+def calculate_size(name, reference_id):
     """ Calculates the request payload size"""
     data_size = 0
     data_size += calculate_size_str(name)
+    data_size += LONG_SIZE_IN_BYTES
     return data_size
 
 
-def encode_request(name):
+def encode_request(name, reference_id):
     """ Encode request into client_message"""
-    client_message = ClientMessage(payload_size=calculate_size(name))
+    client_message = ClientMessage(payload_size=calculate_size(name, reference_id))
     client_message.set_message_type(REQUEST_TYPE)
     client_message.set_retryable(RETRYABLE)
     client_message.append_str(name)
+    client_message.append_long(reference_id)
     client_message.update_frame_length()
     return client_message
 

--- a/hazelcast/protocol/codec/lock_lock_codec.py
+++ b/hazelcast/protocol/codec/lock_lock_codec.py
@@ -6,26 +6,28 @@ from hazelcast.protocol.codec.lock_message_type import *
 
 REQUEST_TYPE = LOCK_LOCK
 RESPONSE_TYPE = 100
-RETRYABLE = False
+RETRYABLE = True
 
 
-def calculate_size(name, lease_time, thread_id):
+def calculate_size(name, lease_time, thread_id, reference_id):
     """ Calculates the request payload size"""
     data_size = 0
     data_size += calculate_size_str(name)
     data_size += LONG_SIZE_IN_BYTES
     data_size += LONG_SIZE_IN_BYTES
+    data_size += LONG_SIZE_IN_BYTES
     return data_size
 
 
-def encode_request(name, lease_time, thread_id):
+def encode_request(name, lease_time, thread_id, reference_id):
     """ Encode request into client_message"""
-    client_message = ClientMessage(payload_size=calculate_size(name, lease_time, thread_id))
+    client_message = ClientMessage(payload_size=calculate_size(name, lease_time, thread_id, reference_id))
     client_message.set_message_type(REQUEST_TYPE)
     client_message.set_retryable(RETRYABLE)
     client_message.append_str(name)
     client_message.append_long(lease_time)
     client_message.append_long(thread_id)
+    client_message.append_long(reference_id)
     client_message.update_frame_length()
     return client_message
 

--- a/hazelcast/protocol/codec/lock_try_lock_codec.py
+++ b/hazelcast/protocol/codec/lock_try_lock_codec.py
@@ -6,28 +6,30 @@ from hazelcast.protocol.codec.lock_message_type import *
 
 REQUEST_TYPE = LOCK_TRYLOCK
 RESPONSE_TYPE = 101
-RETRYABLE = False
+RETRYABLE = True
 
 
-def calculate_size(name, thread_id, lease, timeout):
+def calculate_size(name, thread_id, lease, timeout, reference_id):
     """ Calculates the request payload size"""
     data_size = 0
     data_size += calculate_size_str(name)
     data_size += LONG_SIZE_IN_BYTES
     data_size += LONG_SIZE_IN_BYTES
     data_size += LONG_SIZE_IN_BYTES
+    data_size += LONG_SIZE_IN_BYTES
     return data_size
 
 
-def encode_request(name, thread_id, lease, timeout):
+def encode_request(name, thread_id, lease, timeout, reference_id):
     """ Encode request into client_message"""
-    client_message = ClientMessage(payload_size=calculate_size(name, thread_id, lease, timeout))
+    client_message = ClientMessage(payload_size=calculate_size(name, thread_id, lease, timeout, reference_id))
     client_message.set_message_type(REQUEST_TYPE)
     client_message.set_retryable(RETRYABLE)
     client_message.append_str(name)
     client_message.append_long(thread_id)
     client_message.append_long(lease)
     client_message.append_long(timeout)
+    client_message.append_long(reference_id)
     client_message.update_frame_length()
     return client_message
 

--- a/hazelcast/protocol/codec/lock_unlock_codec.py
+++ b/hazelcast/protocol/codec/lock_unlock_codec.py
@@ -6,24 +6,26 @@ from hazelcast.protocol.codec.lock_message_type import *
 
 REQUEST_TYPE = LOCK_UNLOCK
 RESPONSE_TYPE = 100
-RETRYABLE = False
+RETRYABLE = True
 
 
-def calculate_size(name, thread_id):
+def calculate_size(name, thread_id, reference_id):
     """ Calculates the request payload size"""
     data_size = 0
     data_size += calculate_size_str(name)
     data_size += LONG_SIZE_IN_BYTES
+    data_size += LONG_SIZE_IN_BYTES
     return data_size
 
 
-def encode_request(name, thread_id):
+def encode_request(name, thread_id, reference_id):
     """ Encode request into client_message"""
-    client_message = ClientMessage(payload_size=calculate_size(name, thread_id))
+    client_message = ClientMessage(payload_size=calculate_size(name, thread_id, reference_id))
     client_message.set_message_type(REQUEST_TYPE)
     client_message.set_retryable(RETRYABLE)
     client_message.append_str(name)
     client_message.append_long(thread_id)
+    client_message.append_long(reference_id)
     client_message.update_frame_length()
     return client_message
 

--- a/hazelcast/protocol/codec/map_force_unlock_codec.py
+++ b/hazelcast/protocol/codec/map_force_unlock_codec.py
@@ -6,24 +6,26 @@ from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_FORCEUNLOCK
 RESPONSE_TYPE = 100
-RETRYABLE = False
+RETRYABLE = True
 
 
-def calculate_size(name, key):
+def calculate_size(name, key, reference_id):
     """ Calculates the request payload size"""
     data_size = 0
     data_size += calculate_size_str(name)
     data_size += calculate_size_data(key)
+    data_size += LONG_SIZE_IN_BYTES
     return data_size
 
 
-def encode_request(name, key):
+def encode_request(name, key, reference_id):
     """ Encode request into client_message"""
-    client_message = ClientMessage(payload_size=calculate_size(name, key))
+    client_message = ClientMessage(payload_size=calculate_size(name, key, reference_id))
     client_message.set_message_type(REQUEST_TYPE)
     client_message.set_retryable(RETRYABLE)
     client_message.append_str(name)
     client_message.append_data(key)
+    client_message.append_long(reference_id)
     client_message.update_frame_length()
     return client_message
 

--- a/hazelcast/protocol/codec/map_lock_codec.py
+++ b/hazelcast/protocol/codec/map_lock_codec.py
@@ -6,28 +6,30 @@ from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_LOCK
 RESPONSE_TYPE = 100
-RETRYABLE = False
+RETRYABLE = True
 
 
-def calculate_size(name, key, thread_id, ttl):
+def calculate_size(name, key, thread_id, ttl, reference_id):
     """ Calculates the request payload size"""
     data_size = 0
     data_size += calculate_size_str(name)
     data_size += calculate_size_data(key)
     data_size += LONG_SIZE_IN_BYTES
     data_size += LONG_SIZE_IN_BYTES
+    data_size += LONG_SIZE_IN_BYTES
     return data_size
 
 
-def encode_request(name, key, thread_id, ttl):
+def encode_request(name, key, thread_id, ttl, reference_id):
     """ Encode request into client_message"""
-    client_message = ClientMessage(payload_size=calculate_size(name, key, thread_id, ttl))
+    client_message = ClientMessage(payload_size=calculate_size(name, key, thread_id, ttl, reference_id))
     client_message.set_message_type(REQUEST_TYPE)
     client_message.set_retryable(RETRYABLE)
     client_message.append_str(name)
     client_message.append_data(key)
     client_message.append_long(thread_id)
     client_message.append_long(ttl)
+    client_message.append_long(reference_id)
     client_message.update_frame_length()
     return client_message
 

--- a/hazelcast/protocol/codec/map_try_lock_codec.py
+++ b/hazelcast/protocol/codec/map_try_lock_codec.py
@@ -6,10 +6,10 @@ from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_TRYLOCK
 RESPONSE_TYPE = 101
-RETRYABLE = False
+RETRYABLE = True
 
 
-def calculate_size(name, key, thread_id, lease, timeout):
+def calculate_size(name, key, thread_id, lease, timeout, reference_id):
     """ Calculates the request payload size"""
     data_size = 0
     data_size += calculate_size_str(name)
@@ -17,12 +17,13 @@ def calculate_size(name, key, thread_id, lease, timeout):
     data_size += LONG_SIZE_IN_BYTES
     data_size += LONG_SIZE_IN_BYTES
     data_size += LONG_SIZE_IN_BYTES
+    data_size += LONG_SIZE_IN_BYTES
     return data_size
 
 
-def encode_request(name, key, thread_id, lease, timeout):
+def encode_request(name, key, thread_id, lease, timeout, reference_id):
     """ Encode request into client_message"""
-    client_message = ClientMessage(payload_size=calculate_size(name, key, thread_id, lease, timeout))
+    client_message = ClientMessage(payload_size=calculate_size(name, key, thread_id, lease, timeout, reference_id))
     client_message.set_message_type(REQUEST_TYPE)
     client_message.set_retryable(RETRYABLE)
     client_message.append_str(name)
@@ -30,6 +31,7 @@ def encode_request(name, key, thread_id, lease, timeout):
     client_message.append_long(thread_id)
     client_message.append_long(lease)
     client_message.append_long(timeout)
+    client_message.append_long(reference_id)
     client_message.update_frame_length()
     return client_message
 

--- a/hazelcast/protocol/codec/map_unlock_codec.py
+++ b/hazelcast/protocol/codec/map_unlock_codec.py
@@ -6,26 +6,28 @@ from hazelcast.protocol.codec.map_message_type import *
 
 REQUEST_TYPE = MAP_UNLOCK
 RESPONSE_TYPE = 100
-RETRYABLE = False
+RETRYABLE = True
 
 
-def calculate_size(name, key, thread_id):
+def calculate_size(name, key, thread_id, reference_id):
     """ Calculates the request payload size"""
     data_size = 0
     data_size += calculate_size_str(name)
     data_size += calculate_size_data(key)
     data_size += LONG_SIZE_IN_BYTES
+    data_size += LONG_SIZE_IN_BYTES
     return data_size
 
 
-def encode_request(name, key, thread_id):
+def encode_request(name, key, thread_id, reference_id):
     """ Encode request into client_message"""
-    client_message = ClientMessage(payload_size=calculate_size(name, key, thread_id))
+    client_message = ClientMessage(payload_size=calculate_size(name, key, thread_id, reference_id))
     client_message.set_message_type(REQUEST_TYPE)
     client_message.set_retryable(RETRYABLE)
     client_message.append_str(name)
     client_message.append_data(key)
     client_message.append_long(thread_id)
+    client_message.append_long(reference_id)
     client_message.update_frame_length()
     return client_message
 

--- a/hazelcast/protocol/codec/multi_map_force_unlock_codec.py
+++ b/hazelcast/protocol/codec/multi_map_force_unlock_codec.py
@@ -6,24 +6,26 @@ from hazelcast.protocol.codec.multi_map_message_type import *
 
 REQUEST_TYPE = MULTIMAP_FORCEUNLOCK
 RESPONSE_TYPE = 100
-RETRYABLE = False
+RETRYABLE = True
 
 
-def calculate_size(name, key):
+def calculate_size(name, key, reference_id):
     """ Calculates the request payload size"""
     data_size = 0
     data_size += calculate_size_str(name)
     data_size += calculate_size_data(key)
+    data_size += LONG_SIZE_IN_BYTES
     return data_size
 
 
-def encode_request(name, key):
+def encode_request(name, key, reference_id):
     """ Encode request into client_message"""
-    client_message = ClientMessage(payload_size=calculate_size(name, key))
+    client_message = ClientMessage(payload_size=calculate_size(name, key, reference_id))
     client_message.set_message_type(REQUEST_TYPE)
     client_message.set_retryable(RETRYABLE)
     client_message.append_str(name)
     client_message.append_data(key)
+    client_message.append_long(reference_id)
     client_message.update_frame_length()
     return client_message
 

--- a/hazelcast/protocol/codec/multi_map_lock_codec.py
+++ b/hazelcast/protocol/codec/multi_map_lock_codec.py
@@ -6,28 +6,30 @@ from hazelcast.protocol.codec.multi_map_message_type import *
 
 REQUEST_TYPE = MULTIMAP_LOCK
 RESPONSE_TYPE = 100
-RETRYABLE = False
+RETRYABLE = True
 
 
-def calculate_size(name, key, thread_id, ttl):
+def calculate_size(name, key, thread_id, ttl, reference_id):
     """ Calculates the request payload size"""
     data_size = 0
     data_size += calculate_size_str(name)
     data_size += calculate_size_data(key)
     data_size += LONG_SIZE_IN_BYTES
     data_size += LONG_SIZE_IN_BYTES
+    data_size += LONG_SIZE_IN_BYTES
     return data_size
 
 
-def encode_request(name, key, thread_id, ttl):
+def encode_request(name, key, thread_id, ttl, reference_id):
     """ Encode request into client_message"""
-    client_message = ClientMessage(payload_size=calculate_size(name, key, thread_id, ttl))
+    client_message = ClientMessage(payload_size=calculate_size(name, key, thread_id, ttl, reference_id))
     client_message.set_message_type(REQUEST_TYPE)
     client_message.set_retryable(RETRYABLE)
     client_message.append_str(name)
     client_message.append_data(key)
     client_message.append_long(thread_id)
     client_message.append_long(ttl)
+    client_message.append_long(reference_id)
     client_message.update_frame_length()
     return client_message
 

--- a/hazelcast/protocol/codec/multi_map_try_lock_codec.py
+++ b/hazelcast/protocol/codec/multi_map_try_lock_codec.py
@@ -6,10 +6,10 @@ from hazelcast.protocol.codec.multi_map_message_type import *
 
 REQUEST_TYPE = MULTIMAP_TRYLOCK
 RESPONSE_TYPE = 101
-RETRYABLE = False
+RETRYABLE = True
 
 
-def calculate_size(name, key, thread_id, lease, timeout):
+def calculate_size(name, key, thread_id, lease, timeout, reference_id):
     """ Calculates the request payload size"""
     data_size = 0
     data_size += calculate_size_str(name)
@@ -17,12 +17,13 @@ def calculate_size(name, key, thread_id, lease, timeout):
     data_size += LONG_SIZE_IN_BYTES
     data_size += LONG_SIZE_IN_BYTES
     data_size += LONG_SIZE_IN_BYTES
+    data_size += LONG_SIZE_IN_BYTES
     return data_size
 
 
-def encode_request(name, key, thread_id, lease, timeout):
+def encode_request(name, key, thread_id, lease, timeout, reference_id):
     """ Encode request into client_message"""
-    client_message = ClientMessage(payload_size=calculate_size(name, key, thread_id, lease, timeout))
+    client_message = ClientMessage(payload_size=calculate_size(name, key, thread_id, lease, timeout, reference_id))
     client_message.set_message_type(REQUEST_TYPE)
     client_message.set_retryable(RETRYABLE)
     client_message.append_str(name)
@@ -30,6 +31,7 @@ def encode_request(name, key, thread_id, lease, timeout):
     client_message.append_long(thread_id)
     client_message.append_long(lease)
     client_message.append_long(timeout)
+    client_message.append_long(reference_id)
     client_message.update_frame_length()
     return client_message
 

--- a/hazelcast/protocol/codec/multi_map_unlock_codec.py
+++ b/hazelcast/protocol/codec/multi_map_unlock_codec.py
@@ -6,26 +6,28 @@ from hazelcast.protocol.codec.multi_map_message_type import *
 
 REQUEST_TYPE = MULTIMAP_UNLOCK
 RESPONSE_TYPE = 100
-RETRYABLE = False
+RETRYABLE = True
 
 
-def calculate_size(name, key, thread_id):
+def calculate_size(name, key, thread_id, reference_id):
     """ Calculates the request payload size"""
     data_size = 0
     data_size += calculate_size_str(name)
     data_size += calculate_size_data(key)
     data_size += LONG_SIZE_IN_BYTES
+    data_size += LONG_SIZE_IN_BYTES
     return data_size
 
 
-def encode_request(name, key, thread_id):
+def encode_request(name, key, thread_id, reference_id):
     """ Encode request into client_message"""
-    client_message = ClientMessage(payload_size=calculate_size(name, key, thread_id))
+    client_message = ClientMessage(payload_size=calculate_size(name, key, thread_id, reference_id))
     client_message.set_message_type(REQUEST_TYPE)
     client_message.set_retryable(RETRYABLE)
     client_message.append_str(name)
     client_message.append_data(key)
     client_message.append_long(thread_id)
+    client_message.append_long(reference_id)
     client_message.update_frame_length()
     return client_message
 

--- a/hazelcast/proxy/map.py
+++ b/hazelcast/proxy/map.py
@@ -53,6 +53,10 @@ class Map(Proxy):
 
     This class does not allow ``None`` to be used as a key or value.
     """
+    def __init__(self, client, service_name, name):
+        super(Map, self).__init__(client, service_name, name)
+        self.reference_id_generator = self._client.lock_reference_id_generator
+
     def add_entry_listener(self, include_value=False, key=None, predicate=None, added_func=None, removed_func=None, updated_func=None,
                            evicted_func=None, evict_all_func=None, clear_all_func=None, merged_func=None, expired_func=None):
         """
@@ -318,7 +322,8 @@ class Map(Proxy):
         """
         check_not_none(key, "key can't be None")
         key_data = self._to_data(key)
-        return self._encode_invoke_on_key(map_force_unlock_codec, key_data, key=key_data)
+        return self._encode_invoke_on_key(map_force_unlock_codec, key_data, key=key_data,
+                                          reference_id=self.reference_id_generator.get_next())
 
     def get(self, key):
         """
@@ -473,7 +478,8 @@ class Map(Proxy):
         """
         check_not_none(key, "key can't be None")
         key_data = self._to_data(key)
-        return self._encode_invoke_on_key(map_lock_codec, key_data, key=key_data, thread_id=thread_id(), ttl=to_millis(ttl))
+        return self._encode_invoke_on_key(map_lock_codec, key_data, key=key_data, thread_id=thread_id(),
+                                          ttl=to_millis(ttl), reference_id=self.reference_id_generator.get_next())
 
     def put(self, key, value, ttl=-1):
         """
@@ -741,8 +747,9 @@ class Map(Proxy):
 
         key_data = self._to_data(key)
 
-        return self._encode_invoke_on_key(map_try_lock_codec, key_data, key=key_data, thread_id=thread_id(), lease=to_millis(ttl),
-                                          timeout=to_millis(timeout))
+        return self._encode_invoke_on_key(map_try_lock_codec, key_data, key=key_data, thread_id=thread_id(),
+                                          lease=to_millis(ttl), timeout=to_millis(timeout),
+                                          reference_id=self.reference_id_generator.get_next())
 
     def try_put(self, key, value, timeout=0):
         """
@@ -787,7 +794,8 @@ class Map(Proxy):
 
         key_data = self._to_data(key)
 
-        return self._encode_invoke_on_key(map_unlock_codec, key_data, key=key_data, thread_id=thread_id())
+        return self._encode_invoke_on_key(map_unlock_codec, key_data, key=key_data, thread_id=thread_id(),
+                                          reference_id=self.reference_id_generator.get_next())
 
     def values(self, predicate=None):
         """

--- a/hazelcast/proxy/multi_map.py
+++ b/hazelcast/proxy/multi_map.py
@@ -12,6 +12,10 @@ class MultiMap(Proxy):
     """
     A specialized map whose keys can be associated with multiple values.
     """
+    def __init__(self, client, service_name, name):
+        super(MultiMap, self).__init__(client, service_name, name)
+        self.reference_id_generator = self._client.lock_reference_id_generator
+
     def add_entry_listener(self, include_value=False, key=None, added_func=None, removed_func=None, clear_all_func=None):
         """
         Adds an entry listener for this multimap. The listener will be notified for all multimap add/remove/clear-all
@@ -152,7 +156,8 @@ class MultiMap(Proxy):
         """
         check_not_none(key, "key can't be None")
         key_data = self._to_data(key)
-        return self._encode_invoke_on_key(multi_map_force_unlock_codec, key_data, key=key_data)
+        return self._encode_invoke_on_key(multi_map_force_unlock_codec, key_data, key=key_data,
+                                          reference_id=self.reference_id_generator.get_next())
 
     def key_set(self):
         """
@@ -186,7 +191,8 @@ class MultiMap(Proxy):
         check_not_none(key, "key can't be None")
         key_data = self._to_data(key)
         return self._encode_invoke_on_key(multi_map_lock_codec, key_data, key=key_data,
-                                          thread_id=thread_id(), ttl=to_millis(lease_time))
+                                          thread_id=thread_id(), ttl=to_millis(lease_time),
+                                          reference_id=self.reference_id_generator.get_next())
 
     def remove(self, key, value):
         """
@@ -310,7 +316,8 @@ class MultiMap(Proxy):
         key_data = self._to_data(key)
         return self._encode_invoke_on_key(multi_map_try_lock_codec, key_data, key=key_data,
                                           thread_id=thread_id(), lease=to_millis(lease_time),
-                                          timeout=to_millis(timeout))
+                                          timeout=to_millis(timeout),
+                                          reference_id=self.reference_id_generator.get_next())
 
     def unlock(self, key):
         """
@@ -324,4 +331,4 @@ class MultiMap(Proxy):
         check_not_none(key, "key can't be None")
         key_data = self._to_data(key)
         return self._encode_invoke_on_key(multi_map_unlock_codec, key_data, key=key_data,
-                                          thread_id=thread_id())
+                                          thread_id=thread_id(), reference_id=self.reference_id_generator.get_next())

--- a/hazelcast/util.py
+++ b/hazelcast/util.py
@@ -131,6 +131,24 @@ class AtomicInteger(object):
         self.count = itertools.count(start=value)
 
 
+class LockReferenceIdGenerator(object):
+    """
+    This class generates unique (per client) incrementing reference id which is used during locking related requests.
+    The server side uses this id to match if any previous request with the same id was issued and shall not re-do the
+    lock related operation but it shall just return the previous result. Hence, this id identifies the request sent to
+    the server side for locking operations. Similarly, if the client re-sends the request to the server for some reason
+    it will use the same reference id to make sure that the operation is not executed more than once at the server side.
+    """
+    def __init__(self):
+        self.reference_id_counter = itertools.count(start=1)
+
+    def get_next(self):
+        """
+        :return: (int), A per client unique reference id.
+        """
+        return next(self.reference_id_counter)
+
+
 def enum(**enums):
     """
     Utility method for defining enums.


### PR DESCRIPTION
this pr implements client lock idempotence by 
* adding a lock reference id generator to client
* making some lock related codecs retryable (lock/unlock/force unlock/try lock)
* adding a reference id attributes for these lock related operations on lock, map and multimap proxies.