### PR TITLE
Change default buffer sizes for connection similar to Java clients

### DIFF
--- a/hazelcast/connection.py
+++ b/hazelcast/connection.py
@@ -13,7 +13,7 @@ from hazelcast.util import AtomicInteger, parse_addresses, calculate_version
 from hazelcast.version import CLIENT_TYPE, CLIENT_VERSION, SERIALIZATION_VERSION
 from hazelcast import six
 
-BUFFER_SIZE = 8192
+BUFFER_SIZE = 128000
 PROTOCOL_VERSION = 1
 
 


### PR DESCRIPTION
The default buffers are too small, causing any bigger payload size to queue up a lot on the application side and rely on polling to make it to the socket. As a result any latency benchmark with fat payloads is extremely slow.

Nagle was already off, similarly to Java, and left unchanged.