### PR TITLE
Add an ability to categorize tests using attributes

### DIFF
--- a/tests/predicate_test.py
+++ b/tests/predicate_test.py
@@ -6,7 +6,7 @@ from hazelcast.serialization.predicate import is_equal_to, and_, is_between, is_
 from hazelcast.serialization.api import Portable
 from tests.base import SingleMemberTestCase
 from tests.serialization.portable_test import InnerPortable, FACTORY_ID
-from tests.util import random_string
+from tests.util import random_string, set_attr
 from hazelcast import six
 from hazelcast.six.moves import range
 
@@ -247,6 +247,7 @@ class PredicatePortableTest(SingleMemberTestCase):
             self.assertIn(k, map_keys)
 
 
+@set_attr(category=3.8)
 class NestedPredicatePortableTest(SingleMemberTestCase):
 
     class Body(Portable):

--- a/tests/util.py
+++ b/tests/util.py
@@ -71,3 +71,14 @@ def generate_key_owned_by_instance(client, instance):
         partition_id = client.partition_service.get_partition_id(key)
         if client.partition_service.get_partition_owner(partition_id) == instance:
             return key
+
+
+def set_attr(*args, **kwargs):
+    def wrap_ob(ob):
+        for name in args:
+            setattr(ob, name, True)
+        for name, value in kwargs.items():
+            setattr(ob, name, value)
+        return ob
+
+    return wrap_ob


### PR DESCRIPTION
With this change, test classes or individual tests can be categorized
using tests/util.py/set_attr decorator. Categories can be set with
additional information 
```python
@set_attr(category=3.10)
```
 or directly
```python
@set_attr(slow)
``` 
After categorizing tests, selected tests
can be run using nosetests. For example, tests without category or
test with the category value less than or equal to 3.8 can be selected
with the -A option of the nosetests  using Python-like syntax:
```bash
nosetests -A 'not category or category <= 3.8'
```
When no attribute option is provided to nosetests with -a or -A,
all tests will be selected automatically.