### PR TITLE
Portable versioning documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -767,7 +767,7 @@ As an alternative to the existing serialization methods, Hazelcast offers portab
 
 In order to support these features, a serialized `Portable` object contains meta information like the version and concrete location of the each field in the binary data. This way Hazelcast is able to navigate in the binary data and deserialize only the required field without actually deserializing the whole object which improves the query performance.
 
-With multiversion support, you can have two members that each have different versions of the same object, and Hazelcast will store both meta information and use the correct one to serialize and deserialize portable objects depending on the member. This is very helpful when you are doing a rolling upgrade without shutting down the cluster.
+With multiversion support, you can have two members each having different versions of the same object; Hazelcast stores both meta information and use the correct one to serialize and deserialize portable objects depending on the member. This is very helpful when you are doing a rolling upgrade without shutting down the cluster.
 
 Also note that portable serialization is totally language independent and is used as the binary protocol between Hazelcast server and clients.
 
@@ -823,7 +823,7 @@ More than one version of the same class may need to be serialized and deserializ
 
 Portable serialization supports versioning. It is a global versioning, meaning that all portable classes that are serialized through a member get the globally configured portable version.
 
-You can declare Version in the configuration file `hazelcast.xml` using the `portable-version` element, as shown below.
+You can declare the version in the `hazelcast.xml` configuration file using the `portable-version` element, as shown below.
 
 ```xml
 <hazelcast>
@@ -836,10 +836,9 @@ You can declare Version in the configuration file `hazelcast.xml` using the `por
 ```
 
 If you update the class by changing the type of one of the fields or by adding a new field, it is a good idea to upgrade the version of the class, rather than sticking to the global version specified in the `hazelcast.xml` file.
+In the Python client, you can achieve this by simply adding the `get_class_version()` method to your class’s implementation of `Portable`, and setting the `CLASS_VERSION` to be different than the default global version.
 
-In Python Client, you can achieve this by simply adding the `get_class_version()` method to your class’s implementation of `Portable`, and setting the `CLASS_VERSION` to be different than the default global version.
-
-> Note: If your class that implements `Portable` doesn’t implement this method, its version is set by default to be the global version.
+> Note: If you do not use the `get_class_version()` method in your `Portable` implementation, it will have the global version, by default.
 
 Here is an example implementation of creating a version 2 for the above Foo class:
 
@@ -875,8 +874,9 @@ class Foo(Portable):
 ```
 
 You should consider the following when you perform versioning:
+
 * It is important to change the version whenever an update is performed in the serialized fields of a class, for example by incrementing the version.
-* If a client performs a Portable deserialization on a field and then that Portable is updated by removing that field on the cluster side, this may lead to a problem.
+* If a client performs a Portable deserialization on a field and then that Portable is updated by removing that field on the cluster side, this may lead to problems such as an AttributeError being raised when an older version of the client tries to access the removed field. 
 * Portable serialization does not use reflection and hence, fields in the class and in the serialized content are not automatically mapped. Field renaming is a simpler process. Also, since the class ID is stored, renaming the Portable does not lead to problems.
 * Types of fields need to be updated carefully. Hazelcast performs basic type upgradings, such as `int` to `float`.
 

--- a/README.md
+++ b/README.md
@@ -767,7 +767,7 @@ As an alternative to the existing serialization methods, Hazelcast offers portab
 
 In order to support these features, a serialized `Portable` object contains meta information like the version and concrete location of the each field in the binary data. This way Hazelcast is able to navigate in the binary data and deserialize only the required field without actually deserializing the whole object which improves the query performance.
 
-With multiversion support, you can have two members each having different versions of the same object; Hazelcast stores both meta information and use the correct one to serialize and deserialize portable objects depending on the member. This is very helpful when you are doing a rolling upgrade without shutting down the cluster.
+With multiversion support, you can have two members each having different versions of the same object; Hazelcast stores both meta information and uses the correct one to serialize and deserialize portable objects depending on the member. This is very helpful when you are doing a rolling upgrade without shutting down the cluster.
 
 Also note that portable serialization is totally language independent and is used as the binary protocol between Hazelcast server and clients.
 
@@ -797,7 +797,7 @@ class Foo(Portable):
         self.foo = reader.read_utf("foo")
 ```
 
-> Note: For Portable to work in Python client, the class that inherits it should have default valued parameters in its `__init__` method so that an instance of that class can be created without passing any arguments to it.  
+> **NOTE: For Portable to work in Python client, the class that inherits it should have default valued parameters in its `__init__` method so that an instance of that class can be created without passing any arguments to it.**
 
 Similar to `IdentifiedDataSerializable`, a `Portable` class must provide the `get_class_id()` and `get_factory_id()` methods. The factory dictionary will be used to create the `Portable` object given the class ID.
 
@@ -838,7 +838,7 @@ You can declare the version in the `hazelcast.xml` configuration file using the 
 If you update the class by changing the type of one of the fields or by adding a new field, it is a good idea to upgrade the version of the class, rather than sticking to the global version specified in the `hazelcast.xml` file.
 In the Python client, you can achieve this by simply adding the `get_class_version()` method to your class’s implementation of `Portable`, and setting the `CLASS_VERSION` to be different than the default global version.
 
-> Note: If you do not use the `get_class_version()` method in your `Portable` implementation, it will have the global version, by default.
+> **NOTE: If you do not use the `get_class_version()` method in your `Portable` implementation, it will have the global version, by default.**
 
 Here is an example implementation of creating a version 2 for the above Foo class:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
     * [1.4.1. Configuring Hazelcast IMDG](#141-configuring-hazelcast-imdg)
     * [1.4.2. Configuring Hazelcast Python Client](#142-configuring-hazelcast-python-client)
       * [1.4.2.1. Group Settings](#1421-group-settings)
-      * [1.4.2.2. Network Settings](#1421-network-settings)
+      * [1.4.2.2. Network Settings](#1422-network-settings)
     * [1.4.3. Client System Properties](#143-client-system-properties)
   * [1.5. Basic Usage](#15-basic-usage)
   * [1.6. Code Samples](#16-code-samples)
@@ -23,6 +23,7 @@
 * [4. Serialization](#4-serialization)
   * [4.1. IdentifiedDataSerializable Serialization](#41-identifieddataserializable-serialization)
   * [4.2. Portable Serialization](#42-portable-serialization)
+    * [4.2.1. Versioning for Portable Serialization](#421-versioning-for-portable-serialization)
   * [4.3. Custom Serialization](#43-custom-serialization)
   * [4.4. JSON Serialization](#44-json-serialization)
   * [4.5. Global Serialization](#45-global-serialization)
@@ -770,8 +771,6 @@ With multiversion support, you can have two members that each have different ver
 
 Also note that portable serialization is totally language independent and is used as the binary protocol between Hazelcast server and clients.
 
-### 4.2.1 - Portable Serialization Example Code
-
 A sample portable implementation of a `Foo` class looks like the following:
 
 ```python
@@ -802,8 +801,6 @@ class Foo(Portable):
 
 Similar to `IdentifiedDataSerializable`, a `Portable` class must provide the `get_class_id()` and `get_factory_id()` methods. The factory dictionary will be used to create the `Portable` object given the class ID.
 
-### 4.2.2 - Registering the Portable Factory
-
 A sample `Portable factory` could be created as follows:
 
 ```python
@@ -820,7 +817,7 @@ config.serialization_config.data_serializable_factories[1] = factory
 
 Note that the ID that is passed to the `SerializationConfig` is same as the factory ID that `Foo` class returns.
 
-### 4.2.3 - Versioning for Portable Serialization
+### 4.2.1. Versioning for Portable Serialization
 
 More than one version of the same class may need to be serialized and deserialized. For example, a client may have an older version of a class and the member to which it is connected may have a newer version of the same class.
 
@@ -885,13 +882,13 @@ You should consider the following when you perform versioning:
 
 #### Example Portable Versioning Scenarios:
 
-Assume that a new member joins to the cluster with a class that has been modified and class's version has been upgraded due to this modification.
+Assume that a new client joins to the cluster with a class that has been modified and class's version has been upgraded due to this modification.
 
-If you modified the class by adding a new field, the new member’s put operations include that new field. If this new member tries to get an object that was put from the older members, it gets null for the newly added field.
+If you modified the class by adding a new field, the new client’s put operations include that new field. If this new client tries to get an object that was put from the older clients, it gets null for the newly added field.
 
-If you modified the class by removing a field, the old members get null for the objects that are put by the new member.
+If you modified the class by removing a field, the old clients get null for the objects that are put by the new client.
 
-If you modified the class by changing the type of a field to an incompatible type (such as from `int` to `String`), a `TypeError` (wrapped as `HazelcastSerializationError`) is generated as the member tries accessing an object with the older version of the class. The same applies if a member with the old version tries to access a new version object.
+If you modified the class by changing the type of a field to an incompatible type (such as from `int` to `String`), a `TypeError` (wrapped as `HazelcastSerializationError`) is generated as the client tries accessing an object with the older version of the class. The same applies if a client with the old version tries to access a new version object.
 
 If you did not modify a class at all, it works as usual.
 


### PR DESCRIPTION
This PR adds documentation for multiversion support of Portable Serialization in README inspired by the Reference Manual (with necessary changes for Python). It also improves the format of the headings and subheadings under Portable Serialization. It includes a versioning example for the Foo class as well.