### PR TITLE
fix improper logging configuration

### DIFF
--- a/hazelcast/discovery.py
+++ b/hazelcast/discovery.py
@@ -17,7 +17,6 @@ class HazelcastCloudAddressProvider(object):
     """
     Provides initial addresses for client to find and connect to a node.
     """
-    logging.basicConfig()
     logger = logging.getLogger("HazelcastCloudAddressProvider")
 
     def __init__(self, host, url, connection_timeout):
@@ -39,7 +38,6 @@ class HazelcastCloudAddressTranslator(object):
     """
     Resolves private IP addresses of Hazelcast.cloud service.
     """
-    logging.basicConfig()
     logger = logging.getLogger("HazelcastAddressTranslator")
 
     def __init__(self, host, url, connection_timeout):

--- a/hazelcast/reactor.py
+++ b/hazelcast/reactor.py
@@ -20,8 +20,6 @@ try:
 except ImportError:
     ssl = None
 
-logging.basicConfig()
-
 
 class AsyncoreReactor(object):
     _thread = None


### PR DESCRIPTION
using logging.basicConfig would override the user's logging configuration. Removed logging.basicConfig to let the users to configure logging as they wish