### PR TITLE
make the test categories integer instead of float

### DIFF
--- a/tests/predicate_test.py
+++ b/tests/predicate_test.py
@@ -247,7 +247,7 @@ class PredicatePortableTest(SingleMemberTestCase):
             self.assertIn(k, map_keys)
 
 
-@set_attr(category=3.8)
+@set_attr(category=3.08)
 class NestedPredicatePortableTest(SingleMemberTestCase):
 
     class Body(Portable):

--- a/tests/ssl/mutual_authentication_test.py
+++ b/tests/ssl/mutual_authentication_test.py
@@ -7,7 +7,7 @@ from hazelcast.exception import HazelcastError
 from tests.util import get_ssl_config, configure_logging, get_abs_path, set_attr
 
 
-@set_attr(category=3.8, enterprise=True)
+@set_attr(category=3.08, enterprise=True)
 class MutualAuthenticationTest(HazelcastTestCase):
     current_directory = os.path.dirname(__file__)
     rc = None

--- a/tests/statistics_test.py
+++ b/tests/statistics_test.py
@@ -10,7 +10,7 @@ from tests.hzrc.ttypes import Lang
 from tests.util import random_string, set_attr
 
 
-@set_attr(category=3.9)
+@set_attr(category=3.09)
 class StatisticsTest(HazelcastTestCase):
 
     DEFAULT_STATS_PERIOD = 3


### PR DESCRIPTION
test categories are converted to zero padded values

This is due to the fact that 3.10 is smaller than 3.6 as a float but in the IMDG versioning it is the newer one. This was causing problems in the client backward compatibility tests