### PR TITLE
fix discovery test structure for nosetest

### DIFF
--- a/tests/discovery/hazelcast_cloud_discovery_test.py
+++ b/tests/discovery/hazelcast_cloud_discovery_test.py
@@ -122,8 +122,8 @@ class HazelcastCloudDiscoveryTest(TestCase):
 
         config.set_property(HazelcastCloudDiscovery.CLOUD_URL_BASE_PROPERTY.name, HOST + ":" + str(self.server.port))
         client = TestClient(config)
-        client._address_translator._cloud_discovery._ctx = self.ctx
-        client._address_providers[0]._cloud_discovery._ctx = self.ctx
+        client._address_translator.cloud_discovery._ctx = self.ctx
+        client._address_providers[0].cloud_discovery._ctx = self.ctx
 
         private_addresses = client._address_providers[0].load_addresses()
 


### PR DESCRIPTION
Nosetests was failing to detect the tests in the discovery folder due to missing init file. Added that file and corrected an error on one of the tests