### PR TITLE
re-enable ssl test with the ca signed certificate

### DIFF
--- a/tests/ssl/ssl_test.py
+++ b/tests/ssl/ssl_test.py
@@ -41,8 +41,6 @@ class SSLTest(HazelcastTestCase):
         client.shutdown()
 
     def test_ssl_enabled_trust_default_certificates(self):
-        self.skipTest("Ignore Let's Encrypt test until a solution is found for the expired certificate")
-
         # Member started with Let's Encrypt certificate
         cluster = self.create_cluster(self.rc, self.configure_cluster(self.default_ca_xml))
         cluster.start_member()


### PR DESCRIPTION
Hazelcast 3.12.1-SNAPSHOT is updated with a valid CA signed certificate (valid until 2021). This pr re-enables the ssl test where we check our client to trust default truststore.