### PR TITLE
fix client properties to return false when property with a default va…

### DIFF
--- a/hazelcast/config.py
+++ b/hazelcast/config.py
@@ -723,7 +723,15 @@ class ClientProperties(object):
         :param property: (:class:`~hazelcast.config.ClientProperty`), Property to get value from
         :return: Value of the given property
         """
-        return self._properties.get(property.name) or os.getenv(property.name) or property.default_value
+        value = self._properties.get(property.name, None)
+        if value is not None:
+            return value
+
+        value = os.getenv(property.name, None)
+        if value is not None:
+            return value
+
+        return property.default_value
 
     def get_bool(self, property):
         """

--- a/tests/property_tests.py
+++ b/tests/property_tests.py
@@ -94,3 +94,12 @@ class PropertyTest(TestCase):
         props = ClientProperties(config.get_properties())
         with self.assertRaises(ValueError):
             props.get_seconds_positive_or_default(prop)
+
+    def test_client_properties_set_false_when_default_is_true(self):
+        config = ClientConfig()
+        prop = ClientProperty("test", True)
+        config.set_property(prop.name, False)
+
+        props = ClientProperties(config.get_properties())
+
+        self.assertFalse(props.get(prop))


### PR DESCRIPTION
fix client properties to return false when property with a default value of true set to false

Formerly, it was returning true due to or ing.