### PR TITLE
add hash method to connection class

### DIFF
--- a/hazelcast/connection.py
+++ b/hazelcast/connection.py
@@ -333,6 +333,9 @@ class Connection(object):
     def __repr__(self):
         return "Connection(address=%s, id=%s)" % (self._address, self.id)
 
+    def  __hash__(self):
+        return self.id
+
 
 class DefaultAddressProvider(object):
     """


### PR DESCRIPTION
`test_smart_listener_remove_member` failed again in the backward compatibility tests. This time, the events does not received in some tests. After adding extra logging and testing again, (http://jenkins.hazelcast.com/job/python-backward-compatibility-metin/3/testReport/junit/tests.listener_test/ListenerTest/test_smart_listener_remove_member/) I saw the following logs.

```
Feb 11, 2020 02:39:59 PM HazelcastClient
INFO: [3.12.1] [dev] [hz.client_20] A non-empty group password is configured for the Hazelcast client. Starting with Hazelcast IMDG version 3.11, clients with the same group name, but with different group passwords (that do not use authentication) will be accepted to a cluster. The group password configuration will be removed completely in a future release.
Feb 11, 2020 02:39:59 PM HazelcastClient.LifecycleService
INFO: [3.12.1] [dev] [hz.client_20] (20200211 - dbdb7c7) HazelcastClient is STARTING
Feb 11, 2020 02:39:59 PM HazelcastClient.AsyncoreReactor
DEBUG: [3.12.1] [dev] [hz.client_20] Starting Reactor Thread
Feb 11, 2020 02:39:59 PM HazelcastClient.ClusterService
INFO: [3.12.1] [dev] [hz.client_20] Connecting to Address(host=127.0.0.1, port=5701)
Feb 11, 2020 02:39:59 PM HazelcastClient.Connection[27](127.0.0.1:5701)
DEBUG: [3.12.1] [dev] [hz.client_20] Connected to ('127.0.0.1', 5701)
Feb 11, 2020 02:39:59 PM HazelcastClient.InvocationService
DEBUG: [3.12.1] [dev] [hz.client_20] Sending ClientMessage:{length=62, correlationId=1, messageType=2, partitionId=-1, isComplete=False, isRetryable=True, isEvent=False, writeOffset=22} to Connection(address=('127.0.0.1', 5701), id=27)
Feb 11, 2020 02:39:59 PM HazelcastClient.AsyncoreReactor
DEBUG: [3.12.1] [dev] [hz.client_20] Cancel timer <hazelcast.reactor.Timer object at 0x7fc56a120e90>
Feb 11, 2020 02:39:59 PM HazelcastClient.ConnectionManager
INFO: [3.12.1] [dev] [hz.client_20] Authenticated with Connection(address=('127.0.0.1', 5701), id=27)
Feb 11, 2020 02:39:59 PM HazelcastClient.ListenerService
DEBUG: [3.12.1] Added event handler 2 : <function handler at 0x7fc56b39c668>
Feb 11, 2020 02:39:59 PM HazelcastClient.InvocationService
DEBUG: [3.12.1] [dev] [hz.client_20] Sending ClientMessage:{length=23, correlationId=2, messageType=4, partitionId=-1, isComplete=False, isRetryable=False, isEvent=False, writeOffset=22} to Connection(address=('127.0.0.1', 5701), id=27)
Feb 11, 2020 02:39:59 PM HazelcastClient.ClusterService
DEBUG: [3.12.1] [dev] [hz.client_20] Got initial member list: [Member(host=localhost, port=5701, uuid=b4977afb-e30d-455b-accd-a6643f2f0cdb, liteMember=False, attributes={}), Member(host=localhost, port=5702, uuid=d779e36a-7b8e-49a3-a8a2-38e711c4bd4c, liteMember=False, attributes={}), Member(host=localhost, port=5703, uuid=c3d8c16c-7f0d-418e-b83b-0bc4a90b7221, liteMember=False, attributes={})]
Feb 11, 2020 02:39:59 PM HazelcastClient.ClusterService
INFO: [3.12.1] [dev] [hz.client_20] New member list:

Members [3] {
	Member [localhost]:5703 - c3d8c16c-7f0d-418e-b83b-0bc4a90b7221
	Member [localhost]:5701 - b4977afb-e30d-455b-accd-a6643f2f0cdb
	Member [localhost]:5702 - d779e36a-7b8e-49a3-a8a2-38e711c4bd4c
}

Feb 11, 2020 02:39:59 PM HazelcastClient.AsyncoreReactor
DEBUG: [3.12.1] [dev] [hz.client_20] Cancel timer <hazelcast.reactor.Timer object at 0x7fc5695c32d0>
Feb 11, 2020 02:39:59 PM HazelcastClient.PartitionService
DEBUG: [3.12.1] [dev] [hz.client_20] Start updating partitions
Feb 11, 2020 02:39:59 PM HazelcastClient.ClusterService
DEBUG: [3.12.1] [dev] [hz.client_20] Registered membership listener with ID 1b94c91d-b58a-46d3-8938-308bff09b379
Feb 11, 2020 02:39:59 PM HazelcastClient.LifecycleService
INFO: [3.12.1] [dev] [hz.client_20] (20200211 - dbdb7c7) HazelcastClient is CONNECTED
Feb 11, 2020 02:39:59 PM HazelcastClient.InvocationService
DEBUG: [3.12.1] [dev] [hz.client_20] Sending ClientMessage:{length=22, correlationId=3, messageType=8, partitionId=-1, isComplete=False, isRetryable=False, isEvent=False, writeOffset=22} to Connection(address=('127.0.0.1', 5701), id=27)
Feb 11, 2020 02:39:59 PM HazelcastClient.PartitionService
DEBUG: [3.12.1] [dev] [hz.client_20] Starting partition service
Feb 11, 2020 02:39:59 PM HazelcastClient
INFO: [3.12.1] [dev] [hz.client_20] Client started.
Feb 11, 2020 02:39:59 PM HazelcastClient.Connection[28](localhost:5702)
DEBUG: [3.12.1] [dev] [hz.client_20] Connected to (u'localhost', 5702)
Feb 11, 2020 02:39:59 PM HazelcastClient.InvocationService
DEBUG: [3.12.1] [dev] [hz.client_20] Sending ClientMessage:{length=142, correlationId=4, messageType=2, partitionId=-1, isComplete=False, isRetryable=True, isEvent=False, writeOffset=22} to Connection(address=(u'localhost', 5702), id=28)
Feb 11, 2020 02:39:59 PM HazelcastClient.AsyncoreReactor
DEBUG: [3.12.1] [dev] [hz.client_20] Cancel timer <hazelcast.reactor.Timer object at 0x7fc5695c3750>
Feb 11, 2020 02:39:59 PM HazelcastClient.PartitionService
DEBUG: [3.12.1] [dev] [hz.client_20] Finished updating partitions
Feb 11, 2020 02:39:59 PM HazelcastClient.AsyncoreReactor
DEBUG: [3.12.1] [dev] [hz.client_20] Cancel timer <hazelcast.reactor.Timer object at 0x7fc5695c3b10>
Feb 11, 2020 02:39:59 PM HazelcastClient.ConnectionManager
INFO: [3.12.1] [dev] [hz.client_20] Authenticated with Connection(address=(u'localhost', 5702), id=28)
Feb 11, 2020 02:39:59 PM HazelcastClient.InvocationService
DEBUG: [3.12.1] [dev] [hz.client_20] Sending ClientMessage:{length=101, correlationId=5, messageType=5, partitionId=-1, isComplete=False, isRetryable=False, isEvent=False, writeOffset=22} to Connection(address=(u'localhost', 5702), id=28)
Feb 11, 2020 02:39:59 PM HazelcastClient.AsyncoreReactor
DEBUG: [3.12.1] [dev] [hz.client_20] Cancel timer <hazelcast.reactor.Timer object at 0x7fc5695cb050>
Feb 11, 2020 02:39:59 PM HazelcastClient.InvocationService
DEBUG: [3.12.1] [dev] [hz.client_20] Sending ClientMessage:{length=152, correlationId=6, messageType=257, partitionId=13, isComplete=False, isRetryable=False, isEvent=False, writeOffset=22} to Connection(address=('127.0.0.1', 5701), id=27)
Feb 11, 2020 02:39:59 PM HazelcastClient.AsyncoreReactor
DEBUG: [3.12.1] [dev] [hz.client_20] Cancel timer <hazelcast.reactor.Timer object at 0x7fc5695cb2d0>
Feb 11, 2020 02:39:59 PM HazelcastClient.Connection[29](localhost:5703)
DEBUG: [3.12.1] [dev] [hz.client_20] Connected to (u'localhost', 5703)
Feb 11, 2020 02:39:59 PM HazelcastClient.InvocationService
DEBUG: [3.12.1] [dev] [hz.client_20] Sending ClientMessage:{length=142, correlationId=7, messageType=2, partitionId=-1, isComplete=False, isRetryable=True, isEvent=False, writeOffset=22} to Connection(address=(u'localhost', 5703), id=29)
Feb 11, 2020 02:39:59 PM HazelcastClient.AsyncoreReactor
DEBUG: [3.12.1] [dev] [hz.client_20] Cancel timer <hazelcast.reactor.Timer object at 0x7fc5695cb710>
Feb 11, 2020 02:39:59 PM HazelcastClient.ConnectionManager
INFO: [3.12.1] [dev] [hz.client_20] Authenticated with Connection(address=(u'localhost', 5703), id=29)
Feb 11, 2020 02:39:59 PM HazelcastClient.ListenerService
DEBUG: [3.12.1] Added event handler 8 : <function <lambda> at 0x7fc56a11c5f0>
Feb 11, 2020 02:39:59 PM HazelcastClient.InvocationService
DEBUG: [3.12.1] [dev] [hz.client_20] Sending ClientMessage:{length=68, correlationId=8, messageType=284, partitionId=-1, isComplete=False, isRetryable=False, isEvent=False, writeOffset=22} to Connection(address=(u'localhost', 5703), id=29)
Feb 11, 2020 02:39:59 PM HazelcastClient.AsyncoreReactor
DEBUG: [3.12.1] [dev] [hz.client_20] Cancel timer <hazelcast.reactor.Timer object at 0x7fc5695c3710>
Feb 11, 2020 02:39:59 PM HazelcastClient.ListenerService
DEBUG: [3.12.1] Added event handler 9 : <function <lambda> at 0x7fc56a11c5f0>
Feb 11, 2020 02:39:59 PM HazelcastClient.InvocationService
DEBUG: [3.12.1] [dev] [hz.client_20] Sending ClientMessage:{length=68, correlationId=9, messageType=284, partitionId=-1, isComplete=False, isRetryable=False, isEvent=False, writeOffset=22} to Connection(address=('127.0.0.1', 5701), id=27)
Feb 11, 2020 02:39:59 PM HazelcastClient.AsyncoreReactor
DEBUG: [3.12.1] [dev] [hz.client_20] Cancel timer <hazelcast.reactor.Timer object at 0x7fc5695c3c50>
Feb 11, 2020 02:39:59 PM HazelcastClient.ListenerService
DEBUG: [3.12.1] Added event handler 10 : <function <lambda> at 0x7fc56a11c5f0>
Feb 11, 2020 02:39:59 PM HazelcastClient.InvocationService
DEBUG: [3.12.1] [dev] [hz.client_20] Sending ClientMessage:{length=68, correlationId=10, messageType=284, partitionId=-1, isComplete=False, isRetryable=False, isEvent=False, writeOffset=22} to Connection(address=(u'localhost', 5702), id=28)
Feb 11, 2020 02:39:59 PM HazelcastClient.AsyncoreReactor
DEBUG: [3.12.1] [dev] [hz.client_20] Cancel timer <hazelcast.reactor.Timer object at 0x7fc5695c3c90>
Feb 11, 2020 02:39:59 PM HazelcastClient.Connection[27](127.0.0.1:5701)
WARNING: [3.12.1] [dev] [hz.client_20] Connection closed by server
Feb 11, 2020 02:39:59 PM HazelcastClient.LifecycleService
INFO: [3.12.1] [dev] [hz.client_20] (20200211 - dbdb7c7) HazelcastClient is DISCONNECTED
Feb 11, 2020 02:39:59 PM HazelcastClient.ClusterService
WARNING: [3.12.1] [dev] [hz.client_20] Connection closed to owner node. Trying to reconnect.
Feb 11, 2020 02:39:59 PM HazelcastClient.ListenerService
DEBUG: [3.12.1] Conn removed Connection(address=('127.0.0.1', 5701), id=27). Removing event handler 10
Feb 11, 2020 02:39:59 PM HazelcastClient.ClusterService
INFO: [3.12.1] [dev] [hz.client_20] Connecting to Address(host=localhost, port=5703)
Feb 11, 2020 02:39:59 PM HazelcastClient.ListenerService
DEBUG: [3.12.1] Removed event handler 10
Feb 11, 2020 02:39:59 PM HazelcastClient.InvocationService
DEBUG: [3.12.1] [dev] [hz.client_20] Sending ClientMessage:{length=142, correlationId=11, messageType=2, partitionId=-1, isComplete=False, isRetryable=True, isEvent=False, writeOffset=22} to Connection(address=(u'localhost', 5703), id=29)
Feb 11, 2020 02:39:59 PM HazelcastClient.InvocationService
DEBUG: [3.12.1] [dev] [hz.client_20] Got exception for request ClientMessage:{length=152, correlationId=0, messageType=257, partitionId=0, isComplete=False, isRetryable=False, isEvent=False, writeOffset=22}: IOError: Client is not in connected state
Feb 11, 2020 02:40:00 PM HazelcastClient.AsyncoreReactor
DEBUG: [3.12.1] [dev] [hz.client_20] Cancel timer <hazelcast.reactor.Timer object at 0x7fc5695c30d0>
Feb 11, 2020 02:40:00 PM HazelcastClient.ListenerService
DEBUG: [3.12.1] Added event handler 12 : <function handler at 0x7fc56a0dbc80>
Feb 11, 2020 02:40:00 PM HazelcastClient.InvocationService
DEBUG: [3.12.1] [dev] [hz.client_20] Sending ClientMessage:{length=23, correlationId=12, messageType=4, partitionId=-1, isComplete=False, isRetryable=False, isEvent=False, writeOffset=22} to Connection(address=(u'localhost', 5703), id=29)
Feb 11, 2020 02:40:00 PM HazelcastClient.ClusterService
DEBUG: [3.12.1] [dev] [hz.client_20] Got initial member list: [Member(host=localhost, port=5702, uuid=d779e36a-7b8e-49a3-a8a2-38e711c4bd4c, liteMember=False, attributes={}), Member(host=localhost, port=5703, uuid=c3d8c16c-7f0d-418e-b83b-0bc4a90b7221, liteMember=False, attributes={})]
Feb 11, 2020 02:40:00 PM HazelcastClient.ConnectionManager
WARNING: [3.12.1] [dev] [hz.client_20] No connection with Address(host=localhost, port=5701) was found to close.
Feb 11, 2020 02:40:00 PM HazelcastClient.ClusterService
INFO: [3.12.1] [dev] [hz.client_20] New member list:

Members [2] {
	Member [localhost]:5703 - c3d8c16c-7f0d-418e-b83b-0bc4a90b7221
	Member [localhost]:5702 - d779e36a-7b8e-49a3-a8a2-38e711c4bd4c
}

Feb 11, 2020 02:40:00 PM HazelcastClient.AsyncoreReactor
DEBUG: [3.12.1] [dev] [hz.client_20] Cancel timer <hazelcast.reactor.Timer object at 0x7fc56a10d050>
Feb 11, 2020 02:40:00 PM HazelcastClient.InvocationService
DEBUG: [3.12.1] [dev] [hz.client_20] Got exception for request ClientMessage:{length=152, correlationId=0, messageType=257, partitionId=0, isComplete=False, isRetryable=False, isEvent=False, writeOffset=22}: TargetNotMemberError: Partition owner 'Address(host=localhost, port=5701)' is not a member.
Feb 11, 2020 02:40:00 PM HazelcastClient.ClusterService
DEBUG: [3.12.1] [dev] [hz.client_20] Registered membership listener with ID ca9774fa-b55b-405b-87d4-0a48a74cb264
Feb 11, 2020 02:40:00 PM HazelcastClient.PartitionService
DEBUG: [3.12.1] [dev] [hz.client_20] Start updating partitions
Feb 11, 2020 02:40:00 PM HazelcastClient.LifecycleService
INFO: [3.12.1] [dev] [hz.client_20] (20200211 - dbdb7c7) HazelcastClient is CONNECTED
Feb 11, 2020 02:40:00 PM HazelcastClient.InvocationService
DEBUG: [3.12.1] [dev] [hz.client_20] Sending ClientMessage:{length=22, correlationId=13, messageType=8, partitionId=-1, isComplete=False, isRetryable=False, isEvent=False, writeOffset=22} to Connection(address=(u'localhost', 5703), id=29)
Feb 11, 2020 02:40:00 PM HazelcastClient.AsyncoreReactor
DEBUG: [3.12.1] [dev] [hz.client_20] Cancel timer <hazelcast.reactor.Timer object at 0x7fc56a118750>
Feb 11, 2020 02:40:00 PM HazelcastClient.PartitionService
DEBUG: [3.12.1] [dev] [hz.client_20] Finished updating partitions
Feb 11, 2020 02:40:01 PM HazelcastClient.InvocationService
DEBUG: [3.12.1] [dev] [hz.client_20] Sending ClientMessage:{length=152, correlationId=14, messageType=257, partitionId=13, isComplete=False, isRetryable=False, isEvent=False, writeOffset=22} to Connection(address=(u'localhost', 5702), id=28)
Feb 11, 2020 02:40:01 PM HazelcastClient.ListenerService
WARNING: [3.12.1] [dev] [hz.client_20] Got event message with unknown correlation id: ClientMessage:{length=126, correlationId=10, messageType=203, partitionId=13, isComplete=False, isRetryable=False, isEvent=True, writeOffset=22}
Feb 11, 2020 02:40:01 PM HazelcastClient.ListenerService
DEBUG: [3.12.1] Event handlers: {8: <function <lambda> at 0x7fc56a11c5f0>, 9: <function <lambda> at 0x7fc56a11c5f0>, 2: <function handler at 0x7fc56b39c668>, 12: <function handler at 0x7fc56a0dbc80>}
Feb 11, 2020 02:40:01 PM HazelcastClient.AsyncoreReactor
DEBUG: [3.12.1] [dev] [hz.client_20] Cancel timer <hazelcast.reactor.Timer object at 0x7fc56b402550>
Feb 11, 2020 02:40:09 PM HazelcastClient.PartitionService
DEBUG: [3.12.1] [dev] [hz.client_20] Start updating partitions
Feb 11, 2020 02:40:09 PM HazelcastClient.InvocationService
DEBUG: [3.12.1] [dev] [hz.client_20] Sending ClientMessage:{length=22, correlationId=15, messageType=8, partitionId=-1, isComplete=False, isRetryable=False, isEvent=False, writeOffset=22} to Connection(address=(u'localhost', 5703), id=29)
Feb 11, 2020 02:40:09 PM HazelcastClient.InvocationService
DEBUG: [3.12.1] [dev] [hz.client_20] Sending ClientMessage:{length=22, correlationId=16, messageType=15, partitionId=-1, isComplete=False, isRetryable=True, isEvent=False, writeOffset=22} to Connection(address=(u'localhost', 5702), id=28)
Feb 11, 2020 02:40:09 PM HazelcastClient.AsyncoreReactor
DEBUG: [3.12.1] [dev] [hz.client_20] Cancel timer <hazelcast.reactor.Timer object at 0x7fc5695c3750>
Feb 11, 2020 02:40:09 PM HazelcastClient.PartitionService
DEBUG: [3.12.1] [dev] [hz.client_20] Finished updating partitions
Feb 11, 2020 02:40:09 PM HazelcastClient.AsyncoreReactor
DEBUG: [3.12.1] [dev] [hz.client_20] Cancel timer <hazelcast.reactor.Timer object at 0x7fc56a118710>
Feb 11, 2020 02:40:14 PM HazelcastClient.InvocationService
DEBUG: [3.12.1] [dev] [hz.client_20] Sending ClientMessage:{length=22, correlationId=17, messageType=15, partitionId=-1, isComplete=False, isRetryable=True, isEvent=False, writeOffset=22} to Connection(address=(u'localhost', 5703), id=29)
Feb 11, 2020 02:40:14 PM HazelcastClient.InvocationService
DEBUG: [3.12.1] [dev] [hz.client_20] Sending ClientMessage:{length=22, correlationId=18, messageType=15, partitionId=-1, isComplete=False, isRetryable=True, isEvent=False, writeOffset=22} to Connection(address=(u'localhost', 5702), id=28)
Feb 11, 2020 02:40:14 PM HazelcastClient.AsyncoreReactor
DEBUG: [3.12.1] [dev] [hz.client_20] Cancel timer <hazelcast.reactor.Timer object at 0x7fc56a118050>
Feb 11, 2020 02:40:14 PM HazelcastClient.AsyncoreReactor
DEBUG: [3.12.1] [dev] [hz.client_20] Cancel timer <hazelcast.reactor.Timer object at 0x7fc56a118110>
Feb 11, 2020 02:40:19 PM HazelcastClient.PartitionService
DEBUG: [3.12.1] [dev] [hz.client_20] Start updating partitions
Feb 11, 2020 02:40:19 PM HazelcastClient.InvocationService
DEBUG: [3.12.1] [dev] [hz.client_20] Sending ClientMessage:{length=22, correlationId=19, messageType=8, partitionId=-1, isComplete=False, isRetryable=False, isEvent=False, writeOffset=22} to Connection(address=(u'localhost', 5703), id=29)
Feb 11, 2020 02:40:19 PM HazelcastClient.InvocationService
DEBUG: [3.12.1] [dev] [hz.client_20] Sending ClientMessage:{length=22, correlationId=20, messageType=15, partitionId=-1, isComplete=False, isRetryable=True, isEvent=False, writeOffset=22} to Connection(address=(u'localhost', 5702), id=28)
Feb 11, 2020 02:40:19 PM HazelcastClient.AsyncoreReactor
DEBUG: [3.12.1] [dev] [hz.client_20] Cancel timer <hazelcast.reactor.Timer object at 0x7fc5695cb810>
Feb 11, 2020 02:40:19 PM HazelcastClient.PartitionService
DEBUG: [3.12.1] [dev] [hz.client_20] Finished updating partitions
Feb 11, 2020 02:40:19 PM HazelcastClient.AsyncoreReactor
DEBUG: [3.12.1] [dev] [hz.client_20] Cancel timer <hazelcast.reactor.Timer object at 0x7fc5695cb590>
Feb 11, 2020 02:40:24 PM HazelcastClient.InvocationService
DEBUG: [3.12.1] [dev] [hz.client_20] Sending ClientMessage:{length=22, correlationId=21, messageType=15, partitionId=-1, isComplete=False, isRetryable=True, isEvent=False, writeOffset=22} to Connection(address=(u'localhost', 5703), id=29)
Feb 11, 2020 02:40:24 PM HazelcastClient.InvocationService
DEBUG: [3.12.1] [dev] [hz.client_20] Sending ClientMessage:{length=22, correlationId=22, messageType=15, partitionId=-1, isComplete=False, isRetryable=True, isEvent=False, writeOffset=22} to Connection(address=(u'localhost', 5702), id=28)
Feb 11, 2020 02:40:24 PM HazelcastClient.AsyncoreReactor
DEBUG: [3.12.1] [dev] [hz.client_20] Cancel timer <hazelcast.reactor.Timer object at 0x7fc5695cb090>
Feb 11, 2020 02:40:24 PM HazelcastClient.AsyncoreReactor
DEBUG: [3.12.1] [dev] [hz.client_20] Cancel timer <hazelcast.reactor.Timer object at 0x7fc5695cbbd0>
Feb 11, 2020 02:40:29 PM HazelcastClient.PartitionService
DEBUG: [3.12.1] [dev] [hz.client_20] Start updating partitions
Feb 11, 2020 02:40:29 PM HazelcastClient.InvocationService
DEBUG: [3.12.1] [dev] [hz.client_20] Sending ClientMessage:{length=22, correlationId=23, messageType=8, partitionId=-1, isComplete=False, isRetryable=False, isEvent=False, writeOffset=22} to Connection(address=(u'localhost', 5703), id=29)
Feb 11, 2020 02:40:29 PM HazelcastClient.InvocationService
DEBUG: [3.12.1] [dev] [hz.client_20] Sending ClientMessage:{length=22, correlationId=24, messageType=15, partitionId=-1, isComplete=False, isRetryable=True, isEvent=False, writeOffset=22} to Connection(address=(u'localhost', 5702), id=28)
Feb 11, 2020 02:40:29 PM HazelcastClient.AsyncoreReactor
DEBUG: [3.12.1] [dev] [hz.client_20] Cancel timer <hazelcast.reactor.Timer object at 0x7fc5695cbe10>
Feb 11, 2020 02:40:29 PM HazelcastClient.PartitionService
DEBUG: [3.12.1] [dev] [hz.client_20] Finished updating partitions
Feb 11, 2020 02:40:29 PM HazelcastClient.AsyncoreReactor
DEBUG: [3.12.1] [dev] [hz.client_20] Cancel timer <hazelcast.reactor.Timer object at 0x7fc5695d5090>
```

It is pretty long but the most important thing is that when the connection to 5701 is removed, the event handler that was removed was the handler that corresponds to the 5702.

It turns out that we didn't implement the __hash__ method for the Connection objects. By default, Python uses 
```python
id(self)/16
``` 
as the hash. (integer division). So, collisions are possible for the close id values. I changed the __hash__ function of the connection class so that it returns the unique connection id as of Java client.