### PR TITLE
change debug level to info in lifecycle service

### DIFF
--- a/hazelcast/lifecycle.py
+++ b/hazelcast/lifecycle.py
@@ -58,7 +58,7 @@ class LifecycleService(object):
             self.is_live = False
 
         self.state = new_state
-        self.logger.debug("New Lifecycle state is %s", new_state)
+        self.logger.info("New Lifecycle state is %s", new_state)
         for listener in list(self._listeners.values()):
             try:
                 listener(new_state)


### PR DESCRIPTION
Firing a lifecycle event should have `info` level instead of `debug`.