### PR TITLE
let the python handle the loop while reading a byte array

### DIFF
--- a/hazelcast/serialization/input.py
+++ b/hazelcast/serialization/input.py
@@ -111,7 +111,7 @@ class _ObjectDataInput(ObjectDataInput):
         result = bytearray(length)
         if length > 0:
             self.read_into(result, 0, length)
-        return [x for x in result]
+        return list(result)
 
     def read_boolean_array(self):
         return self._read_array_fnc(self.read_boolean)


### PR DESCRIPTION
we were looping over the result to convert the byte array into a list. This was causing a huge latency problem when the result we iterate over is huge. With this change, the conversion is delegated to python itself.

By the way, `read_byte_array` method returns list of byte sized integers, not a byte array. I think we can just return the `result` without converting it to a list since `bytearray` is special type in python. If we do that, we can also change the `read_utf` method to something like this as we did in the Node.js client
```python
def read_utf(self):
  result = self.read_byte_array()
  if result is None:
    return None
  return result.decode("utf-8")
```
This `read_utf` change solves the issue described in #149.  The duration of the string read test described in the issue goes from 35 seconds to 100-200 milliseconds in my laptop.