### PR TITLE
remove git_info.json after test

### DIFF
--- a/tests/version_test.py
+++ b/tests/version_test.py
@@ -18,6 +18,11 @@ class VersionTest(TestCase):
         self.assertEqual(commit_id, info.get("commit_id"))
         self.assertEqual(commit_date, info.get("commit_date"))
 
+        try:
+            os.remove(os.path.join(here, "git_info.json"))
+        except:
+            pass
+
     def test_git_info_provider(self):
         info_provider = GitInfoProvider()
 


### PR DESCRIPTION
nosetests fails with the following exception when you run it twice within the same folder

```
Unable to load tests from file /home/jenkins/jenkins_slave/workspace/python-backward-compatibility/python/3.12/tests/git_info.json
```

basically, it tries to load tests from .json file. This fix removes the git_info.json which we created during the test so that we can run nosetests in the same directory more than once