### PR TITLE
fix typo on the invocation service

### DIFF
--- a/hazelcast/invocation.py
+++ b/hazelcast/invocation.py
@@ -239,7 +239,7 @@ class InvocationService(object):
             if self.logger.isEnabledFor(logging.DEBUG):
                 self.logger.debug('Error will not be retried because invocation timed out: %s', error,
                                   extra=self._logger_extras)
-            invocation.set_excetion(TimeoutError(
+            invocation.set_exception(TimeoutError(
                 '%s timed out because an error occurred after invocation timeout: %s' % (invocation.request, error),
                 traceback))
             return

--- a/tests/invocation_test.py
+++ b/tests/invocation_test.py
@@ -1,0 +1,25 @@
+import time
+
+from hazelcast.config import ClientProperties
+from hazelcast.exception import TimeoutError
+from hazelcast.invocation import Invocation
+from tests.base import SingleMemberTestCase
+
+
+class InvocationTest(SingleMemberTestCase):
+    @classmethod
+    def configure_client(cls, config):
+        config.set_property(ClientProperties.INVOCATION_TIMEOUT_SECONDS.name, 1)
+        return config
+
+    def test_invocation_timeout(self):
+        invocation_service = self.client.invoker
+        invocation = Invocation(invocation_service, None, partition_id=-1)
+
+        def mocked_has_partition_id():
+            time.sleep(2)
+            return True
+
+        invocation.has_partition_id = mocked_has_partition_id
+        with self.assertRaises(TimeoutError):
+            invocation_service.invoke(invocation).result()


### PR DESCRIPTION
fixes #191 

Also adds a test to verify that the TimeoutError is actually raised. Test uses the fact that there is no partition owner for the id of -1, so invocation will be retried. We sleep 2 * INVOCATION_TIMEOUT_SECONDS inside the mocked has_partition_id method to simulate the timeout scenario. 