### PR TITLE
Mark ssl tests as enterprise

### DIFF
--- a/tests/ssl/mutual_authentication_test.py
+++ b/tests/ssl/mutual_authentication_test.py
@@ -1,15 +1,13 @@
 import os
 
-from unittest import skipIf
 from tests.base import HazelcastTestCase
 from hazelcast.client import HazelcastClient
 from hazelcast.config import PROTOCOL
 from hazelcast.exception import HazelcastError
-from tests.util import is_oss, get_ssl_config, configure_logging, get_abs_path, set_attr
+from tests.util import get_ssl_config, configure_logging, get_abs_path, set_attr
 
 
-@set_attr(category=3.8)
-@skipIf(is_oss(), "SSL/TLS is only supported with enterprise server.")
+@set_attr(category=3.8, enterprise=True)
 class MutualAuthenticationTest(HazelcastTestCase):
     current_directory = os.path.dirname(__file__)
     rc = None

--- a/tests/ssl/ssl_test.py
+++ b/tests/ssl/ssl_test.py
@@ -1,14 +1,13 @@
 import os
 
-from unittest import skipIf
 from tests.base import HazelcastTestCase
 from hazelcast.client import HazelcastClient
 from hazelcast.exception import HazelcastError
 from hazelcast.config import PROTOCOL
-from tests.util import is_oss, get_ssl_config, configure_logging, fill_map, get_abs_path
+from tests.util import get_ssl_config, configure_logging, fill_map, get_abs_path, set_attr
 
 
-@skipIf(is_oss(), "SSL/TLS is only supported with enterprise server.")
+@set_attr(enterprise=True)
 class SSLTest(HazelcastTestCase):
     current_directory = os.path.dirname(__file__)
     rc = None

--- a/tests/util.py
+++ b/tests/util.py
@@ -24,12 +24,6 @@ def event_collector():
     return collector
 
 
-def is_oss():
-    return (os.getenv("SERVER_TYPE") == "oss") \
-           or (os.getenv("HZ_TYPE") == "oss") \
-           or ("HAZELCAST_ENTERPRISE_KEY" not in os.environ)
-
-
 def fill_map(map, size=10, key_prefix="key", value_prefix="val"):
     entries = dict()
     for i in range(size):


### PR DESCRIPTION
Earlier enterprise check was not enough to determine the hazelcast
member type within the nosetests. Added the enterprise attribute to
the ssl related tests.