### PR TITLE
Add missing loaded event

### DIFF
--- a/hazelcast/proxy/base.py
+++ b/hazelcast/proxy/base.py
@@ -113,7 +113,8 @@ class TransactionalProxy(object):
 
 
 ItemEventType = enum(added=1, removed=2)
-EntryEventType = enum(added=1, removed=2, updated=4, evicted=8, evict_all=16, clear_all=32, merged=64, expired=128, invalidation=256)
+EntryEventType = enum(added=1, removed=2, updated=4, evicted=8, evict_all=16, clear_all=32, merged=64, expired=128,
+                      invalidation=256, loaded=512)
 
 
 class ItemEvent(object):

--- a/hazelcast/proxy/map.py
+++ b/hazelcast/proxy/map.py
@@ -57,8 +57,9 @@ class Map(Proxy):
         super(Map, self).__init__(client, service_name, name)
         self.reference_id_generator = self._client.lock_reference_id_generator
 
-    def add_entry_listener(self, include_value=False, key=None, predicate=None, added_func=None, removed_func=None, updated_func=None,
-                           evicted_func=None, evict_all_func=None, clear_all_func=None, merged_func=None, expired_func=None):
+    def add_entry_listener(self, include_value=False, key=None, predicate=None, added_func=None, removed_func=None,
+                           updated_func=None, evicted_func=None, evict_all_func=None, clear_all_func=None,
+                           merged_func=None, expired_func=None, loaded_func=None):
         """
         Adds a continuous entry listener for this map. Listener will get notified for map events filtered with given
         parameters.
@@ -74,13 +75,14 @@ class Map(Proxy):
         :param clear_all_func: Function to be called when entries are cleared from map (optional).
         :param merged_func: Function to be called when WAN replicated entry is merged_func (optional).
         :param expired_func: Function to be called when an entry's live time is expired (optional).
+        :param loaded_func: Function to be called when an entry is loaded from a map loader (optional).
         :return: (str), a registration id which is used as a key to remove the listener.
 
         .. seealso:: :class:`~hazelcast.serialization.predicate.Predicate` for more info about predicates.
         """
         flags = get_entry_listener_flags(added=added_func, removed=removed_func, updated=updated_func,
                                          evicted=evicted_func, evict_all=evict_all_func, clear_all=clear_all_func,
-                                         merged=merged_func, expired=expired_func)
+                                         merged=merged_func, expired=expired_func, loaded=loaded_func)
 
         if key and predicate:
             key_data = self._to_data(key)
@@ -116,6 +118,8 @@ class Map(Proxy):
                 merged_func(event)
             elif event.event_type == EntryEventType.expired:
                 expired_func(event)
+            elif event.event_type == EntryEventType.loaded:
+                loaded_func(event)
 
         return self._register_listener(request, lambda r: map_add_entry_listener_codec.decode_response(r)['response'],
                                        lambda reg_id: map_remove_entry_listener_codec.encode_request(self.name, reg_id),

--- a/tests/proxy/hazelcast_mapstore.xml
+++ b/tests/proxy/hazelcast_mapstore.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.2.xsd"
+           xmlns="http://www.hazelcast.com/schema/config">
+    <map name="mapstore-test">
+        <map-store enabled="true">
+            <class-name>com.hazelcast.client.test.SampleMapStore</class-name>
+        </map-store>
+    </map>
+</hazelcast>

--- a/tests/proxy/map_test.py
+++ b/tests/proxy/map_test.py
@@ -556,3 +556,17 @@ class MapStoreTest(SingleMemberTestCase):
     def test_evict_all(self):
         self.map.evict_all()
         self.assertEqual(self.map.size(), 0)
+
+    def test_add_entry_listener_item_loaded(self):
+        collector = event_collector()
+        self.map.add_entry_listener(include_value=True, loaded_func=collector)
+        self.map.put('key', 'value', ttl=0.1)
+        time.sleep(2)
+        self.map.get('key')
+
+        def assert_event():
+            self.assertEqual(len(collector.events), 1)
+            event = collector.events[0]
+            self.assertEntryEvent(event, key='key', value='value', event_type=EntryEventType.loaded)
+
+        self.assertTrueEventually(assert_event, 10)

--- a/tests/proxy/map_test.py
+++ b/tests/proxy/map_test.py
@@ -5,7 +5,7 @@ from hazelcast.proxy.map import EntryEventType
 from hazelcast.serialization.api import IdentifiedDataSerializable
 from hazelcast.serialization.predicate import SqlPredicate
 from tests.base import SingleMemberTestCase
-from tests.util import random_string, event_collector
+from tests.util import random_string, event_collector, fill_map
 from hazelcast import six
 from hazelcast.six.moves import range
 
@@ -500,3 +500,59 @@ class MapTest(SingleMemberTestCase):
         for k, v in six.iteritems(map):
             self.map.put(k, v)
         return map
+
+
+class MapStoreTest(SingleMemberTestCase):
+    @classmethod
+    def configure_cluster(cls):
+        path = os.path.abspath(__file__)
+        dir_path = os.path.dirname(path)
+        with open(os.path.join(dir_path, "hazelcast_mapstore.xml")) as f:
+            return f.read()
+
+    def setUp(self):
+        self.map = self.client.get_map("mapstore-test").blocking()
+        self.entries = fill_map(self.map, size=10, key_prefix="key", value_prefix="val")
+
+    def tearDown(self):
+        self.map.destroy()
+
+    def test_load_all_with_no_args_loads_all_keys(self):
+        self.map.evict_all()
+        self.map.load_all()
+        entry_set = self.map.get_all(self.entries.keys())
+        six.assertCountEqual(self, entry_set, self.entries)
+
+    def test_load_all_with_key_set_loads_given_keys(self):
+        self.map.evict_all()
+        self.map.load_all(['key0', 'key1'])
+        entry_set = self.map.get_all(['key0', 'key1'])
+        six.assertCountEqual(self, entry_set, {'key0': 'val0', 'key1': 'val1'})
+
+    def test_load_all_overrides_entries_in_memory_by_default(self):
+        self.map.evict_all()
+        self.map.put_transient('key0', 'new0')
+        self.map.put_transient('key1', 'new1')
+        self.map.load_all(['key0', 'key1'])
+        entry_set = self.map.get_all(['key0', 'key1'])
+        six.assertCountEqual(self, entry_set, {'key0': 'val0', 'key1': 'val1'})
+
+    def test_load_all_with_replace_existing_false_does_not_override(self):
+        self.map.evict_all()
+        self.map.put_transient('key0', 'new0')
+        self.map.put_transient('key1', 'new1')
+        self.map.load_all(['key0', 'key1'], replace_existing_values=False)
+        entry_set = self.map.get_all(['key0', 'key1'])
+        six.assertCountEqual(self, entry_set, {'key0': 'new0', 'key1': 'new1'})
+
+    def test_evict(self):
+        self.map.evict('key0')
+        self.assertEqual(self.map.size(), 9)
+
+    def test_evict_non_existing_key(self):
+        self.map.evict('non_existing_key')
+        self.assertEqual(self.map.size(), 10)
+
+    def test_evict_all(self):
+        self.map.evict_all()
+        self.assertEqual(self.map.size(), 0)

--- a/tests/util.py
+++ b/tests/util.py
@@ -29,6 +29,7 @@ def fill_map(map, size=10, key_prefix="key", value_prefix="val"):
     for i in range(size):
         entries[key_prefix + str(i)] = value_prefix + str(i)
     map.put_all(entries)
+    return entries
 
 
 def get_ssl_config(enable_ssl=False,


### PR DESCRIPTION
Added missing EntryLoaded event alongside the missing mapstore tests.

The test for the loaded event uses `SampleMapStore` in the `com.hazelcast.client.test` package. It firsts puts a data to map with TTL. After 0.1 second, data is not available on the map but available on the map store. So, the get method call causes the event to fire by loading the entry from the underlying MapStore

fixes #172 