### PR TITLE
Implement distributed object listener and get_distributed_objects method

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@
   * [7.5. Distributed Events](#75-distributed-events)
     * [7.5.1. Cluster Events](#751-cluster-events)
       * [7.5.1.1. Listening for Member Events](#7511-listening-for-member-events)
-      * [7.5.1.2. Listening for Lifecycle Events](#7512-listening-for-lifecycle-events)
+      * [7.5.1.2. Listenring for Distributed Object Events](#7512-listening-for-distributed-object-events)
+      * [7.5.1.3. Listening for Lifecycle Events](#7513-listening-for-lifecycle-events)
     * [7.5.2. Distributed Data Structure Events](#752-distributed-data-structure-events)
       * [7.5.2.1. Listening for Map Events](#7521-listening-for-map-events)
   * [7.6. Distributed Computing](#76-distributed-computing)
@@ -1737,7 +1738,42 @@ The following is a membership listener registration by using the `add_listener()
 client.cluster.add_listener(member_added=lambda m: print("Member Added: The address is {}".format(m.address)))
 ```
 
-#### 7.5.1.2. Listening for Lifecycle Events
+#### 7.5.1.2. Listening for Distributed Object Events
+
+The events for distributed objects are invoked when they are created and destroyed in the cluster. When an event
+is received, listener function will be called. The parameter passed into the listener function will be of the type
+``DistributedObjectEvent``. A ``DistributedObjectEvent`` contains the following fields:
+* ``name``: Name of the distributed object.
+* ``service_name``: Service name of the distributed object.
+* ``event_type``: Type of the invoked event. It is either ``CREATED`` or ``DESTROYED``.
+
+The following is example of adding a distributed object listener to a client.
+
+```python
+def distributed_object_listener(event):
+    print("Distributed object event >>>", event.name, event.service_name, event.event_type)
+
+client.add_distributed_object_listener(listener_func=distributed_object_listener)
+
+map_name = "test_map"
+
+# This call causes a CREATED event
+test_map = client.get_map(map_name)
+
+# This causes no event because map was already created
+test_map2 = client.get_map(map_name)
+
+# This causes a DESTROYED event
+test_map.destroy()
+```
+
+**Output**
+```
+Distributed object event >>> test_map hz:impl:mapService CREATED
+Distributed object event >>> test_map hz:impl:mapService DESTROYED
+```
+
+#### 7.5.1.3. Listening for Lifecycle Events
 
 The `Lifecycle Listener` notifies for the following events:
 

--- a/examples/monitoring/distributed_object_listener.py
+++ b/examples/monitoring/distributed_object_listener.py
@@ -1,0 +1,28 @@
+import hazelcast
+
+
+def distributed_object_listener(event):
+    print("Distributed object event >>>", event.name, event.service_name, event.event_type)
+
+
+if __name__ == "__main__":
+    client = hazelcast.HazelcastClient()
+
+    # Register the listener
+    reg_id = client.add_distributed_object_listener(distributed_object_listener)
+
+    map_name = "test_map"
+
+    # This call causes a CREATED event
+    test_map = client.get_map(map_name)
+
+    # This causes no event because map was already created
+    test_map2 = client.get_map(map_name)
+
+    # This causes a DESTROYED event
+    test_map.destroy()
+
+    # Deregister the listener
+    client.remove_distributed_object_listener(reg_id)
+
+    client.shutdown()

--- a/hazelcast/core.py
+++ b/hazelcast/core.py
@@ -3,6 +3,7 @@ import json
 
 from hazelcast import six
 from hazelcast import util
+from hazelcast.util import enum
 
 
 class Member(object):
@@ -54,6 +55,39 @@ class DistributedObjectInfo(object):
 
     def __repr__(self):
         return "DistributedObjectInfo(name={}, serviceName={})".format(self.name, self.service_name)
+
+    def __hash__(self):
+        return hash((self.name, self.service_name))
+
+    def __eq__(self, other):
+        if isinstance(other, DistributedObjectInfo):
+            return self.name == other.name and self.service_name == other.service_name
+        return False
+
+
+DistributedObjectEventType = enum(CREATED="CREATED", DESTROYED="DESTROYED")
+"""
+Type of the distributed object event.
+
+* CREATED : DistributedObject is created.
+* DESTROYED: DistributedObject is destroyed. 
+"""
+
+
+class DistributedObjectEvent(object):
+    """
+    Distributed Object Event
+    """
+
+    def __init__(self, name, service_name, event_type):
+        self.name = name
+        self.service_name = service_name
+        self.event_type = DistributedObjectEventType.reverse.get(event_type, None)
+
+    def __repr__(self):
+        return "DistributedObjectEvent[name={}, " \
+               "service_name={}, " \
+               "event_type={}]".format(self.name, self.service_name, self.event_type)
 
 
 class EntryView(object):

--- a/hazelcast/proxy/base.py
+++ b/hazelcast/proxy/base.py
@@ -199,3 +199,19 @@ def get_entry_listener_flags(**kwargs):
         if value:
             flags |= getattr(EntryEventType, key)
     return flags
+
+
+class DistributedObjectEvent(object):
+    """
+    Distributed Object Event
+    """
+
+    def __init__(self, name, service_name, event_type):
+        self.name = name
+        self.service_name = service_name
+        self.event_type = event_type
+
+    def __repr__(self):
+        return "DistributedObjectEvent[name={}, " \
+               "service_name={}, " \
+               "event_type={}]".format(self.name, self.service_name, self.event_type)

--- a/hazelcast/proxy/base.py
+++ b/hazelcast/proxy/base.py
@@ -199,4 +199,3 @@ def get_entry_listener_flags(**kwargs):
         if value:
             flags |= getattr(EntryEventType, key)
     return flags
-

--- a/hazelcast/proxy/base.py
+++ b/hazelcast/proxy/base.py
@@ -200,18 +200,3 @@ def get_entry_listener_flags(**kwargs):
             flags |= getattr(EntryEventType, key)
     return flags
 
-
-class DistributedObjectEvent(object):
-    """
-    Distributed Object Event
-    """
-
-    def __init__(self, name, service_name, event_type):
-        self.name = name
-        self.service_name = service_name
-        self.event_type = event_type
-
-    def __repr__(self):
-        return "DistributedObjectEvent[name={}, " \
-               "service_name={}, " \
-               "event_type={}]".format(self.name, self.service_name, self.event_type)

--- a/hazelcast/util.py
+++ b/hazelcast/util.py
@@ -341,3 +341,7 @@ def create_git_info():
     if GIT_COMMIT_ID:
         return "(" + GIT_COMMIT_ID + ") "
     return ""
+
+
+def to_list(*args, **kwargs):
+    return list(*args, **kwargs)

--- a/tests/base.py
+++ b/tests/base.py
@@ -77,6 +77,11 @@ class HazelcastTestCase(unittest.TestCase):
         self.assertEqual(event.old_value, old_value)
         self.assertEqual(event.number_of_affected_entries, number_of_affected_entries)
 
+    def assertDistributedObjectEvent(self, event, name, service_name, event_type):
+        self.assertEqual(name, event.name)
+        self.assertEqual(service_name, event.service_name)
+        self.assertEqual(event_type, event.event_type)
+
     def set_logging_level(self, level):
         logging.getLogger().setLevel(level)
 

--- a/tests/proxy/distributed_objects_test.py
+++ b/tests/proxy/distributed_objects_test.py
@@ -1,0 +1,96 @@
+import hazelcast
+
+from hazelcast.proxy import MAP_SERVICE
+from tests.base import SingleMemberTestCase
+from tests.util import event_collector
+from hazelcast import six
+
+
+class DistributedObjectsTest(SingleMemberTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.rc = cls.create_rc()
+        cls.cluster = cls.create_cluster(cls.rc, cls.configure_cluster())
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.rc.exit()
+
+    def setUp(self):
+        self.member = self.cluster.start_member()
+        self.client = hazelcast.HazelcastClient()
+
+    def tearDown(self):
+        self.client.shutdown()
+        self.member.shutdown()
+
+    def test_get_distributed_objects(self):
+        six.assertCountEqual(self, [], self.client.get_distributed_objects())
+
+        m = self.client.get_map("map")
+        s = self.client.get_set("set")
+        q = self.client.get_queue("queue")
+
+        six.assertCountEqual(self, [m, s, q], self.client.get_distributed_objects())
+
+    def test_add_distributed_object_listener_object_created(self):
+        collector = event_collector()
+        self.client.add_distributed_object_listener(listener_func=collector)
+
+        self.client.get_map("test-map")
+
+        def assert_event():
+            self.assertEqual(1, len(collector.events))
+            event = collector.events[0]
+            self.assertDistributedObjectEvent(event, "test-map", MAP_SERVICE, "CREATED")
+
+        self.assertTrueEventually(assert_event)
+
+    def test_add_distributed_object_listener_object_destroyed(self):
+        collector = event_collector()
+        m = self.client.get_map("test-map")
+        self.client.add_distributed_object_listener(listener_func=collector)
+
+        m.destroy()
+
+        def assert_event():
+            self.assertEqual(1, len(collector.events))
+            event = collector.events[0]
+            self.assertDistributedObjectEvent(event, "test-map", MAP_SERVICE, "DESTROYED")
+
+        self.assertTrueEventually(assert_event)
+
+    def test_add_distributed_object_listener_object_created_and_destroyed(self):
+        collector = event_collector()
+        self.client.add_distributed_object_listener(listener_func=collector)
+
+        m = self.client.get_map("test-map")
+        m.destroy()
+
+        def assert_event():
+            self.assertEqual(2, len(collector.events))
+            created_event = collector.events[0]
+            destroyed_event = collector.events[1]
+            self.assertDistributedObjectEvent(created_event, "test-map", MAP_SERVICE, "CREATED")
+            self.assertDistributedObjectEvent(destroyed_event, "test-map", MAP_SERVICE, "DESTROYED")
+
+        self.assertTrueEventually(assert_event)
+
+    def test_remove_distributed_object_listener(self):
+        collector = event_collector()
+        reg_id = self.client.add_distributed_object_listener(listener_func=collector)
+        m = self.client.get_map("test-map")
+
+        response = self.client.remove_distributed_object_listener(reg_id)
+        self.assertTrue(response)
+        m.destroy()
+
+        # only map creation should be notified
+        def assert_event():
+            self.assertEqual(1, len(collector.events))
+            event = collector.events[0]
+            self.assertDistributedObjectEvent(event, "test-map", MAP_SERVICE, "CREATED")
+        self.assertTrueEventually(assert_event)
+
+    def test_remove_invalid_distributed_object_listener(self):
+        self.assertFalse(self.client.remove_distributed_object_listener("invalid-reg-id"))

--- a/tests/proxy/distributed_objects_test.py
+++ b/tests/proxy/distributed_objects_test.py
@@ -40,7 +40,7 @@ class DistributedObjectsTest(SingleMemberTestCase):
         six.assertCountEqual(self, [m], self.client.get_distributed_objects())
 
         other_client = hazelcast.HazelcastClient()
-        other_clients_map = other_client.get_map("map").blocking()
+        other_clients_map = other_client.get_map("map")
         other_clients_map.destroy()
 
         six.assertCountEqual(self, [], self.client.get_distributed_objects())


### PR DESCRIPTION
This PR contains the code samples, documentation and implementation for the distributed object listener and get_distributed_objects method of the client.

Just like the Java client, call to the get_distributed_objects method clears the local instances of the destoyed proxies.