### PR TITLE
revert SSL hostname check and trust default ca certificates

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -104,14 +104,12 @@ Hazelcast Cloud Configuration
 -----------------------------
 Hazelcast client can be configured to connect a cluster running on the Hazelcast.Cloud using
 :class:`~hazelcast.config.ClientCloudConfig`. Please note that, in order for
-:class:`~hazelcast.config.ClientCloudConfig` to work, SSL/TLS should be enabled
-using :class:`~hazelcast.config.SSLConfig` and a cafile should be set.
+:class:`~hazelcast.config.ClientCloudConfig` to work, SSL/TLS should be enabled.
 You should also specify the group name and password of your cluster using :class:`~hazelcast.config.GroupConfig`.
 
 .. code-block:: python
 
     config.network_config.ssl_config.enabled = True
-    config.network_config.ssl_config.cafile = "cert.pem"
     config.group_config.name = "name"
     config.group_config.password = "password"
     config.network_config.cloud_config.enabled = True

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -76,7 +76,8 @@ SSL enabled to use this feature.
 
 To use SSL to authenticate the Hazelcast members, SSL should be enabled on the client side. Client should also
 provide a CA file in the PEM format that includes the certificates offered by Hazelcast members during the handshake.
-You should provide the absolute path of your CA file to the cafile field.
+You should provide the absolute path of your CA file to the cafile field. When SSL is enabled and cafile is not set,
+a set of default CA certificates from default locations will be used.
 
 .. code-block:: python
 

--- a/examples/cloud-discovery/hazelcast_cloud_discovery_example.py
+++ b/examples/cloud-discovery/hazelcast_cloud_discovery_example.py
@@ -11,9 +11,8 @@ if __name__ == "__main__":
     config.group_config.name = "name"
     config.group_config.password = "password"
 
-    # Enable SSL for encryption. CA file should be set as the absolute path.
+    # Enable SSL for encryption. Default CA certificates will be used.
     config.network_config.ssl_config.enabled = True
-    config.network_config.ssl_config.cafile = "cert.pem"
 
     # Enable Hazelcast.Cloud configuration and set the token of your cluster.
     config.network_config.cloud_config.enabled = True

--- a/examples/ssl/ssl_example.py
+++ b/examples/ssl/ssl_example.py
@@ -20,10 +20,6 @@ if __name__ == "__main__":
     # Select the protocol used in SSL communication. This step is optional. Default is TLSv1_2
     ssl_config.protocol = PROTOCOL.TLSv1_3
 
-    # Hostname of the server can be checked against its certificate. This step is optional.
-    # By default, Python client will not check hostname.
-    ssl_config.check_hostname = True
-
     config.network_config.ssl_config = ssl_config
 
     config.network_config.addresses.append("foo.bar.com:8888")

--- a/examples/ssl/ssl_mutual_authentication_example.py
+++ b/examples/ssl/ssl_mutual_authentication_example.py
@@ -28,10 +28,6 @@ if __name__ == "__main__":
     # Select the protocol used in SSL communication. This step is optional. Default is TLSv1_2
     ssl_config.protocol = PROTOCOL.TLSv1_3
 
-    # Hostname of the server can be checked against its certificate. This step is optional.
-    # By default, Python client will not check hostname.
-    ssl_config.check_hostname = True
-
     config.network_config.ssl_config = ssl_config
 
     config.network_config.addresses.append("foo.bar.com:8888")

--- a/hazelcast/config.py
+++ b/hazelcast/config.py
@@ -482,7 +482,11 @@ class SSLConfig(object):
         """Enables/disables SSL."""
 
         self.cafile = None
-        """Absolute path of concatenated CA certificates used to validate server's certificates in PEM format."""
+        """
+        Absolute path of concatenated CA certificates used to validate server's certificates in PEM format.
+        When SSL is enabled and cafile is not set, a set of default CA certificates from default locations
+        will be used.
+        """
 
         self.certfile = None
         """Absolute path of the client certificate in PEM format."""
@@ -503,13 +507,7 @@ class SSLConfig(object):
         """
 
         self.protocol = PROTOCOL.TLS
-        """Protocol version used in SSL communication."""
-
-        self.check_hostname = False
-        """
-        If True, verifies that server's certificate matches the server's hostname. The rules applied are those 
-        for checking the identity of HTTPS servers as outlined in RFC 2818, RFC 5280 and RFC 6125.
-        """
+        """Protocol version used in SSL communication. Default value is TLSv1.2"""
 
         self.ciphers = None
         """

--- a/hazelcast/reactor.py
+++ b/hazelcast/reactor.py
@@ -165,6 +165,8 @@ class AsyncoreConnection(Connection, asyncore.dispatcher):
 
             if ssl_config.cafile:
                 ssl_context.load_verify_locations(ssl_config.cafile)
+            else:
+                ssl_context.load_default_certs()
 
             if ssl_config.certfile:
                 ssl_context.load_cert_chain(ssl_config.certfile, ssl_config.keyfile, ssl_config.password)
@@ -172,9 +174,7 @@ class AsyncoreConnection(Connection, asyncore.dispatcher):
             if ssl_config.ciphers:
                 ssl_context.set_ciphers(ssl_config.ciphers)
 
-            ssl_context.check_hostname = ssl_config.check_hostname
-
-            self.socket = ssl_context.wrap_socket(self.socket, server_hostname=self._address[0])
+            self.socket = ssl_context.wrap_socket(self.socket)
 
         # the socket should be non-blocking from now on
         self.socket.settimeout(0)

--- a/tests/ssl/ssl_test.py
+++ b/tests/ssl/ssl_test.py
@@ -44,13 +44,6 @@ class SSLTest(HazelcastTestCase):
         self.assertEqual(test_map.size().result(), 10)
         client.shutdown()
 
-    def test_ssl_enabled_with_check_hostname(self):
-        # Member has the certificate with common name of 'foo.bar.com'
-        with self.assertRaises(HazelcastError):
-            client = HazelcastClient(get_ssl_config(True,
-                                                    get_abs_path(self.current_directory, "server1-cert.pem"),
-                                                    check_hostname=True, protocol=PROTOCOL.TLSv1))
-
     def test_ssl_enabled_with_custom_ciphers(self):
         client = HazelcastClient(get_ssl_config(True, get_abs_path(self.current_directory, "server1-cert.pem"),
                                                 protocol=PROTOCOL.TLSv1,

--- a/tests/util.py
+++ b/tests/util.py
@@ -43,7 +43,6 @@ def get_ssl_config(enable_ssl=False,
                    keyfile=None,
                    password=None,
                    protocol=PROTOCOL.TLS,
-                   check_hostname=None,
                    ciphers=None,
                    attempt_limit=1):
     config = ClientConfig()
@@ -54,7 +53,6 @@ def get_ssl_config(enable_ssl=False,
     config.network_config.ssl_config.keyfile = keyfile
     config.network_config.ssl_config.password = password
     config.network_config.ssl_config.protocol = protocol
-    config.network_config.ssl_config.check_hostname = check_hostname
     config.network_config.ssl_config.ciphers = ciphers
 
     config.network_config.connection_attempt_limit = attempt_limit


### PR DESCRIPTION
SSL hostname check option is removed. When cafile is not set,
client will try to load default ca certificates from default
certificate locations.