### PR TITLE
Update Hazelcast Cloud documentation and code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@
   * [7.5. Distributed Events](#75-distributed-events)
     * [7.5.1. Cluster Events](#751-cluster-events)
       * [7.5.1.1. Listening for Member Events](#7511-listening-for-member-events)
-      * [7.5.1.2. Listenring for Distributed Object Events](#7512-listening-for-distributed-object-events)
+      * [7.5.1.2. Listening for Distributed Object Events](#7512-listening-for-distributed-object-events)
       * [7.5.1.3. Listening for Lifecycle Events](#7513-listening-for-lifecycle-events)
     * [7.5.2. Distributed Data Structure Events](#752-distributed-data-structure-events)
       * [7.5.2.1. Listening for Map Events](#7521-listening-for-map-events)
@@ -1109,21 +1109,19 @@ As explained in the [TLS/SSL section](#61-tlsssl), Hazelcast members have key st
 
 ## 5.8. Enabling Hazelcast Cloud Discovery
 
-The purpose of Hazelcast Cloud Discovery is to provide the clients the means to use IP addresses provided by `hazelcast orchestrator`. To enable Hazelcast Cloud Discovery, specify a token for the `discovery_token` field and set the `enabled` field to `True`.
- 
-The following is the example configuration.
+Python client can discover and connect to Hazelcast clusters running on [Hazelcast Cloud](https://cloud.hazelcast.com/).
+For this, provide authentication information as `group_config`, enable `cloud_config` and set your `discovery_token` as shown below.
 
 ```python
-config.group_config.name = "hazel"
-config.group_config.password = "cast"
-
-config.network_config.ssl_config.enabled = True
+config.group_config.name = "YOUR_CLUSTER_NAME"
+config.group_config.password = "YOUR_CLUSTER_PASSWORD"
 
 config.network_config.cloud_config.enabled = True
-config.network_config.cloud_config.discovery_token = "dc9220bc5d9"
+config.network_config.cloud_config.discovery_token = "YOUR_CLUSTER_DISCOVERY_TOKEN"
 ```
 
-To be able to connect to the provided IP addresses, you should use secure TLS/SSL connection between the client and members. Therefore, you should enable the SSL configuration as described in the [TLS/SSL for Hazelcast Python Client section](#612-tlsssl-for-hazelcast-python-clients).
+If you have enabled encryption for your cluster, you should also enable TLS/SSL configuration to secure communication between your 
+client and cluster members as described in the [TLS/SSL for Hazelcast Python Client section](#612-tlsssl-for-hazelcast-python-clients). 
 
 # 6. Securing Client Connection
 

--- a/examples/cloud-discovery/hazelcast_cloud_discovery_example.py
+++ b/examples/cloud-discovery/hazelcast_cloud_discovery_example.py
@@ -4,21 +4,26 @@ if __name__ == "__main__":
     config = hazelcast.ClientConfig()
 
     # Set up group name and password for authentication
-    config.group_config.name = "name"
-    config.group_config.password = "password"
-
-    # Enable SSL for encryption. Default CA certificates will be used.
-    config.network_config.ssl_config.enabled = True
+    config.group_config.name = "YOUR_CLUSTER_NAME"
+    config.group_config.password = "YOUR_CLUSTER_PASSWORD"
 
     # Enable Hazelcast.Cloud configuration and set the token of your cluster.
     config.network_config.cloud_config.enabled = True
-    config.network_config.cloud_config.discovery_token = "token"
+    config.network_config.cloud_config.discovery_token = "YOUR_CLUSTER_DISCOVERY_TOKEN"
+
+    # If you have enabled encryption for your cluster, also configure TLS/SSL for the client.
+    # Otherwise, skip this step.
+    config.network_config.ssl_config.enabled = True
+    config.network_config.ssl_config.cafile = "/path/to/ca.pem"
+    config.network_config.ssl_config.certfile = "/path/to/cert.pem"
+    config.network_config.ssl_config.keyfile = "/path/to/key.pem"
+    config.network_config.ssl_config.password = "YOUR_KEY_STORE_PASSWORD"
 
     # Start a new Hazelcast client with this configuration.
     client = hazelcast.HazelcastClient(config)
 
-    my_map = client.get_map("map-on-the-cloud")
-    my_map.put("key", "hazelcast.cloud")
+    my_map = client.get_map("map-on-the-cloud").blocking()
+    my_map.put("key", "value")
 
     print(my_map.get("key"))
 


### PR DESCRIPTION
We didn't updated Hazelcast Cloud section since we have implemented
it. Right now, Hazelcast Cloud does not use secure communication
by default. One have to enable encryption before starting the cluster
to use secure communication. Also, unlike the code sample we have
provided, Hazelcast Cloud does not use certificates signed by
trusted CA. It generates a private certificate pair. This commit
updates the code sample accordingly.

fixes #207 