### PR TITLE
fix race on the listener registration

### DIFF
--- a/hazelcast/listener.py
+++ b/hazelcast/listener.py
@@ -107,9 +107,9 @@ class ListenerService(object):
                 if connection.live():
                     self.logger.warning("Listener %s can not be added to a new connection: %s, reason: %s",
                                         user_registration_id, connection, e.args[0], extra=self._logger_extras)
+                raise e
 
-        future.add_done_callback(callback)
-        return future
+        return future.continue_with(callback)
 
     def deregister_listener(self, user_registration_id):
         check_not_none(user_registration_id, "None userRegistrationId is not allowed!")

--- a/tests/proxy/queue_test.py
+++ b/tests/proxy/queue_test.py
@@ -80,10 +80,6 @@ class QueueTest(SingleMemberTestCase):
 
         def assert_event():
             self.assertEqual(len(collector.events), 0)
-            if len(collector.events) > 0:
-                event = collector.events[0]
-                self.assertEqual(event.item, None)
-                self.assertEqual(event.event_type, ItemEventType.added)
 
         self.assertTrueEventually(assert_event, 5)
 


### PR DESCRIPTION
The implementation of the Future runs the callbacks after notifying the threads waiting on the condition. Because of that, the blocking call `result` on futures may be returned before executing the callbacks. This was causing the `test_remove_entry_listener_item_added` on `queue_test.py` to fail randomly. In the runs that fail, following scenario occurs:

1. `reg_id = self.queue.add_listener(include_value=False, item_added_func=collector)` is called. The result is set and the test runner continues with the next line but the callbacks are not fully executed yet (callbacks are executed on the reactor thread whereas tests run on the main thread)
2. `self.queue.remove_listener(reg_id)` is called. This calls `deregister_listener` method of the listener service. The problematic line is the following. https://github.com/hazelcast/hazelcast-python-client/blob/master/hazelcast/listener.py#L122 . Since the callbacks are not executed yet, `connection_registrations` does not contain the registration done on step 1. Hence, no deregister listener request is made to the server, client receives events and test fails. 

To fix the problem, `register_listener_on_connection_async` sets the result of the future it returns after executing the callback