### PR TITLE
Minor networking / serialization changes for better latency on single calls

### DIFF
--- a/hazelcast/client.py
+++ b/hazelcast/client.py
@@ -51,7 +51,7 @@ class HazelcastClient(object):
         self.partition_service = PartitionService(self)
         self.proxy = ProxyManager(self)
         self.load_balancer = RandomLoadBalancer(self.cluster)
-        self.serialization_service = SerializationServiceV1(serialization_config=self.config.serialization_config)
+        self.serialization_service = SerializationServiceV1(serialization_config=self.config.serialization_config, properties=self.properties)
         self.transaction_manager = TransactionManager(self)
         self.lock_reference_id_generator = AtomicInteger(1)
         self.near_cache_manager = NearCacheManager(self)

--- a/hazelcast/config.py
+++ b/hazelcast/config.py
@@ -706,6 +706,12 @@ class ClientProperties(object):
     Period in seconds to collect statistics.
     """
 
+    SERIALIZATION_INPUT_RETURNS_BYTEARRAY = ClientProperty("hazelcast.serialization.input.returns.bytearray", False)
+    """
+    Input#read_byte_array returns a List if property is False, otherwise it will return a byte-array.
+    Changing this to True, gives a considerable performance benefit.
+    """
+
     def __init__(self, properties):
         self._properties = properties
 

--- a/hazelcast/serialization/service.py
+++ b/hazelcast/serialization/service.py
@@ -5,6 +5,7 @@ from hazelcast.serialization.portable.context import PortableContext
 from hazelcast.serialization.portable.serializer import PortableSerializer
 from hazelcast.serialization.serializer import *
 from hazelcast import six
+from hazelcast.config import ClientProperties
 
 DEFAULT_OUT_BUFFER_SIZE = 4 * 1024
 
@@ -16,7 +17,8 @@ def default_partition_strategy(key):
 
 
 class SerializationServiceV1(BaseSerializationService):
-    def __init__(self, serialization_config, version=1, global_partition_strategy=default_partition_strategy,
+
+    def __init__(self, serialization_config, properties=ClientProperties({}), version=1, global_partition_strategy=default_partition_strategy,
                  output_buffer_size=DEFAULT_OUT_BUFFER_SIZE):
         super(SerializationServiceV1, self).__init__(version, global_partition_strategy, output_buffer_size,
                                                      serialization_config.is_big_endian,
@@ -39,6 +41,8 @@ class SerializationServiceV1(BaseSerializationService):
         global_serializer = serialization_config.global_serializer
         if global_serializer:
             self._registry._global_serializer = global_serializer()
+
+        self.properties = properties
 
     def _register_constant_serializers(self):
         self._registry.register_constant_serializer(self._registry._null_serializer, type(None))

--- a/tests/serialization/identified_test.py
+++ b/tests/serialization/identified_test.py
@@ -3,6 +3,7 @@ import unittest
 import hazelcast
 from hazelcast.serialization import SerializationServiceV1
 from hazelcast.serialization.api import IdentifiedDataSerializable
+from hazelcast.config import ClientProperties
 
 FACTORY_ID = 1
 
@@ -108,6 +109,11 @@ def create_identified():
                                      ['a', 'b', 'c'], [1, 2, 3], [4, 2, 3], [11, 2, 3], [1.0, 2.0, 3.0], [11.0, 22.0, 33.0],
                                      "the string text", ["item1", "item2", "item3"])
 
+def create_identified_with_bytearray():
+    return SerializationV1Identified(99, True, 'c', 11, 1234134, 1341431221, 1.0, 2.0, bytes([1, 2, 3]), [True, False, True],
+                                     ['a', 'b', 'c'], [1, 2, 3], [4, 2, 3], [11, 2, 3], [1.0, 2.0, 3.0], [11.0, 22.0, 33.0],
+                                     "the string text", ["item1", "item2", "item3"])
+
 
 the_factory = {SerializationV1Identified.CLASS_ID: SerializationV1Identified}
 
@@ -123,3 +129,19 @@ class IdentifiedSerializationTestCase(unittest.TestCase):
 
         obj2 = service.to_object(data)
         self.assertTrue(obj == obj2)
+
+    def test_encode_decode_respect_bytearray_fields(self):
+        config = hazelcast.ClientConfig()
+        config.set_property("hazelcast.serialization.input.returns.bytearray", True)
+        config.serialization_config.data_serializable_factories[FACTORY_ID] = the_factory
+        service = SerializationServiceV1(config.serialization_config, properties=ClientProperties(config.get_properties()))
+        obj = create_identified_with_bytearray()
+        data = service.to_data(obj)
+
+        obj2 = service.to_object(data)
+        self.assertTrue(obj == obj2)
+
+        service = SerializationServiceV1(config.serialization_config)
+
+        obj2 = service.to_object(data)
+        self.assertFalse(obj == obj2)

--- a/tests/serialization/portable_test.py
+++ b/tests/serialization/portable_test.py
@@ -7,6 +7,7 @@ from hazelcast.serialization.api import Portable
 from hazelcast.serialization.portable.classdef import ClassDefinitionBuilder
 from tests.serialization.identified_test import create_identified, SerializationV1Identified
 from hazelcast import six
+from hazelcast.config import ClientProperties
 
 if not six.PY2:
     long = int


### PR DESCRIPTION
- Replaced BUFFER_SIZE import with a local variable which respects the configuration (if exists)
- Removed the timeout of the asyncore loop to allow for the thread to finish faster, allowing other threads to make progress sooner
- Replaced the double list iteration on the Input#read_byte_array with a bytearray, similar to what was done here https://github.com/hazelcast/hazelcast-python-client/pull/174 but this version doesn't wrap the result, rather leaves it as pure `bytearray` which is **slightly concerning because it changes the type of the function**, but it gives a good bit of extra boost.