### PR TITLE
use mutable bytearray instead of bytes as buffer

### DIFF
--- a/hazelcast/connection.py
+++ b/hazelcast/connection.py
@@ -271,7 +271,7 @@ class Connection(object):
         self.logger = logging.getLogger("Connection[%s](%s:%d)" % (self.id, address.host, address.port))
         self._connection_closed_callback = connection_closed_callback
         self._builder = ClientMessageBuilder(message_callback)
-        self._read_buffer = b""
+        self._read_buffer = bytearray()
         self.last_read_in_seconds = 0
         self.last_write_in_seconds = 0
         self.start_time_in_seconds = 0

--- a/hazelcast/reactor.py
+++ b/hazelcast/reactor.py
@@ -186,7 +186,7 @@ class AsyncoreConnection(Connection, asyncore.dispatcher):
         self.logger.debug("Connected to %s", self._address)
 
     def handle_read(self):
-        self._read_buffer += self.recv(BUFFER_SIZE)
+        self._read_buffer.extend(self.recv(BUFFER_SIZE))
         self.last_read_in_seconds = time.time()
         self.receive_message()
 


### PR DESCRIPTION
This is a partial fix for the issue described in #149 
Formerly, we were using an immutable bytes field as the buffer and each time reactor reads data from the socket, it were appending the received data to this buffer which was copying and re-creating the existing buffer data with the newly received data.  I changed that to the bytearray which is mutable in python so extra re-creation is eliminated . 


So overall, python client improved from ~50 seconds to ~35 seconds for the string test and from ~7 seconds to ~1 seconds for the bytes test in my computer

These were the results of the tests described in the #149 in my computer with the old code.

**Bytes test, java client**
```
Map Size = 10000
2019-02-19T14:36:48.760Z
Entries Iterated = 10000
2019-02-19T14:36:48.913Z
10849511800752
```

**Bytes test, python client**
```
--------------------------------------

USING SYNC...
map size: 10000
WITH ITERATOR...
2019-02-19 17:39:57.537118 start
2019-02-19 17:40:03.826406 stop
list length: 10000

WITHOUT ITERATOR...
2019-02-19 17:40:03.826461 start
2019-02-19 17:40:11.092503 stop
list length: 10000

--------------------------------------

USING ASYNC...
map size: 10000
WITH ITERATOR...
2019-02-19 17:40:11.094390 start
2019-02-19 17:40:17.379446 stop
list length: 10000

WITHOUT ITERATOR...
2019-02-19 17:40:17.379487 start
2019-02-19 17:40:23.662076 stop
list length: 10000
process done...
```

**String test, java client**
```
Map Size = 10000
2019-02-19T14:41:56.660Z
Entries Iterated = 10000
2019-02-19T14:41:56.853Z
3815515015000
```

**String test, python client**
```--------------------------------------

USING SYNC...
map size: 10000
WITH ITERATOR...
2019-02-19 17:42:46.135877 start
2019-02-19 17:43:38.686844 stop
list length: 10000

WITHOUT ITERATOR...
2019-02-19 17:43:38.686897 start
2019-02-19 17:44:31.023816 stop
list length: 10000

--------------------------------------

USING ASYNC...
map size: 10000
WITH ITERATOR...
2019-02-19 17:44:31.025240 start
2019-02-19 17:45:22.264135 stop
list length: 10000

WITHOUT ITERATOR...
2019-02-19 17:45:22.264172 start
2019-02-19 17:46:13.941635 stop
list length: 10000
process done...
```

And here are the results for python client with the new code

**String test, python client**
```--------------------------------------

USING SYNC...
map size: 10000
WITH ITERATOR...
2019-02-19 17:50:45.371581 start
2019-02-19 17:51:19.353318 stop
list length: 10000

WITHOUT ITERATOR...
2019-02-19 17:51:19.353372 start
2019-02-19 17:51:53.071307 stop
list length: 10000

--------------------------------------

USING ASYNC...
map size: 10000
WITH ITERATOR...
2019-02-19 17:51:53.073200 start
2019-02-19 17:52:26.789717 stop
list length: 10000

WITHOUT ITERATOR...
2019-02-19 17:52:26.789801 start
2019-02-19 17:53:00.492137 stop
list length: 10000
process done...
```

**Bytes test, python client**
```
--------------------------------------

USING SYNC...
map size: 10000
WITH ITERATOR...
2019-02-19 17:53:52.663747 start
2019-02-19 17:53:53.528287 stop
list length: 10000

WITHOUT ITERATOR...
2019-02-19 17:53:53.528344 start
2019-02-19 17:53:54.447894 stop
list length: 10000

--------------------------------------

USING ASYNC...
map size: 10000
WITH ITERATOR...
2019-02-19 17:53:54.449627 start
2019-02-19 17:53:55.401066 stop
list length: 10000

WITHOUT ITERATOR...
2019-02-19 17:53:55.401108 start
2019-02-19 17:53:56.491391 stop
list length: 10000
process done...
```