### PR TITLE
categorize mutual authetincation tests

### DIFF
--- a/tests/ssl/mutual_authentication_test.py
+++ b/tests/ssl/mutual_authentication_test.py
@@ -5,11 +5,12 @@ from tests.base import HazelcastTestCase
 from hazelcast.client import HazelcastClient
 from hazelcast.config import PROTOCOL
 from hazelcast.exception import HazelcastError
-from tests.util import is_oss, get_ssl_config, configure_logging, get_abs_path
+from tests.util import is_oss, get_ssl_config, configure_logging, get_abs_path, set_attr
 
 
+@set_attr(category=3.8)
 @skipIf(is_oss(), "SSL/TLS is only supported with enterprise server.")
-class SSLAuthenticationTest(HazelcastTestCase):
+class MutualAuthenticationTest(HazelcastTestCase):
     current_directory = os.path.dirname(__file__)
     rc = None
     mutual_auth = True


### PR DESCRIPTION
mutual authentication feature comes with Hazelcast 3.8.1. Categorized mutual authentication tests to 3.8.