### PR TITLE
Fix the flake id generator test

### DIFF
--- a/tests/proxy/flake_id_generator_test.py
+++ b/tests/proxy/flake_id_generator_test.py
@@ -124,7 +124,10 @@ class FlakeIdGeneratorTest(SingleMemberTestCase):
         for i in range(1, SHORT_TERM_BATCH_SIZE):
             flake_id_generator.new_id()
 
-        # Batch should be exhausted now
+        # Batch is exhausted. We should wait for a little so that the member
+        # sends the new batch with a base greater than the last id
+        # generated + flake id step size.
+        time.sleep(1)
 
         second_id = flake_id_generator.new_id()
         self.assertGreater(second_id, first_id + FLAKE_ID_STEP * SHORT_TERM_BATCH_SIZE)


### PR DESCRIPTION
`test_ids_are_from_new_batch_after_batch_is_exhausted` was failing sometimes because when we request small sized batches from the member one after another, member could send the newly requested batch with the base of `last batch's base + flake id step * batch size`. So, the test fails to differentiate between ids that are from the same batch and ids that are from the different batches but with the batch bases described above. I added a small sleep to make sure that member side sends a batch with a base greater than the base described above 