### PR TITLE
operate on a copy of the listener registration request

### DIFF
--- a/hazelcast/connection.py
+++ b/hazelcast/connection.py
@@ -333,7 +333,7 @@ class Connection(object):
     def __repr__(self):
         return "Connection(address=%s, id=%s)" % (self._address, self.id)
 
-    def  __hash__(self):
+    def __hash__(self):
         return self.id
 
 

--- a/hazelcast/listener.py
+++ b/hazelcast/listener.py
@@ -92,7 +92,7 @@ class ListenerService(object):
         if connection in registration_map:
             return
 
-        registration_request = listener_registration.registration_request
+        registration_request = listener_registration.registration_request.clone()
         future = self._invocation_service.invoke_on_connection(registration_request, connection,
                                                                event_handler=listener_registration.handler)
 

--- a/hazelcast/protocol/client_message.py
+++ b/hazelcast/protocol/client_message.py
@@ -214,6 +214,11 @@ class ClientMessage(object):
         self.buffer += client_message.buffer[start:end]
         self.set_frame_length(len(self.buffer))
 
+    def clone(self):
+        client_message = ClientMessage(bytearray(self.buffer))
+        client_message.set_retryable(self._retryable)
+        return client_message
+
     def __repr__(self):
         return binascii.hexlify(self.buffer)
 

--- a/tests/client_message_test.py
+++ b/tests/client_message_test.py
@@ -168,6 +168,19 @@ class ClientMessageTest(unittest.TestCase):
         self.assertFalse(message.is_flag_set(END_FLAG))
         self.assertTrue(message.is_flag_set(LISTENER_FLAG))
 
+    def test_clone(self):
+        message = ClientMessage(payload_size=0)
+        message.set_flags(0)
+
+        message.add_flag(LISTENER_FLAG)
+        clone = message.clone()
+        clone.add_flag(BEGIN_FLAG)
+
+        self.assertTrue(message.is_flag_set(LISTENER_FLAG))
+        self.assertTrue(clone.is_flag_set(LISTENER_FLAG))
+        self.assertFalse(message.is_flag_set(BEGIN_FLAG))
+        self.assertTrue(clone.is_flag_set(BEGIN_FLAG))
+
 
 class ClientMessageBuilderTest(unittest.TestCase):
     def test_message_accumulate(self):


### PR DESCRIPTION
Formerly, client was reusing the same client message for listener registration requests.  Since on each invoke, we set a new correlation id for the client messages, getting the correlation id as https://github.com/hazelcast/hazelcast-python-client/blob/master/hazelcast/listener.py#L103 were resulting in event registrations with duplicate correlation ids