### PR TITLE
Issue #112: return non-None values

### DIFF
--- a/hazelcast/util.py
+++ b/hazelcast/util.py
@@ -193,7 +193,7 @@ class ImmutableLazyDataList(Sequence):
                 self._list_obj[index] = (self.to_object(key), self.to_object(value))
             else:
                 self._list_obj[index] = self.to_object(data)
-            return self._list_obj[index]
+        return self._list_obj[index]
 
     def __eq__(self, other):
         if not isinstance(other, Iterable):

--- a/tests/predicate_test.py
+++ b/tests/predicate_test.py
@@ -92,6 +92,13 @@ class PredicateTest(SingleMemberTestCase):
         for n in range(0, count):
             self.map.put(n, n)
 
+    def test_key_set(self):
+        self._fill_map()
+        key_set = self.map.key_set()
+        key_set_list = list(key_set)
+        key_set_list = list(key_set)
+        assert key_set_list[0]
+
     def test_sql(self):
         self._fill_map()
         predicate = sql("this == 'value-1'")


### PR DESCRIPTION
Now 3-read_from_a_map.py works:

```
>>> import hazelcast
>>> import logging
>>> logging.basicConfig()
>>> logging.getLogger().setLevel(logging.INFO)
>>> config = hazelcast.ClientConfig()
>>> config.network_config.addresses.append("10.88.0.25:5701")
>>> config.network_config.addresses.append("10.88.0.26:5701")
>>> config.network_config.addresses.append("10.88.0.27:5701")
>>> config.group_config.name= 'production'
>>> client = hazelcast.HazelcastClient(config)
INFO:ClusterService:Connecting to Address(host=10.88.0.27, port=5701)
INFO:ConnectionManager:Authenticated with <hazelcast.reactor.AsyncoreConnection connected 10.88.0.27:5701 at 0x7f7000992c18>
INFO:ClusterService:New member list:

Members [3] {
	Member [10.88.0.26]:5701 - 47f8c80b-4751-437b-8c08-7953f21615ee
	Member [10.88.0.25]:5701 - 9d9fc330-c158-4ee0-9001-38d7cec1dd84
	Member [10.88.0.27]:5701 - c5434f06-27ee-4b83-8916-3a6b0665a4d9
}

INFO:HazelcastClient:Client started.
>>> 
>>> greetings_map = client.get_map("greetings-map")
INFO:ConnectionManager:Authenticated with <hazelcast.reactor.AsyncoreConnection connected 10.88.0.25:5701 at 0x7f6fee2a3710>
>>> list( greetings_map.key_set().result() )
INFO:ConnectionManager:Authenticated with <hazelcast.reactor.AsyncoreConnection connected 10.88.0.26:5701 at 0x7f6fee2af518>
['French', 'Spanish', 'German', 'Italian', 'English']
```