### PR TITLE
Use Google style for the docstrings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,14 @@ import hazelcast
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
+    'sphinx.ext.napoleon',
 ]
+
+autodoc_default_options = {
+    'members': None,
+    'undoc-members': None,
+    'show-inheritance': None,
+}
 
 # Autosummary on
 autosummary_generate = True
@@ -91,7 +98,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 #default_role = None
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
-#add_function_parentheses = True
+add_function_parentheses = True
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).

--- a/docs/hazelcast.client.rst
+++ b/docs/hazelcast.client.rst
@@ -2,6 +2,3 @@ Hazelcast Client
 ================
 
 .. automodule:: hazelcast.client
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.cluster.rst
+++ b/docs/hazelcast.cluster.rst
@@ -1,7 +1,4 @@
 Hazelcast Cluster
 =================
 
-.. automodule:: hazelcast.cluster
-    :members:
-    :undoc-members:
-    :show-inheritance:
+.. autoclass:: hazelcast.cluster.ClusterService

--- a/docs/hazelcast.config.rst
+++ b/docs/hazelcast.config.rst
@@ -1,7 +1,13 @@
 Config
 ======
 
-.. automodule:: hazelcast.config
-    :members:
-    :undoc-members:
-    :show-inheritance:
+.. py:currentmodule:: hazelcast.config
+
+.. autoclass:: IntType
+.. autoclass:: EvictionPolicy
+.. autoclass:: InMemoryFormat
+.. autoclass:: SSLProtocol
+.. autoclass:: QueryConstants
+.. autoclass:: UniqueKeyTransformation
+.. autoclass:: IndexType
+.. autoclass:: ReconnectMode

--- a/docs/hazelcast.connection.rst
+++ b/docs/hazelcast.connection.rst
@@ -1,7 +1,0 @@
-Connection
-==========
-
-.. automodule:: hazelcast.connection
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.core.rst
+++ b/docs/hazelcast.core.rst
@@ -2,6 +2,3 @@ Core
 ====
 
 .. automodule:: hazelcast.core
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.discovery.rst
+++ b/docs/hazelcast.discovery.rst
@@ -1,7 +1,0 @@
-Discovery
-=========
-
-.. automodule:: hazelcast.discovery
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.errors.rst
+++ b/docs/hazelcast.errors.rst
@@ -1,0 +1,5 @@
+Errors
+======
+
+.. automodule:: hazelcast.errors
+    :no-undoc-members:

--- a/docs/hazelcast.exception.rst
+++ b/docs/hazelcast.exception.rst
@@ -1,7 +1,0 @@
-Exception
-=========
-
-.. automodule:: hazelcast.exception
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.future.rst
+++ b/docs/hazelcast.future.rst
@@ -1,7 +1,7 @@
 Future
 ======
 
-.. automodule:: hazelcast.future
-    :members:
-    :undoc-members:
-    :show-inheritance:
+.. py:currentmodule:: hazelcast.future
+
+.. autoclass:: Future
+.. autofunction:: combine_futures

--- a/docs/hazelcast.hash.rst
+++ b/docs/hazelcast.hash.rst
@@ -1,7 +1,0 @@
-Hash
-====
-
-.. automodule:: hazelcast.hash
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.invocation.rst
+++ b/docs/hazelcast.invocation.rst
@@ -1,7 +1,0 @@
-Invocation
-==========
-
-.. automodule:: hazelcast.invocation
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.lifecycle.rst
+++ b/docs/hazelcast.lifecycle.rst
@@ -1,7 +1,4 @@
-LifeCycle
+Lifecycle
 =========
 
 .. automodule:: hazelcast.lifecycle
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.near_cache.rst
+++ b/docs/hazelcast.near_cache.rst
@@ -1,7 +1,0 @@
-NearCache
-=========
-
-.. automodule:: hazelcast.near_cache
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.partition.rst
+++ b/docs/hazelcast.partition.rst
@@ -2,6 +2,4 @@ Partition
 =========
 
 .. automodule:: hazelcast.partition
-    :members:
-    :undoc-members:
-    :show-inheritance:
+    :no-undoc-members:

--- a/docs/hazelcast.proxy.atomic_long.rst
+++ b/docs/hazelcast.proxy.atomic_long.rst
@@ -1,7 +1,0 @@
-AtomicLong
-==========
-
-.. automodule:: hazelcast.proxy.atomic_long
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.proxy.atomic_reference.rst
+++ b/docs/hazelcast.proxy.atomic_reference.rst
@@ -1,7 +1,0 @@
-AtomicReference
-===============
-
-.. automodule:: hazelcast.proxy.atomic_reference
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.proxy.base.rst
+++ b/docs/hazelcast.proxy.base.rst
@@ -2,6 +2,3 @@ Base
 ====
 
 .. automodule:: hazelcast.proxy.base
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.proxy.count_down_latch.rst
+++ b/docs/hazelcast.proxy.count_down_latch.rst
@@ -1,7 +1,0 @@
-CountDownLatch
-==============
-
-.. automodule:: hazelcast.proxy.count_down_latch
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.proxy.executor.rst
+++ b/docs/hazelcast.proxy.executor.rst
@@ -2,6 +2,3 @@ Executor
 ========
 
 .. automodule:: hazelcast.proxy.executor
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.proxy.flake_id_generator.rst
+++ b/docs/hazelcast.proxy.flake_id_generator.rst
@@ -2,6 +2,3 @@ FlakeIdGenerator
 ================
 
 .. automodule:: hazelcast.proxy.flake_id_generator
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.proxy.id_generator.rst
+++ b/docs/hazelcast.proxy.id_generator.rst
@@ -1,7 +1,0 @@
-IdGenerator
-===========
-
-.. automodule:: hazelcast.proxy.id_generator
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.proxy.list.rst
+++ b/docs/hazelcast.proxy.list.rst
@@ -2,6 +2,3 @@ List
 ====
 
 .. automodule:: hazelcast.proxy.list
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.proxy.lock.rst
+++ b/docs/hazelcast.proxy.lock.rst
@@ -1,7 +1,0 @@
-Lock
-====
-
-.. automodule:: hazelcast.proxy.lock
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.proxy.map.rst
+++ b/docs/hazelcast.proxy.map.rst
@@ -1,7 +1,6 @@
 Map
 ====
 
-.. automodule:: hazelcast.proxy.map
-    :members:
-    :undoc-members:
-    :show-inheritance:
+.. py:currentmodule:: hazelcast.proxy.map
+
+.. autoclass:: Map

--- a/docs/hazelcast.proxy.multi_map.rst
+++ b/docs/hazelcast.proxy.multi_map.rst
@@ -2,6 +2,3 @@ MultiMap
 ========
 
 .. automodule:: hazelcast.proxy.multi_map
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.proxy.pn_counter.rst
+++ b/docs/hazelcast.proxy.pn_counter.rst
@@ -2,6 +2,3 @@ PNCounter
 =========
 
 .. automodule:: hazelcast.proxy.pn_counter
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.proxy.queue.rst
+++ b/docs/hazelcast.proxy.queue.rst
@@ -2,6 +2,3 @@ Queue
 =====
 
 .. automodule:: hazelcast.proxy.queue
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.proxy.replicated_map.rst
+++ b/docs/hazelcast.proxy.replicated_map.rst
@@ -2,6 +2,3 @@ ReplicatedMap
 =============
 
 .. automodule:: hazelcast.proxy.replicated_map
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.proxy.ringbuffer.rst
+++ b/docs/hazelcast.proxy.ringbuffer.rst
@@ -2,6 +2,3 @@ RingBuffer
 ==========
 
 .. automodule:: hazelcast.proxy.ringbuffer
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.proxy.rst
+++ b/docs/hazelcast.proxy.rst
@@ -3,22 +3,16 @@ Hazelcast Proxies
 
 .. toctree::
 
-   hazelcast.proxy.atomic_long
-   hazelcast.proxy.atomic_reference
    hazelcast.proxy.base
-   hazelcast.proxy.count_down_latch
    hazelcast.proxy.executor
    hazelcast.proxy.flake_id_generator
-   hazelcast.proxy.id_generator
    hazelcast.proxy.list
-   hazelcast.proxy.lock
    hazelcast.proxy.map
    hazelcast.proxy.multi_map
    hazelcast.proxy.queue
    hazelcast.proxy.pn_counter
    hazelcast.proxy.replicated_map
    hazelcast.proxy.ringbuffer
-   hazelcast.proxy.semaphore
    hazelcast.proxy.set
    hazelcast.proxy.topic
    hazelcast.proxy.transactional_list

--- a/docs/hazelcast.proxy.semaphore.rst
+++ b/docs/hazelcast.proxy.semaphore.rst
@@ -1,7 +1,0 @@
-Semaphore
-=========
-
-.. automodule:: hazelcast.proxy.semaphore
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.proxy.set.rst
+++ b/docs/hazelcast.proxy.set.rst
@@ -1,6 +1,3 @@
 Set
 ====
 .. automodule:: hazelcast.proxy.set
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.proxy.topic.rst
+++ b/docs/hazelcast.proxy.topic.rst
@@ -2,6 +2,3 @@ Topic
 =====
 
 .. automodule:: hazelcast.proxy.topic
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.proxy.transactional_list.rst
+++ b/docs/hazelcast.proxy.transactional_list.rst
@@ -2,6 +2,3 @@ TransactionalList
 =================
 
 .. automodule:: hazelcast.proxy.transactional_list
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.proxy.transactional_map.rst
+++ b/docs/hazelcast.proxy.transactional_map.rst
@@ -2,6 +2,3 @@ TransactionalMap
 ================
 
 .. automodule:: hazelcast.proxy.transactional_map
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.proxy.transactional_multi_map.rst
+++ b/docs/hazelcast.proxy.transactional_multi_map.rst
@@ -2,6 +2,3 @@ TransactionalMultiMap
 =====================
 
 .. automodule:: hazelcast.proxy.transactional_multi_map
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.proxy.transactional_queue.rst
+++ b/docs/hazelcast.proxy.transactional_queue.rst
@@ -2,6 +2,3 @@ TransactionalQueue
 ==================
 
 .. automodule:: hazelcast.proxy.transactional_queue
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.proxy.transactional_set.rst
+++ b/docs/hazelcast.proxy.transactional_set.rst
@@ -2,6 +2,3 @@ TransactionalSet
 ================
 
 .. automodule:: hazelcast.proxy.transactional_set
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.reactor.rst
+++ b/docs/hazelcast.reactor.rst
@@ -1,7 +1,0 @@
-Reactor
-=======
-
-.. automodule:: hazelcast.reactor
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.rst
+++ b/docs/hazelcast.rst
@@ -7,21 +7,13 @@ Hazelcast Python Client
     hazelcast.client
     hazelcast.cluster
     hazelcast.config
-    hazelcast.connection
     hazelcast.core
-    hazelcast.discovery
-    hazelcast.exception
+    hazelcast.errors
     hazelcast.future
-    hazelcast.hash
-    hazelcast.invocation
     hazelcast.lifecycle
-    hazelcast.near_cache
     hazelcast.partition
     hazelcast.proxy
-    hazelcast.reactor
     hazelcast.serialization
-    hazelcast.statistics
     hazelcast.transaction
     hazelcast.util
-    hazelcast.version
 

--- a/docs/hazelcast.serialization.api.rst
+++ b/docs/hazelcast.serialization.api.rst
@@ -2,6 +2,3 @@ Serialization API
 =================
 
 .. automodule:: hazelcast.serialization.api
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.serialization.api.rst
+++ b/docs/hazelcast.serialization.api.rst
@@ -1,4 +1,0 @@
-Serialization API
-=================
-
-.. automodule:: hazelcast.serialization.api

--- a/docs/hazelcast.serialization.data.rst
+++ b/docs/hazelcast.serialization.data.rst
@@ -1,4 +1,0 @@
-Data
-====
-
-.. automodule:: hazelcast.serialization.data

--- a/docs/hazelcast.serialization.data.rst
+++ b/docs/hazelcast.serialization.data.rst
@@ -2,6 +2,3 @@ Data
 ====
 
 .. automodule:: hazelcast.serialization.data
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.serialization.rst
+++ b/docs/hazelcast.serialization.rst
@@ -1,7 +1,4 @@
 Serialization
 =============
 
-.. toctree::
-
-   hazelcast.serialization.api
-   hazelcast.serialization.data
+.. automodule:: hazelcast.serialization.api

--- a/docs/hazelcast.statistics.rst
+++ b/docs/hazelcast.statistics.rst
@@ -1,7 +1,0 @@
-Statistics
-==========
-
-.. automodule:: hazelcast.statistics
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.transaction.rst
+++ b/docs/hazelcast.transaction.rst
@@ -2,6 +2,3 @@ Transaction
 ===========
 
 .. automodule:: hazelcast.transaction
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/hazelcast.util.rst
+++ b/docs/hazelcast.util.rst
@@ -1,7 +1,8 @@
 Util
 ====
 
-.. automodule:: hazelcast.util
-    :members:
-    :undoc-members:
-    :show-inheritance:
+.. py:currentmodule:: hazelcast.util
+
+.. autoclass:: LoadBalancer
+.. autoclass:: RoundRobinLB
+.. autoclass:: RandomLB

--- a/docs/hazelcast.version.rst
+++ b/docs/hazelcast.version.rst
@@ -1,7 +1,0 @@
-Version
-=========
-
-.. automodule:: hazelcast.version
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/hazelcast/client.py
+++ b/hazelcast/client.py
@@ -28,7 +28,256 @@ from hazelcast.errors import IllegalStateError
 
 
 class HazelcastClient(object):
-    """Hazelcast Client."""
+    """Hazelcast client instance to access access and manipulate
+    distributed data structures on the Hazelcast clusters.
+
+    Keyword Args:
+        cluster_members (list[str]): Candidate address list that client
+            will use to establish initial connection.
+            By default, set to ``["127.0.0.1"]``.
+        cluster_name (str): Name of the cluster to connect to. The name is
+            sent as part of the the client authentication message and may
+            be verified on the member. By default, set to ``dev``.
+        client_name (str): Name of the client instance. By default,
+            set to ``hz.client_${CLIENT_ID}``, where ``CLIENT_ID`` starts
+            from ``0`` and it is incremented by ``1`` for each new client.
+        connection_timeout (float): Socket timeout value in seconds for
+            client to connect member nodes. Setting this to ``0`` makes
+            the connection blocking. By default, set to ``5.0``.
+        socket_options (list[tuple]): List of socket option tuples. The
+            tuples must contain the parameters passed into the
+            :func:`socket.setsockopt` in the same order.
+        redo_operation (bool): When set to ``True``, the client will redo
+            the operations that were executing on the server in case if the
+            client lost connection. This can happen because of network problems,
+            or simply because the member died. However it is not clear whether
+            the operation was performed or not. For idempotent operations this is
+            harmless, but for non idempotent ones retrying can cause to undesirable
+            effects. Note that the redo can be processed on any member. By default,
+            set to ``False``.
+        smart_routing (bool): Enables smart mode for the client instead of
+            unisocket client. Smart clients send key based operations to owner of
+            the keys. Unisocket clients send all operations to a single node. By
+            default, set to ``True``.
+        ssl_enabled (bool): If it is ``True``, SSL is enabled. By default, set
+            to ``False``.
+        ssl_cafile (str): Absolute path of concatenated CA certificates used to
+            validate server's certificates in PEM format. When SSL is enabled and
+            cafile is not set, a set of default CA certificates from default
+            locations will be used.
+        ssl_certfile (str): Absolute path of the client certificate in PEM format.
+        ssl_keyfile (str): Absolute path of the private key file for the client
+            certificate in the PEM format. If this parameter is ``None``, private
+            key will be taken from the certfile.
+        ssl_password (str|bytes|bytearray|function): Password for decrypting the
+            keyfile if it is encrypted. The password may be a function to call to
+            get the password. It will be called with no arguments, and it should
+            return a string, bytes, or bytearray. If the return value is a string
+            it will be encoded as UTF-8 before using it to decrypt the key.
+            Alternatively a string, bytes, or bytearray value may be supplied
+            directly as the password.
+        ssl_protocol (int): Protocol version used in SSL communication.
+            By default, set to ``SSLProtocol.TLSv1_2``.
+        ssl_ciphers (str): String in the OpenSSL cipher list format to set the
+            available ciphers for sockets. More than one cipher can be set by
+            separating them with a colon.
+        cloud_discovery_token (str): Discovery token of the Hazelcast Cloud cluster.
+            When this value is set, Hazelcast Cloud discovery is enabled.
+        async_start (bool): Enables non-blocking start mode of :class:`HazelcastClient`.
+            When set to ``True``, the client creation will not wait to connect to
+            cluster. The client instance will throw exceptions until it connects to
+            cluster and becomes ready. If set to ``False``, :class:`HazelcastClient`
+            will block until a cluster connection established and it is ready to use
+            the client instance. By default, set to ``False``.
+        reconnect_mode (int): Defines how a client reconnects to cluster after a
+            disconnect. By default, set to ``ReconnectMode.ON``.
+        retry_initial_backoff (float): Wait period in seconds after the first failure
+            before retrying. Must be non-negative. By default, set to ``1.0``.
+        retry_max_backoff (float): Upper bound for the backoff interval in seconds.
+            Must be non-negative. By default, set to ``30.0``.
+        retry_jitter (float): Defines how much to randomize backoffs. At each iteration
+            the calculated back-off is randomized via following method in pseudo-code
+            ``Random(-jitter * current_backoff, jitter * current_backoff)``. Must be
+            in range ``[0.0, 1.0]``. By default, set to ``0.0`` (no randomization).
+        retry_multiplier (float): The factor with which to multiply backoff after a
+            failed retry. Must be greater than or equal to ``1``. By default,
+            set to ``1.0``.
+        cluster_connect_timeout (float): Timeout value in seconds for the client to
+            give up a connection attempt to the cluster. Must be non-negative.
+            By default, set to `20.0`.
+        portable_version (int): Default value for the portable version if the
+            class does not have the :func:`get_portable_version` method. Portable
+            versions are used to differentiate two versions of the
+            :class:`hazelcast.serialization.api.Portable` classes that have added
+            or removed fields, or fields with different types.
+        data_serializable_factories (dict[int, dict[int, class]]): Dictionary of
+            factory id and corresponding
+            :class:`hazelcast.serialization.api.IdentifiedDataSerializable` factories.
+            A factory is simply a dictionary with class id and callable class
+            constructors.
+
+            .. code-block:: python
+
+                FACTORY_ID = 1
+                CLASS_ID = 1
+
+                class SomeSerializable(IdentifiedDataSerializable):
+                    # omitting the implementation
+                    pass
+
+
+                client = HazelcastClient(data_serializable_factories={
+                    FACTORY_ID: {
+                        CLASS_ID: SomeSerializable
+                    }
+                })
+
+        portable_factories (dict[int, dict[int, class]]): Dictionary of
+            factory id and corresponding
+            :class:`hazelcast.serialization.api.Portable` factories.
+            A factory is simply a dictionary with class id and callable class
+            constructors.
+
+            .. code-block:: python
+
+                FACTORY_ID = 2
+                CLASS_ID = 2
+
+                class SomeSerializable(Portable):
+                    # omitting the implementation
+                    pass
+
+
+                client = HazelcastClient(portable_factories={
+                    FACTORY_ID: {
+                        CLASS_ID: SomeSerializable
+                    }
+                })
+
+        class_definitions (list[hazelcast.serialization.portable.classdef.ClassDefinition]):
+            List of all portable class definitions.
+        check_class_definition_errors (bool): When enabled, serialization system
+            will check for class definitions error at start and throw an
+            ``HazelcastSerializationError`` with error definition. By default,
+            set to ``True``.
+        is_big_endian (bool): Defines if big-endian is used as the byte order
+            for the serialization. By default, set to ``True``.
+        default_int_type (int): Defines how the ``int``/``long`` type is
+            represented on the cluster side. By default, it is serialized
+            as ``IntType.INT`` (``32`` bits).
+        global_serializer (hazelcast.serialization.api.StreamSerializer):
+            Defines the global serializer. This serializer
+            is registered as a fallback serializer to handle all other objects
+            if a serializer cannot be located for them.
+        custom_serializers (dict[class, hazelcast.serialization.api.StreamSerializer]):
+            Dictionary of class and the corresponding custom serializers.
+
+            .. code-block:: python
+
+                class SomeClass(object):
+                    # omitting the implementation
+                    pass
+
+
+                class SomeClassSerializer(StreamSerializer):
+                    # omitting the implementation
+                    pass
+
+                client = HazelcastClient(custom_serializers={
+                    SomeClass: SomeClassSerializer
+                })
+
+        near_caches (dict[str, dict[str, any]]): Dictionary of near cache
+            names and the corresponding near cache configurations as a dictionary.
+            The near cache configurations contains the following options.
+            When an option is missing from the configuration, it will be
+            set to its default value.
+
+            - **invalidate_on_change** (bool): Enables cluster-assisted invalidate
+              on change behavior. When set to ``True``, entries are invalidated
+              when they are changed in cluster. By default, set to ``True``.
+            - **in_memory_format** (int): Specifies in which format data will be
+              stored in the Near Cache. By default, set to ``InMemoryFormat.BINARY``.
+            - **time_to_live** (float): Maximum number of seconds that an entry can
+              stay in cache. When not set, entries won't be evicted due
+              to expiration.
+            - **max_idle** (float): Maximum number of seconds that an entry can stay
+              in the Near Cache until it is accessed. When not set, entries won't be
+              evicted due to inactivity.
+            - **eviction_policy** (int): Defines eviction policy configuration.
+              By default, set to ``EvictionPolicy.LRU``.
+            - **eviction_max_size** (int): Defines maximum number of entries kept in
+              the memory before eviction kicks in. By default, set to ``10000``.
+            - **eviction_sampling_count** (int): Number of random entries that are
+              evaluated to see if some of them are already expired. By default,
+              set to ``8``.
+            - **eviction_sampling_pool_size** (int): Size of the pool for eviction
+              candidates. The pool is kept sorted according to the eviction policy.
+              By default, set to ``16``.
+
+        load_balancer (hazelcast.util.LoadBalancer): Load balancer implementation
+            for the client
+        membership_listeners (list[tuple[function, function]]): List of membership
+            listener tuples. Tuples must be of size ``2``. The first element will
+            be the function to be called when a member is added, and the second
+            element will be the function to be called when the member is removed
+            with the :class:`hazelcast.core.MemberInfo` as the only parameter.
+            Any of the elements can be ``None``, but not at the same time.
+        lifecycle_listeners (list[function]): List of lifecycle listeners.
+            Listeners will be called with the new lifecycle state as the only
+            parameter when the client changes lifecycle states.
+        flake_id_generators (dict[str, dict[str, any]]): Dictionary of flake id
+            generator names and the corresponding flake id generator configurations
+            as a dictionary. The flake id generator configurations contains the
+            following options. When an option is missing from the configuration, it
+            will be set to its default value.
+
+            - **prefetch_count** (int): Defines how many IDs are pre-fetched on the
+              background when a new flake id is requested from the cluster. Should
+              be in the range ``1..100000``. By default, set to ``100``.
+            - **prefetch_validity** (float): Defines for how long the pre-fetched IDs
+              can be used. If this time elapsed, a new batch of IDs will be fetched.
+              Time unit is in seconds. By default, set to ``600`` (10 minutes).
+
+              The IDs contain timestamp component, which ensures rough global ordering
+              of IDs. If an ID is assigned to an object that was created much later,
+              it will be much out of order. If you don't care about ordering, set this
+              value to ``0`` for unlimited ID validity.
+
+        labels (list[str]): Labels for the client to be sent to the cluster.
+        heartbeat_interval (float): Time interval between the heartbeats sent by the
+            client to the member nodes in seconds. By default, set to ``5.0``.
+        heartbeat_timeout (float): If there is no message passing between the client
+            and a member within the given time via this property in seconds, the
+            connection will be closed. By default, set to ``60.0``.
+        invocation_timeout (float): When an invocation gets an exception because
+
+            - Member throws an exception.
+            - Connection between the client and member is closed.
+            - Client's heartbeat requests are timed out.
+
+            Time passed since invocation started is compared with this property.
+            If the time is already passed, then the exception is delegated to the user.
+            If not, the invocation is retried. Note that, if invocation gets no exception
+            and it is a long running one, then it will not get any exception, no matter
+            how small this timeout is set. Time unit is in seconds. By default,
+            set to ``120.0``.
+
+        invocation_retry_pause (float): Pause time between each retry cycle of an
+            invocation in seconds. By default, set to ``1.0``.
+        statistics_enabled (bool): When set to ``True``, client statistics collection
+            is enabled. By default, set to ``False``.
+        statistics_period (float): The period in seconds the statistics run.
+        shuffle_member_list (bool): Client shuffles the given member list to prevent
+            all clients to connect to the same node when this property is set to
+            ``True``. When it is set to ``False``, the client tries to connect to
+            the nodes in the given order. By default, set to ``True``.
+        logging_config (dict): The configuration to use as the logging config.
+            It must follow the configuration dictionary schema described in the
+            logging module of the standard library.
+        logging_level (int): Sets the logging level for the default logging
+            configuration. By default, set to ``logging.INFO``.
+    """
 
     _CLIENT_ID = AtomicInteger()
     logger = logging.getLogger("HazelcastClient")

--- a/hazelcast/client.py
+++ b/hazelcast/client.py
@@ -298,7 +298,7 @@ class HazelcastClient(object):
         self._invocation_service = InvocationService(self, self._reactor, self._logger_extras)
         self._address_provider = self._create_address_provider()
         self._internal_partition_service = _InternalPartitionService(self, self._logger_extras)
-        self.partition_service = PartitionService(self._internal_partition_service)
+        self.partition_service = PartitionService(self._internal_partition_service, self._serialization_service)
         self._internal_cluster_service = _InternalClusterService(self, self._logger_extras)
         self.cluster_service = ClusterService(self._internal_cluster_service)
         self._connection_manager = ConnectionManager(self, self._reactor, self._address_provider,

--- a/hazelcast/client.py
+++ b/hazelcast/client.py
@@ -28,9 +28,8 @@ from hazelcast.errors import IllegalStateError
 
 
 class HazelcastClient(object):
-    """
-    Hazelcast Client.
-    """
+    """Hazelcast Client."""
+
     _CLIENT_ID = AtomicInteger()
     logger = logging.getLogger("HazelcastClient")
 
@@ -107,134 +106,163 @@ class HazelcastClient(object):
         self.logger.info("Client started.", extra=self._logger_extras)
 
     def get_executor(self, name):
-        """
-        Creates cluster-wide :class:`~hazelcast.proxy.executor.Executor`.
+        """Creates cluster-wide ExecutorService.
 
-        :param name: (str), name of the Executor proxy.
-        :return: (:class:`~hazelcast.proxy.executor.Executor`), Executor proxy for the given name.
+        Args:
+            name (str): Name of the Executor proxy.
+
+        Returns:
+            hazelcast.proxy.executor.Executor: Executor proxy for the given name.
         """
         return self._proxy_manager.get_or_create(EXECUTOR_SERVICE, name)
 
     def get_flake_id_generator(self, name):
-        """
-        Creates or returns a cluster-wide :class:`~hazelcast.proxy.flake_id_generator.FlakeIdGenerator`.
+        """Creates or returns a cluster-wide FlakeIdGenerator.
 
-        :param name: (str), name of the FlakeIdGenerator proxy.
-        :return: (:class:`~hazelcast.proxy.flake_id_generator.FlakeIdGenerator`), FlakeIdGenerator proxy for the given name
+        Args:
+            name (str): Name of the FlakeIdGenerator proxy.
+
+        Returns:
+            hazelcast.proxy.flake_id_generator.FlakeIdGenerator: FlakeIdGenerator proxy for the given name
+
         """
         return self._proxy_manager.get_or_create(FLAKE_ID_GENERATOR_SERVICE, name)
 
     def get_queue(self, name):
-        """
-        Returns the distributed queue instance with the specified name.
+        """Returns the distributed queue instance with the specified name.
 
-        :param name: (str), name of the distributed queue.
-        :return: (:class:`~hazelcast.proxy.queue.Queue`), distributed queue instance with the specified name.
+        Args:
+            name (str): Name of the distributed queue.
+
+        Returns:
+            hazelcast.proxy.queue.Queue: Distributed queue instance with the specified name.
         """
         return self._proxy_manager.get_or_create(QUEUE_SERVICE, name)
 
     def get_list(self, name):
-        """
-        Returns the distributed list instance with the specified name.
+        """Returns the distributed list instance with the specified name.
 
-        :param name: (str), name of the distributed list.
-        :return: (:class:`~hazelcast.proxy.list.List`), distributed list instance with the specified name.
+        Args:
+            name (str): Name of the distributed list.
+
+        Returns:
+            hazelcast.proxy.list.List: Distributed list instance with the specified name.
         """
         return self._proxy_manager.get_or_create(LIST_SERVICE, name)
 
     def get_map(self, name):
-        """
-        Returns the distributed map instance with the specified name.
+        """Returns the distributed map instance with the specified name.
 
-        :param name: (str), name of the distributed map.
-        :return: (:class:`~hazelcast.proxy.map.Map`), distributed map instance with the specified name.
+        Args:
+            name (str): Name of the distributed map.
+
+        Returns:
+            hazelcast.proxy.map.Map: Distributed map instance with the specified name.
         """
         return self._proxy_manager.get_or_create(MAP_SERVICE, name)
 
     def get_multi_map(self, name):
-        """
-        Returns the distributed MultiMap instance with the specified name.
+        """Returns the distributed MultiMap instance with the specified name.
 
-        :param name: (str), name of the distributed MultiMap.
-        :return: (:class:`~hazelcast.proxy.multi_map.MultiMap`), distributed MultiMap instance with the specified name.
+        Args:
+            name (str): Name of the distributed MultiMap.
+
+        Returns:
+            hazelcast.proxy.multi_map.MultiMap: Distributed MultiMap instance with the specified name.
         """
         return self._proxy_manager.get_or_create(MULTI_MAP_SERVICE, name)
 
     def get_pn_counter(self, name):
-        """
-        Returns the PN Counter instance with the specified name.
+        """Returns the PN Counter instance with the specified name.
 
-        :param name: (str), name of the PN Counter.
-        :return: (:class:`~hazelcast.proxy.pn_counter.PNCounter`), the PN Counter.
+        Args:
+            name (str): Name of the PN Counter.
+
+        Returns:
+            hazelcast.proxy.pn_counter.PNCounter: The PN Counter.
         """
         return self._proxy_manager.get_or_create(PN_COUNTER_SERVICE, name)
 
     def get_reliable_topic(self, name):
-        """
-        Returns the :class:`~hazelcast.proxy.reliable_topic.ReliableTopic` instance with the specified name.
+        """Returns the ReliableTopic instance with the specified name.
 
-        :param name: (str), name of the ReliableTopic.
-        :return: (:class:`~hazelcast.proxy.reliable_topic.ReliableTopic`), the ReliableTopic.
+        Args:
+            name (str): Name of the ReliableTopic.
+
+        Returns:
+            hazelcast.proxy.reliable_topic.ReliableTopic: The ReliableTopic.
         """
         return self._proxy_manager.get_or_create(RELIABLE_TOPIC_SERVICE, name)
 
     def get_replicated_map(self, name):
-        """
-        Returns the distributed ReplicatedMap instance with the specified name.
+        """Returns the distributed ReplicatedMap instance with the specified name.
 
-        :param name: (str), name of the distributed ReplicatedMap.
-        :return: (:class:`~hazelcast.proxy.replicated_map.ReplicatedMap`), distributed ReplicatedMap instance with the specified name.
+        Args:
+            name (str): Name of the distributed ReplicatedMap.
+
+        Returns:
+            hazelcast.proxy.replicated_map.ReplicatedMap: Distributed ReplicatedMap instance with the specified name.
         """
         return self._proxy_manager.get_or_create(REPLICATED_MAP_SERVICE, name)
 
     def get_ringbuffer(self, name):
-        """
-        Returns the distributed RingBuffer instance with the specified name.
+        """Returns the distributed Ringbuffer instance with the specified name.
 
-        :param name: (str), name of the distributed RingBuffer.
-        :return: (:class:`~hazelcast.proxy.ringbuffer.RingBuffer`), distributed RingBuffer instance with the specified name.
+        Args:
+            name (str): Name of the distributed Ringbuffer.
+
+        Returns:
+            hazelcast.proxy.ringbuffer.Ringbuffer: Distributed RingBuffer instance with the specified name.
         """
 
         return self._proxy_manager.get_or_create(RINGBUFFER_SERVICE, name)
 
     def get_set(self, name):
-        """
-        Returns the distributed Set instance with the specified name.
+        """Returns the distributed Set instance with the specified name.
 
-        :param name: (str), name of the distributed Set.
-        :return: (:class:`~hazelcast.proxy.set.Set`), distributed Set instance with the specified name.
+        Args:
+            name (str): Name of the distributed Set.
+
+        Returns:
+            hazelcast.proxy.set.Set: Distributed Set instance with the specified name.
         """
         return self._proxy_manager.get_or_create(SET_SERVICE, name)
 
     def get_topic(self, name):
-        """
-        Returns the :class:`~hazelcast.proxy.topic.Topic` instance with the specified name.
+        """Returns the Topic instance with the specified name.
 
-        :param name: (str), name of the Topic.
-        :return: (:class:`~hazelcast.proxy.topic.Topic`), the Topic.
+        Args:
+            name (str): Name of the Topic.
+
+        Returns:
+            hazelcast.proxy.topic.Topic: The Topic.
         """
         return self._proxy_manager.get_or_create(TOPIC_SERVICE, name)
 
     def new_transaction(self, timeout=120, durability=1, type=TWO_PHASE):
-        """
-        Creates a new :class:`~hazelcast.transaction.Transaction` associated with the current thread using default or given options.
+        """Creates a new Transaction associated with the current thread using default or given options.
 
-        :param timeout: (long), the timeout in seconds determines the maximum lifespan of a transaction. So if a
-            transaction is configured with a timeout of 2 minutes, then it will automatically rollback if it hasn't
-            committed yet.
-        :param durability: (int), the durability is the number of machines that can take over if a member fails during a
-        transaction commit or rollback
-        :param type: (Transaction Type), the transaction type which can be :const:`~hazelcast.transaction.TWO_PHASE` or :const:`~hazelcast.transaction.ONE_PHASE`
-        :return: (:class:`~hazelcast.transaction.Transaction`), new Transaction associated with the current thread.
+        Args:
+            timeout (int): The timeout in seconds determines the maximum lifespan of a transaction. So if a
+                transaction is configured with a timeout of 2 minutes, then it will automatically rollback if it hasn't
+                committed yet.
+            durability (int): The durability is the number of machines that can take over if a member fails during a
+                transaction commit or rollback.
+            type (int): The transaction type which can be ``TWO_PHASE`` or ``ONE_PHASE``.
+
+        Returns:
+            hazelcast.transaction.Transaction: New Transaction associated with the current thread.
         """
         return self._transaction_manager.new_transaction(timeout, durability, type)
 
     def add_distributed_object_listener(self, listener_func):
-        """
-        Adds a listener which will be notified when a
-        new distributed object is created or destroyed.
-        :param listener_func: Function to be called when a distributed object is created or destroyed.
-        :return: (str), a registration id which is used as a key to remove the listener.
+        """Adds a listener which will be notified when a new distributed object is created or destroyed.
+
+        Args:
+            listener_func (function): Function to be called when a distributed object is created or destroyed.
+
+        Returns:
+            str: A registration id which is used as a key to remove the listener.
         """
         is_smart = self.config.smart_routing
         request = client_add_distributed_object_listener_codec.encode_request(is_smart)
@@ -256,18 +284,25 @@ class HazelcastClient(object):
                                                         encode_remove_listener, event_handler)
 
     def remove_distributed_object_listener(self, registration_id):
-        """
-        Removes the specified distributed object listener. Returns silently if there is no such listener added before.
-        :param registration_id: (str), id of registered listener.
-        :return: (bool), ``true`` if registration is removed, ``false`` otherwise.
+        """Removes the specified distributed object listener.
+
+        Returns silently if there is no such listener added before.
+
+        Args:
+            registration_id (str): The id of registered listener.
+
+        Returns:
+            bool: ``True`` if registration is removed, ``False`` otherwise.
         """
         return self._listener_service.deregister_listener(registration_id)
 
     def get_distributed_objects(self):
-        """
-        Returns all distributed objects such as; queue, map, set, list, topic, lock, multimap.
+        """Returns all distributed objects such as; queue, map, set, list, topic, lock, multimap.
+
         Also, as a side effect, it clears the local instances of the destroyed proxies.
-        :return:(Sequence), List of instances created by Hazelcast.
+
+        Returns:
+            list[hazelcast.proxy.base.Proxy]: List of instances created by Hazelcast.
         """
         request = client_get_distributed_objects_codec.encode_request()
         invocation = Invocation(request, response_handler=lambda m: m)
@@ -289,9 +324,7 @@ class HazelcastClient(object):
         return self._proxy_manager.get_distributed_objects()
 
     def shutdown(self):
-        """
-        Shuts down this HazelcastClient.
-        """
+        """Shuts down this HazelcastClient."""
         with self._shutdown_lock:
             if self._internal_lifecycle_service.running:
                 self._internal_lifecycle_service.fire_lifecycle_event(LifecycleState.SHUTTING_DOWN)

--- a/hazelcast/cluster.py
+++ b/hazelcast/cluster.py
@@ -263,10 +263,12 @@ class _InternalClusterService(object):
 class VectorClock(object):
     """Vector clock consisting of distinct replica logical clocks.
     
-    See https://en.wikipedia.org/wiki/Vector_clock
     The vector clock may be read from different thread but concurrent
     updates must be synchronized externally. There is no guarantee for
     concurrent updates.
+
+    See Also:
+        https://en.wikipedia.org/wiki/Vector_clock
     """
 
     def __init__(self):

--- a/hazelcast/cluster.py
+++ b/hazelcast/cluster.py
@@ -17,24 +17,22 @@ class _MemberListSnapshot(object):
 
 
 class ClientInfo(object):
-    """
-    Local information of the client.
+    """Local information of the client.
+
+    Attributes:
+        uuid (uuid.UUID): Unique id of this client instance.
+        address (hazelcast.core.Address): Local address that is used to communicate with cluster.
+        name (str): Name of the client.
+        labels (set[str]): Read-only set of all labels of this client.
     """
 
     __slots__ = ("uuid", "address", "name", "labels")
 
     def __init__(self, client_uuid, address, name, labels):
         self.uuid = client_uuid
-        """Unique id of this client instance."""
-
         self.address = address
-        """Local address that is used to communicate with cluster."""
-
         self.name = name
-        """Name of the client."""
-
         self.labels = labels
-        """Read-only set of all labels of this client."""
 
     def __repr__(self):
         return "ClientInfo(uuid=%s, address=%s, name=%s, labels=%s)" % (self.uuid, self.address, self.name, self.labels)
@@ -63,15 +61,13 @@ class ClusterService(object):
         There is no check for duplicate registrations, so if you register the listener
         twice, it will get events twice.
 
-        :param member_added: Function to be called when a member is added to the cluster.
-        :type member_added: function
-        :param member_removed: Function to be called when a member is removed from the cluster.
-        :type member_removed: function
-        :param fire_for_existing: Whether or not fire member_added for existing members.
-        :type fire_for_existing: bool
+        Args:
+            member_added (function): Function to be called when a member is added to the cluster.
+            member_removed (function): Function to be called when a member is removed from the cluster.
+            fire_for_existing (bool): Whether or not fire member_added for existing members.
 
-        :return: Registration id of the listener which will be used for removing this listener.
-        :rtype: str
+        Returns:
+            str: Registration id of the listener which will be used for removing this listener.
         """
         return self._service.add_listener(member_added, member_removed, fire_for_existing)
 
@@ -79,11 +75,11 @@ class ClusterService(object):
         """
         Removes the specified membership listener.
 
-        :param registration_id: Registration id of the listener to be removed.
-        :type registration_id: str
+        Args:
+            registration_id (str): Registration id of the listener to be removed.
 
-        :return: ``True`` if the registration is removed, ``False`` otherwise.
-        :rtype: bool
+        Returns:
+            bool: ``True`` if the registration is removed, ``False`` otherwise.
         """
         return self._service.remove_listener(registration_id)
 
@@ -94,12 +90,12 @@ class ClusterService(object):
         Every member in the cluster returns the members in the same order.
         To obtain the oldest member in the cluster, you can retrieve the first item in the list.
 
-        :param member_selector: Function to filter members to return.
-            If not provided, the returned list will contain all the available cluster members.
-        :type member_selector: function
+        Args:
+            member_selector (function): Function to filter members to return.
+                If not provided, the returned list will contain all the available cluster members.
 
-        :return: Current members in the cluster
-        :rtype: list[:class:`~hazelcast.core.MemberInfo`]
+        Returns:
+            list[hazelcast.core.MemberInfo]: Current members in the cluster
         """
         return self._service.get_members(member_selector)
 
@@ -140,18 +136,16 @@ class _InternalClusterService(object):
 
     def size(self):
         """
-        Returns the size of the cluster.
-
-        :return: (int), size of the cluster.
+        Returns:
+            int: Size of the cluster.
         """
         snapshot = self._member_list_snapshot
         return len(snapshot.members)
 
     def get_local_client(self):
         """
-        Returns the info representing the local client.
-
-        :return: (:class: `~hazelcast.cluster.ClientInfo`), client info
+        Returns:
+            hazelcast.cluster.ClientInfo: The client info.
         """
         connection_manager = self._connection_manager
         connection = connection_manager.get_random_connection()
@@ -170,12 +164,6 @@ class _InternalClusterService(object):
         return registration_id
 
     def remove_listener(self, registration_id):
-        """
-        Removes the specified membership listener.
-
-        :param registration_id: (str), registration id of the listener to be deleted.
-        :return: (bool), if the registration is removed, ``false`` otherwise.
-        """
         try:
             self._listeners.pop(registration_id)
             return True
@@ -183,11 +171,12 @@ class _InternalClusterService(object):
             return False
 
     def wait_initial_member_list_fetched(self):
-        """
-        Blocks until the initial member list is fetched from the cluster.
+        """Blocks until the initial member list is fetched from the cluster.
+
         If it is not received within the timeout, an error is raised.
 
-        :raises IllegalStateError: If the member list could not be fetched
+        Raises:
+            IllegalStateError: If the member list could not be fetched
         """
         fetched = self._initial_list_fetched.wait(_INITIAL_MEMBERS_TIMEOUT_SECONDS)
         if not fetched:
@@ -272,9 +261,8 @@ class _InternalClusterService(object):
 
 
 class VectorClock(object):
-    """
-    Vector clock consisting of distinct replica logical clocks.
-
+    """Vector clock consisting of distinct replica logical clocks.
+    
     See https://en.wikipedia.org/wiki/Vector_clock
     The vector clock may be read from different thread but concurrent
     updates must be synchronized externally. There is no guarantee for
@@ -285,13 +273,15 @@ class VectorClock(object):
         self._replica_timestamps = {}
 
     def is_after(self, other):
-        """
-        Returns true if this vector clock is causally strictly after the
+        """Returns ``True`` if this vector clock is causally strictly after the
         provided vector clock. This means that it the provided clock is neither
         equal to, greater than or concurrent to this vector clock.
 
-        :param other: (:class:`~hazelcast.cluster.VectorClock`), Vector clock to be compared
-        :return: (bool), True if this vector clock is strictly after the other vector clock, False otherwise
+        Args:
+            other (hazelcast.cluster.VectorClock): Vector clock to be compared
+
+        Returns:
+            bool: ``True`` if this vector clock is strictly after the other vector clock, ``False`` otherwise.
         """
         any_timestamp_greater = False
         for replica_id, other_timestamp in other.entry_set():
@@ -306,29 +296,28 @@ class VectorClock(object):
         return any_timestamp_greater or other.size() < self.size()
 
     def set_replica_timestamp(self, replica_id, timestamp):
-        """
-        Sets the logical timestamp for the given replica ID.
+        """Sets the logical timestamp for the given replica ID.
 
-        :param replica_id: (str), Replica ID.
-        :param timestamp: (int), Timestamp for the given replica ID.
+        Args:
+            replica_id (str): Replica ID.
+            timestamp (int): Timestamp for the given replica ID.
         """
         self._replica_timestamps[replica_id] = timestamp
 
     def entry_set(self):
-        """
-        Returns the entry set of the replica timestamps in a format
-        of list of tuples. Each tuple contains the replica ID and the
-        timestamp associated with it.
+        """Returns the entry set of the replica timestamps in a format of list of tuples.
 
-        :return: (list), List of tuples.
+        Each tuple contains the replica ID and the timestamp associated with it.
+        
+        Returns:
+            list: List of tuples.
         """
         return list(self._replica_timestamps.items())
 
     def size(self):
-        """
-        Returns the number of timestamps that are in the
-        replica timestamps dictionary.
-
-        :return: (int), Number of timestamps in the replica timestamps.
+        """Returns the number of timestamps that are in the replica timestamps dictionary.
+        
+        Returns:
+            int: Number of timestamps in the replica timestamps.
         """
         return len(self._replica_timestamps)

--- a/hazelcast/config.py
+++ b/hazelcast/config.py
@@ -9,10 +9,9 @@ from hazelcast import six
 from hazelcast.errors import InvalidConfigurationError
 from hazelcast.serialization.api import StreamSerializer, IdentifiedDataSerializable, Portable
 from hazelcast.serialization.portable.classdef import ClassDefinition
-from hazelcast.util import check_not_none, with_reversed_items, number_types, LoadBalancer, none_type
+from hazelcast.util import check_not_none, number_types, LoadBalancer, none_type, get_attr_name
 
 
-@with_reversed_items
 class IntType(object):
     """Integer type options that can be used by serialization service."""
 
@@ -53,7 +52,6 @@ class IntType(object):
     """
 
 
-@with_reversed_items
 class EvictionPolicy(object):
     """Near Cache eviction policy options."""
 
@@ -78,7 +76,6 @@ class EvictionPolicy(object):
     """
 
 
-@with_reversed_items
 class InMemoryFormat(object):
     """Near Cache in memory format of the values."""
 
@@ -93,7 +90,6 @@ class InMemoryFormat(object):
     """
 
 
-@with_reversed_items
 class SSLProtocol(object):
     """SSL protocol options.
 
@@ -132,7 +128,6 @@ class SSLProtocol(object):
     """
 
 
-@with_reversed_items
 class QueryConstants(object):
     """Contains constants for Query."""
 
@@ -147,7 +142,6 @@ class QueryConstants(object):
     """
 
 
-@with_reversed_items
 class UniqueKeyTransformation(object):
     """Defines an assortment of transformations which can be applied to unique key values."""
 
@@ -171,7 +165,6 @@ class UniqueKeyTransformation(object):
     """
 
 
-@with_reversed_items
 class IndexType(object):
     """Type of the index."""
 
@@ -191,7 +184,6 @@ class IndexType(object):
     """
 
 
-@with_reversed_items
 class ReconnectMode(object):
     """Reconnect options."""
 
@@ -229,7 +221,7 @@ class BitmapIndexOptions(object):
 
     @unique_key.setter
     def unique_key(self, value):
-        if value in QueryConstants.reverse:
+        if get_attr_name(QueryConstants, value):
             self._unique_key = value
         else:
             raise TypeError("unique_key must be of type QueryConstants")
@@ -240,7 +232,7 @@ class BitmapIndexOptions(object):
     
     @unique_key_transformation.setter
     def unique_key_transformation(self, value):
-        if value in UniqueKeyTransformation.reverse:
+        if get_attr_name(UniqueKeyTransformation, value):
             self._unique_key_transformation = value
         else:
             raise TypeError("unique_key_transformation must be of type UniqueKeyTransformation")
@@ -301,7 +293,7 @@ class IndexConfig(object):
 
     @type.setter
     def type(self, value):
-        if value in IndexType.reverse:
+        if get_attr_name(IndexType, value):
             self._type = value
         else:
             raise TypeError("type must be of type IndexType")
@@ -667,7 +659,7 @@ class _Config(object):
 
     @ssl_protocol.setter
     def ssl_protocol(self, value):
-        if value in SSLProtocol.reverse:
+        if get_attr_name(SSLProtocol, value):
             self._ssl_protocol = value
         else:
             raise TypeError("ssl_protocol must be of type SSLProtocol")
@@ -711,7 +703,7 @@ class _Config(object):
 
     @reconnect_mode.setter
     def reconnect_mode(self, value):
-        if value in ReconnectMode.reverse:
+        if get_attr_name(ReconnectMode, value):
             self._reconnect_mode = value
         else:
             raise TypeError("reconnect_mode must be a type of ReconnectMode")
@@ -889,7 +881,7 @@ class _Config(object):
 
     @default_int_type.setter
     def default_int_type(self, value):
-        if value in IntType.reverse:
+        if get_attr_name(IntType, value):
             self._default_int_type = value
         else:
             raise TypeError("default_int_type must be of type IntType")
@@ -1183,7 +1175,7 @@ class _NearCacheConfig(object):
 
     @in_memory_format.setter
     def in_memory_format(self, value):
-        if value in InMemoryFormat.reverse:
+        if get_attr_name(InMemoryFormat, value):
             self._in_memory_format = value
         else:
             raise TypeError("in_memory_format must be of the type InMemoryFormat")
@@ -1220,7 +1212,7 @@ class _NearCacheConfig(object):
 
     @eviction_policy.setter
     def eviction_policy(self, value):
-        if value in EvictionPolicy.reverse:
+        if get_attr_name(EvictionPolicy, value):
             self._eviction_policy = value
         else:
             raise TypeError("eviction_policy must be of type EvictionPolicy")

--- a/hazelcast/config.py
+++ b/hazelcast/config.py
@@ -14,9 +14,8 @@ from hazelcast.util import check_not_none, with_reversed_items, number_types, Lo
 
 @with_reversed_items
 class IntType(object):
-    """
-    Integer type options that can be used by serialization service.
-    """
+    """Integer type options that can be used by serialization service."""
+
     VAR = 0
     """
     Integer types will be serialized as 8, 16, 32, 64 bit integers
@@ -56,9 +55,7 @@ class IntType(object):
 
 @with_reversed_items
 class EvictionPolicy(object):
-    """
-    Near Cache eviction policy options.
-    """
+    """Near Cache eviction policy options."""
 
     NONE = 0
     """
@@ -83,9 +80,7 @@ class EvictionPolicy(object):
 
 @with_reversed_items
 class InMemoryFormat(object):
-    """
-    Near Cache in memory format of the values.
-    """
+    """Near Cache in memory format of the values."""
 
     BINARY = 0
     """
@@ -100,8 +95,7 @@ class InMemoryFormat(object):
 
 @with_reversed_items
 class SSLProtocol(object):
-    """
-    SSL protocol options.
+    """SSL protocol options.
 
     TLSv1+ requires at least Python 2.7.9 or Python 3.4 build with OpenSSL 1.0.1+
     TLSv1_3 requires at least Python 2.7.15 or Python 3.7 build with OpenSSL 1.1.1+
@@ -140,9 +134,7 @@ class SSLProtocol(object):
 
 @with_reversed_items
 class QueryConstants(object):
-    """
-    Contains constants for Query.
-    """
+    """Contains constants for Query."""
 
     KEY_ATTRIBUTE_NAME = "__key"
     """
@@ -157,10 +149,7 @@ class QueryConstants(object):
 
 @with_reversed_items
 class UniqueKeyTransformation(object):
-    """
-    Defines an assortment of transformations which can be applied to
-    unique key values.
-    """
+    """Defines an assortment of transformations which can be applied to unique key values."""
 
     OBJECT = 0
     """
@@ -184,9 +173,7 @@ class UniqueKeyTransformation(object):
 
 @with_reversed_items
 class IndexType(object):
-    """
-    Type of the index.
-    """
+    """Type of the index."""
 
     SORTED = 0
     """
@@ -206,9 +193,7 @@ class IndexType(object):
 
 @with_reversed_items
 class ReconnectMode(object):
-    """
-    Reconnect options.
-    """
+    """Reconnect options."""
 
     OFF = 0
     """

--- a/hazelcast/connection.py
+++ b/hazelcast/connection.py
@@ -73,9 +73,7 @@ class _AuthenticationStatus(object):
 
 
 class ConnectionManager(object):
-    """
-    ConnectionManager is responsible for managing :mod:`Connection` objects.
-    """
+    """ConnectionManager is responsible for managing ``Connection`` objects."""
     logger = logging.getLogger("HazelcastClient.ConnectionManager")
 
     def __init__(self, client, reactor, address_provider, lifecycle_service,
@@ -112,12 +110,13 @@ class ConnectionManager(object):
         self._load_balancer = None
 
     def add_listener(self, on_connection_opened=None, on_connection_closed=None):
-        """
-        Registers a ConnectionListener. If the same listener is registered multiple times, it will be notified multiple
-        times.
+        """Registers a ConnectionListener.
 
-        :param on_connection_opened: (Function), function to be called when a connection is opened.
-        :param on_connection_closed: (Function), function to be called when a connection is removed.
+        If the same listener is registered multiple times, it will be notified multiple times.
+
+        Args:
+            on_connection_opened (function): Function to be called when a connection is opened. (Default value = None)
+            on_connection_closed (function): Function to be called when a connection is removed. (Default value = None)
         """
         self._connection_listeners.append((on_connection_opened, on_connection_closed))
 
@@ -505,9 +504,7 @@ class _HeartbeatManager(object):
         self._heartbeat_interval = config.heartbeat_interval
 
     def start(self):
-        """
-        Starts sending periodic HeartBeat operations.
-        """
+        """Starts sending periodic HeartBeat operations."""
 
         def _heartbeat():
             if not self._connection_manager.live:
@@ -521,9 +518,7 @@ class _HeartbeatManager(object):
         self._heartbeat_timer = self._reactor.add_timer(self._heartbeat_interval, _heartbeat)
 
     def shutdown(self):
-        """
-        Stops HeartBeat operations.
-        """
+        """Stops HeartBeat operations."""
         if self._heartbeat_timer:
             self._heartbeat_timer.cancel()
 
@@ -622,9 +617,7 @@ class _Reader(object):
 
 
 class Connection(object):
-    """
-    Connection object which stores connection related information and operations.
-    """
+    """Connection object which stores connection related information and operations."""
 
     def __init__(self, connection_manager, connection_id, message_callback, logger_extras=None):
         self.remote_address = None
@@ -646,11 +639,13 @@ class Connection(object):
         self._reader = _Reader(self._builder)
 
     def send_message(self, message):
-        """
-        Sends a message to this connection.
+        """Sends a message to this connection.
 
-        :param message: (Message), message to be sent to this connection.
-        :return: (bool),
+        Args:
+            message (hazelcast.protocol.client_message.OutboundMessage): Message to be sent to this connection.
+
+        Returns:
+            bool: ``True`` if the message is written to the socket, ``False`` otherwise.
         """
         if not self.live:
             return False
@@ -659,11 +654,11 @@ class Connection(object):
         return True
 
     def close(self, reason, cause):
-        """
-        Closes the connection.
+        """Closes the connection.
 
-        :param reason: (str), The reason this connection is going to be closed. Is allowed to be None.
-        :param cause: (Exception), The exception responsible for closing this connection. Is allowed to be None.
+        Args:
+            reason (str): The reason this connection is going to be closed. Is allowed to be None.
+            cause (Exception): The exception responsible for closing this connection. Is allowed to be None.
         """
         if not self.live:
             return
@@ -707,8 +702,8 @@ class Connection(object):
 
 
 class DefaultAddressProvider(object):
-    """
-    Provides initial addresses for client to find and connect to a node.
+    """Provides initial addresses for client to find and connect to a node.
+
     It also provides a no-op translator.
     """
 
@@ -716,9 +711,7 @@ class DefaultAddressProvider(object):
         self._addresses = addresses
 
     def load_addresses(self):
-        """
-        :return: (Tuple), The possible primary and secondary member addresses to connect to.
-        """
+        """Returns the possible primary and secondary member addresses to connect to."""
         configured_addresses = self._addresses
 
         if not configured_addresses:
@@ -734,8 +727,8 @@ class DefaultAddressProvider(object):
         return primaries, secondaries
 
     def translate(self, address):
-        """
-        No-op address translator. It is there to provide the same API
-        with other address providers.
+        """No-op address translator.
+
+        It is there to provide the same API with other address providers.
         """
         return address

--- a/hazelcast/core.py
+++ b/hazelcast/core.py
@@ -7,18 +7,38 @@ from hazelcast.util import with_reversed_items
 
 
 class MemberInfo(object):
-    __slots__ = ("address", "uuid", "attributes", "lite_member", "version")
-
     """
     Represents a member in the cluster with its address, uuid, lite member status, attributes and version.
     """
 
+    __slots__ = ("address", "uuid", "attributes", "lite_member", "version")
+
     def __init__(self, address, uuid, attributes, lite_member, version, *_):
         self.address = address
+        """
+        hazelcast.core.Address: Address of the member.
+        """
+
         self.uuid = uuid
+        """
+        uuid.UUID: UUID of the member.
+        """
+
         self.attributes = attributes
+        """
+        dict[str, str]: Configured attributes of the member.
+        """
+
         self.lite_member = lite_member
+        """
+        bool: ``True`` if the member is a lite member, ``False`` otherwise.
+        Lite members do not own any partition.
+        """
+
         self.version = version
+        """
+        hazelcast.core.MemberVersion: Hazelcast codebase version of the member.
+        """
 
     def __str__(self):
         return "Member [%s]:%s - %s" % (self.address.host, self.address.port, self.uuid)
@@ -98,8 +118,6 @@ class AddressHelper(object):
 
 
 class DistributedObjectInfo(object):
-    """Represents name of the Distributed Object and the name of service which it belongs to."""
-
     def __init__(self, service_name, name):
         self.service_name = service_name
         self.name = name
@@ -136,9 +154,24 @@ class DistributedObjectEvent(object):
 
     def __init__(self, name, service_name, event_type, source):
         self.name = name
+        """
+        str: Name of the distributed object.
+        """
+
         self.service_name = service_name
+        """
+        str: Service name of the distributed object.
+        """
+
         self.event_type = DistributedObjectEventType.reverse.get(event_type, event_type)
+        """
+        str: Event type. Either ``CREATED`` or ``DESTROYED``.
+        """
+
         self.source = source
+        """
+        uuid.UUID: UUID of the member that fired the event.
+        """
 
     def __repr__(self):
         return "DistributedObjectEvent(name=%s, service_name=%s, event_type=%s, source=%s)" \
@@ -161,52 +194,52 @@ class SimpleEntryView(object):
 
         self.cost = cost
         """
-        The cost in bytes of the entry.
+        int: The cost in bytes of the entry.
         """
 
         self.creation_time = creation_time
         """
-        The creation time of the entry.
+        int: The creation time of the entry.
         """
 
         self.expiration_time = expiration_time
         """
-        The expiration time of the entry.
+        int: The expiration time of the entry.
         """
 
         self.hits = hits
         """
-        Number of hits of the entry.
+        int: Number of hits of the entry.
         """
 
         self.last_access_time = last_access_time
         """
-        The last access time for the entry.
+        int: The last access time for the entry.
         """
 
         self.last_stored_time = last_stored_time
         """
-        The last store time for the value.
+        int: The last store time for the value.
         """
 
         self.last_update_time = last_update_time
         """
-        The last time the value was updated.
+        int: The last time the value was updated.
         """
 
         self.version = version
         """
-        The version of the entry.
+        int: The version of the entry.
         """
 
         self.ttl = ttl
         """
-        The last set time to live milliseconds.
+        int: The last set time to live milliseconds.
         """
 
         self.max_idle = max_idle
         """
-        The last set max idle time in milliseconds.
+        int: The last set max idle time in milliseconds.
         """
 
     def __repr__(self):
@@ -275,6 +308,10 @@ class HazelcastJsonValue(object):
 
 
 class MemberVersion(object):
+    """
+    Determines the Hazelcast codebase version in terms of major.minor.patch version.
+    """
+
     __slots__ = ("major", "minor", "patch")
 
     def __init__(self, major, minor, patch):

--- a/hazelcast/core.py
+++ b/hazelcast/core.py
@@ -38,9 +38,7 @@ class MemberInfo(object):
 
 
 class Address(object):
-    """
-    Represents an address of a member in the cluster.
-    """
+    """Represents an address of a member in the cluster."""
 
     def __init__(self, host, port):
         self.host = host
@@ -100,9 +98,7 @@ class AddressHelper(object):
 
 
 class DistributedObjectInfo(object):
-    """
-    Represents name of the Distributed Object and the name of service which it belongs to.
-    """
+    """Represents name of the Distributed Object and the name of service which it belongs to."""
 
     def __init__(self, service_name, name):
         self.service_name = service_name
@@ -122,9 +118,7 @@ class DistributedObjectInfo(object):
 
 @with_reversed_items
 class DistributedObjectEventType(object):
-    """
-    Type of the distributed object event.
-    """
+    """Type of the distributed object event."""
 
     CREATED = "CREATED"
     """
@@ -138,9 +132,7 @@ class DistributedObjectEventType(object):
 
 
 class DistributedObjectEvent(object):
-    """
-    Distributed Object Event
-    """
+    """Distributed Object Event"""
 
     def __init__(self, name, service_name, event_type, source):
         self.name = name
@@ -154,9 +146,7 @@ class DistributedObjectEvent(object):
 
 
 class SimpleEntryView(object):
-    """
-    EntryView represents a readonly view of a map entry.
-    """
+    """EntryView represents a readonly view of a map entry."""
     def __init__(self, key, value, cost, creation_time, expiration_time, hits, last_access_time,
                  last_stored_time, last_update_time, version, ttl, max_idle):
         self.key = key
@@ -228,52 +218,28 @@ class SimpleEntryView(object):
                   self.ttl, self.max_idle)
 
 
-class MemberSelector(object):
-    """
-    Subclasses of this class select members
-    that are capable of executing a special kind of task.
-    The select(Member) method is called for every available
-    member in the cluster and it is up to the implementation to decide
-    if the member is going to be used or not.
-    """
-
-    def select(self, member):
-        """
-        Decides if the given member will be part of an operation or not.
-
-        :param member: (:class:`~hazelcast.core.Member`), the member instance to decide upon.
-        :return: (bool), True if the member should take part in the operation, False otherwise.
-        """
-        raise NotImplementedError()
-
-
-class DataMemberSelector(MemberSelector):
-    def select(self, member):
-        return not member.is_lite_member
-
-
 class HazelcastJsonValue(object):
-    """
-    HazelcastJsonValue is a wrapper for JSON formatted strings. It is preferred
-    to store HazelcastJsonValue instead of Strings for JSON formatted strings.
+    """HazelcastJsonValue is a wrapper for JSON formatted strings.
+
+    It is preferred to store HazelcastJsonValue instead of Strings for JSON formatted strings.
     Users can run predicates and use indexes on the attributes of the underlying
     JSON strings.
-
+    
     HazelcastJsonValue is queried using Hazelcast's querying language.
     See `Distributed Query section <https://github.com/hazelcast/hazelcast-python-client#77-distributed-query>`_.
-
+    
     In terms of querying, numbers in JSON strings are treated as either
     Long or Double in the Java side. str, bool and None
     are treated as String, boolean and null respectively.
-
+    
     HazelcastJsonValue keeps given string as it is. Strings are not
     checked for being valid. Ill-formatted JSON strings may cause false
     positive or false negative results in queries.
-
+    
     HazelcastJsonValue can also be constructed from JSON serializable objects.
     In that case, objects are converted to JSON strings and stored as such.
     If an error occurs during the conversion, it is raised directly.
-
+    
     None values are not allowed.
     """
 
@@ -285,19 +251,19 @@ class HazelcastJsonValue(object):
             self._json_string = json.dumps(value)
 
     def to_string(self):
-        """
-        Returns unaltered string that was used to create this object.
-
-        :return: (str), original string
+        """Returns unaltered string that was used to create this object.
+        
+        Returns:
+            str: The original string.
         """
         return self._json_string
 
     def loads(self):
-        """
-        Deserializes the string that was used to create this object
+        """Deserializes the string that was used to create this object
         and returns as Python object.
-
-        :return: (object), Python object represented by the original string
+        
+        Returns:
+            any: The Python object represented by the original string.
         """
         return json.loads(self._json_string)
 

--- a/hazelcast/core.py
+++ b/hazelcast/core.py
@@ -3,7 +3,6 @@ import json
 
 from hazelcast import six
 from hazelcast import util
-from hazelcast.util import with_reversed_items
 
 
 class MemberInfo(object):
@@ -62,7 +61,14 @@ class Address(object):
 
     def __init__(self, host, port):
         self.host = host
+        """
+        str: Host of the address.
+        """
+
         self.port = port
+        """
+        int: Port of the address.
+        """
 
     def __repr__(self):
         return "Address(host=%s, port=%d)" % (self.host, self.port)
@@ -134,7 +140,6 @@ class DistributedObjectInfo(object):
         return False
 
 
-@with_reversed_items
 class DistributedObjectEventType(object):
     """Type of the distributed object event."""
 
@@ -163,7 +168,7 @@ class DistributedObjectEvent(object):
         str: Service name of the distributed object.
         """
 
-        self.event_type = DistributedObjectEventType.reverse.get(event_type, event_type)
+        self.event_type = event_type
         """
         str: Event type. Either ``CREATED`` or ``DESTROYED``.
         """

--- a/hazelcast/discovery.py
+++ b/hazelcast/discovery.py
@@ -12,8 +12,7 @@ except ImportError:
 
 
 class HazelcastCloudAddressProvider(object):
-    """
-    Provides initial addresses for client to find and connect to a node
+    """Provides initial addresses for client to find and connect to a node
     and resolves private IP addresses of Hazelcast Cloud service.
     """
     logger = logging.getLogger("HazelcastClient.HazelcastCloudAddressProvider")
@@ -24,10 +23,11 @@ class HazelcastCloudAddressProvider(object):
         self._logger_extras = logger_extras
 
     def load_addresses(self):
-        """
-        Loads member addresses from Hazelcast Cloud endpoint.
-
-        :return: (Tuple), The possible member addresses as primary addresses to connect to.
+        """Loads member addresses from Hazelcast Cloud endpoint.
+        
+        Returns:
+            tuple[list[hazelcast.core.Address], list[hazelcast.core.Address]]: The possible member addresses
+                as primary addresses to connect to.
         """
         try:
             nodes = self.cloud_discovery.discover_nodes()
@@ -39,11 +39,13 @@ class HazelcastCloudAddressProvider(object):
         return [], []
 
     def translate(self, address):
-        """
-        Translates the given address to another address specific to network or service.
+        """Translates the given address to another address specific to network or service.
 
-        :param address: (:class:`~hazelcast.core.Address`), private address to be translated
-        :return: (:class:`~hazelcast.core.Address`), new address if given address is known, otherwise returns None
+        Args:
+            address (hazelcast.core.Address): Private address to be translated
+
+        Returns:
+            hazelcast.core.Address: New address if given address is known, otherwise returns None
         """
         if address is None:
             return None
@@ -57,9 +59,7 @@ class HazelcastCloudAddressProvider(object):
         return self._private_to_public.get(address, None)
 
     def refresh(self):
-        """
-        Refreshes the internal lookup table if necessary.
-        """
+        """Refreshes the internal lookup table if necessary."""
         try:
             self._private_to_public = self.cloud_discovery.discover_nodes()
         except Exception as e:
@@ -68,8 +68,7 @@ class HazelcastCloudAddressProvider(object):
 
 
 class HazelcastCloudDiscovery(object):
-    """
-    Discovery service that discover nodes via Hazelcast.cloud
+    """Discovery service that discover nodes via Hazelcast.cloud
     https://coordinator.hazelcast.cloud/cluster/discovery?token=<TOKEN>
     """
     _CLOUD_URL_BASE = "coordinator.hazelcast.cloud"
@@ -84,10 +83,11 @@ class HazelcastCloudDiscovery(object):
         self._ctx = ssl.create_default_context()
 
     def discover_nodes(self):
-        """
-        Discovers nodes from Hazelcast.cloud.
-
-        :return: (dict), Dictionary that maps private addresses to public addresses.
+        """Discovers nodes from Hazelcast.cloud.
+        
+        Returns:
+            dict[hazelcast.core.Address, hazelcast.core.Address]: Dictionary that maps private
+                addresses to public addresses.
         """
         try:
             https_connection = http_client.HTTPSConnection(host=self._CLOUD_URL_BASE,

--- a/hazelcast/errors.py
+++ b/hazelcast/errors.py
@@ -4,20 +4,20 @@ EXCEPTION_MESSAGE_TYPE = 0
 
 
 def retryable(cls):
-    """
-    Makes the given error retryable.
+    """Makes the given error retryable.
 
-    :param cls: (:class:`~hazelcast.exception.HazelcastError`), the given error.
-    :return: (:class:`~hazelcast.exception.HazelcastError`), the given error with retryable property.
+    Args:
+        cls (hazelcast.errors.HazelcastError): The given error.
+
+    Returns:
+        hazelcast.errors.HazelcastError: The given error with retryable property.
     """
     cls.retryable = True
     return cls
 
 
 class HazelcastError(Exception):
-    """
-    General HazelcastError class.
-    """
+    """General HazelcastError class."""
     def __init__(self, message=None, cause=None):
         super(HazelcastError, self).__init__(message, cause)
 
@@ -610,11 +610,14 @@ class _ErrorsCodec(object):
 
 
 def create_error_from_message(error_message):
-    """
-    Creates an exception with given error codec.
+    """Creates an exception with given error codec.
 
-    :param error_message: (ClientMessage), error message which includes the class name, message and exception trace.
-    :return: (Exception), the created exception.
+    Args:
+        error_message (hazelcast.protocol.client_message.InboundMessage): Error message which
+            includes the class name, message and exception trace.
+
+    Returns:
+        Exception: The created exception.
     """
     error_holders = _ErrorsCodec.decode(error_message)
     return _create_error(error_holders, 0)
@@ -638,9 +641,12 @@ def _create_error(error_holders, idx):
 
 
 def is_retryable_error(error):
-    """
-    Determines whether the given error is retryable or not.
-    :param error: (:class:`~hazelcast.exception.HazelcastError`), the given error.
-    :return: (bool), ``true`` if the given error is retryable, ``false`` otherwise.
+    """Determines whether the given error is retryable or not.
+
+    Args:
+        error (hazelcast.errors.HazelcastError): The given error.
+
+    Returns:
+        bool: ``True`` if the given error is retryable, ``False`` otherwise.
     """
     return hasattr(error, 'retryable')

--- a/hazelcast/errors.py
+++ b/hazelcast/errors.py
@@ -4,14 +4,6 @@ EXCEPTION_MESSAGE_TYPE = 0
 
 
 def retryable(cls):
-    """Makes the given error retryable.
-
-    Args:
-        cls (hazelcast.errors.HazelcastError): The given error.
-
-    Returns:
-        hazelcast.errors.HazelcastError: The given error with retryable property.
-    """
     cls.retryable = True
     return cls
 
@@ -610,15 +602,6 @@ class _ErrorsCodec(object):
 
 
 def create_error_from_message(error_message):
-    """Creates an exception with given error codec.
-
-    Args:
-        error_message (hazelcast.protocol.client_message.InboundMessage): Error message which
-            includes the class name, message and exception trace.
-
-    Returns:
-        Exception: The created exception.
-    """
     error_holders = _ErrorsCodec.decode(error_message)
     return _create_error(error_holders, 0)
 
@@ -641,12 +624,4 @@ def _create_error(error_holders, idx):
 
 
 def is_retryable_error(error):
-    """Determines whether the given error is retryable or not.
-
-    Args:
-        error (hazelcast.errors.HazelcastError): The given error.
-
-    Returns:
-        bool: ``True`` if the given error is retryable, ``False`` otherwise.
-    """
     return hasattr(error, 'retryable')

--- a/hazelcast/future.py
+++ b/hazelcast/future.py
@@ -9,9 +9,7 @@ NONE_RESULT = object()
 
 
 class Future(object):
-    """
-    Future is used for representing an asynchronous computation result.
-    """
+    """Future is used for representing an asynchronous computation result."""
     _result = None
     _exception = None
     _traceback = None
@@ -23,10 +21,10 @@ class Future(object):
         self._event = _Event()
 
     def set_result(self, result):
-        """
-        Sets the result of the Future.
+        """Sets the result of the Future.
 
-        :param result: Result of the Future.
+        Args:
+            result: Result of the Future.
         """
         if result is None:
             self._result = NONE_RESULT
@@ -36,11 +34,11 @@ class Future(object):
         self._invoke_callbacks()
 
     def set_exception(self, exception, traceback=None):
-        """
-        Sets the exception for this Future in case of errors.
+        """Sets the exception for this Future in case of errors.
 
-        :param exception: (Exception), exception to be threw in case of error.
-        :param traceback: (Function), function to be called on traceback (optional).
+        Args:
+            exception (Exception): Exception to be threw in case of error.
+            traceback (function): Function to be called on traceback.
         """
         if not isinstance(exception, BaseException):
             raise RuntimeError("Exception must be of BaseException type")
@@ -50,10 +48,10 @@ class Future(object):
         self._invoke_callbacks()
 
     def result(self):
-        """
-        Returns the result of the Future, which makes the call synchronous if the result has not been computed yet.
-
-        :return: Result of the Future.
+        """Returns the result of the Future, which makes the call synchronous if the result has not been computed yet.
+        
+        Returns:
+            Result of the Future.
         """
         self._reactor_check()
         self._event.wait()
@@ -71,40 +69,37 @@ class Future(object):
                     "Use add_done_callback instead.")
 
     def is_success(self):
-        """
-        Determines whether the result can be successfully computed or not.
-        """
+        """Determines whether the result can be successfully computed or not."""
         return self._result is not None
 
     def done(self):
-        """
-        Determines whether the result is computed or not.
-
-        :return: (bool), ``true`` if the result is computed, ``false`` otherwise.
+        """Determines whether the result is computed or not.
+        
+        Returns:
+            bool: ``True`` if the result is computed, ``False`` otherwise.
         """
         return self._event.is_set()
 
     def running(self):
-        """
-        Determines whether the asynchronous call, the computation is still running or not.
-
-        :return: (bool), ``true`` if the  result is being computed, ``false`` otherwise.
+        """Determines whether the asynchronous call, the computation is still running or not.
+        
+        Returns:
+            bool: ``True`` if the  result is being computed, ``False`` otherwise.
         """
         return not self.done()
 
     def exception(self):
-        """
-        Throws exception.
-        :return: (Exception), exception of this Future.
+        """Returns the exceptional result, if any.
+
+        Returns:
+            Exception: Exception of this Future.
         """
         self._reactor_check()
         self._event.wait()
         return self._exception
 
     def traceback(self):
-        """
-        Traceback function for the Future.
-        """
+        """Traceback function for the Future."""
         self._reactor_check()
         self._event.wait()
         return self._traceback
@@ -131,12 +126,15 @@ class Future(object):
             self.logger.exception("Exception when invoking callback")
 
     def continue_with(self, continuation_func, *args):
-        """
-        Create a continuation that executes when the Future is completed.
+        """Create a continuation that executes when the Future is completed.
 
-        :param continuation_func: A function which takes the future as the only parameter. Return value of the function
-        will be set as the result of the continuation future.
-        :return: A new Future which will be completed when the continuation is done.
+        Args:
+            continuation_func (function): A function which takes the future as the only parameter.
+                Return value of the function will be set as the result of the continuation future.
+            *args: Arguments to be passed into ``continuation_function``.
+
+        Returns:
+            Future: A new Future which will be completed when the continuation is done.
         """
         future = Future()
 
@@ -231,11 +229,13 @@ class ImmediateExceptionFuture(Future):
 
 
 def combine_futures(*futures):
-    """
-    Combines set of Futures.
+    """Combines set of Futures.
 
-    :param futures: (Futures), Futures to be combined.
-    :return: Result of the combination.
+    Args:
+        *futures (Future): Futures to be combined.
+
+    Returns:
+        Future: Result of the combination.
     """
     expected = len(futures)
     results = []
@@ -281,9 +281,12 @@ class _BlockingWrapper(object):
 
 
 def make_blocking(instance):
-    """
-    Takes an instance and returns an object whose methods which return non-blocking Future become blocking calls.
-    :param instance: (object), a non-blocking instance.
-    :return: (object), blocking version of given non-blocking instance.
+    """Takes an instance and returns an object whose methods which return non-blocking Future become blocking calls.
+
+    Args:
+        instance: A non-blocking instance.
+
+    Returns:
+        Blocking version of given non-blocking instance.
     """
     return _BlockingWrapper(instance)

--- a/hazelcast/hash.py
+++ b/hazelcast/hash.py
@@ -11,14 +11,16 @@ def _fmix(h):
 
 
 def murmur_hash3_x86_32(data, offset, size, seed=0x01000193):
-    """
-    murmur3 hash function to determine partition
+    """murmur3 hash function to determine partition
 
-    :param data: (byte array), input byte array
-    :param offset: (long), offset.
-    :param size: (long), byte length.
-    :param seed: murmur hash seed hazelcast uses 0x01000193
-    :return: (int32), calculated hash value.
+    Args:
+        data (bytearray): Input byte array
+        offset (int): Offset.
+        size (int): Byte length.
+        seed (int): Murmur hash seed hazelcast uses 0x01000193.
+
+    Returns:
+        int: Calculated hash value.
     """
     key = bytearray(data[offset: offset + size])
     length = len(key)

--- a/hazelcast/lifecycle.py
+++ b/hazelcast/lifecycle.py
@@ -2,10 +2,9 @@ import logging
 import uuid
 
 from hazelcast import six
-from hazelcast.util import create_git_info, with_reversed_items
+from hazelcast.util import create_git_info
 
 
-@with_reversed_items
 class LifecycleState(object):
     """Lifecycle states."""
 

--- a/hazelcast/lifecycle.py
+++ b/hazelcast/lifecycle.py
@@ -7,9 +7,7 @@ from hazelcast.util import create_git_info, with_reversed_items
 
 @with_reversed_items
 class LifecycleState(object):
-    """
-    Lifecycle states.
-    """
+    """Lifecycle states."""
 
     STARTING = "STARTING"
     """
@@ -55,8 +53,8 @@ class LifecycleService(object):
         """
         Checks whether or not the instance is running.
 
-        :return: ``True``, if the client is active and running, ``False`` otherwise.
-        :rtype: bool
+        Returns:
+            bool: ``True``, if the client is active and running, ``False`` otherwise.
         """
         return self._service.running
 
@@ -64,11 +62,11 @@ class LifecycleService(object):
         """
         Adds a listener to listen for lifecycle events.
 
-        :param on_state_change: Function to be called when lifecycle state is changed.
-        :type on_state_change: function
+        Args:
+            on_state_change (function): Function to be called when lifecycle state is changed.
 
-        :return: Registration id of the listener
-        :rtype: str
+        Returns:
+            str: Registration id of the listener
         """
         return self._service.add_listener(on_state_change)
 
@@ -76,11 +74,11 @@ class LifecycleService(object):
         """
         Removes a lifecycle listener.
 
-        :param registration_id: The id of the listener to be removed.
-        :type registration_id: str
+        Args:
+            registration_id (str): The id of the listener to be removed.
 
-        :return: ``True`` if the listener is removed successfully, ``False`` otherwise.
-        :rtype: bool
+        Returns:
+            bool: ``True`` if the listener is removed successfully, ``False`` otherwise.
         """
         self._service.remove_listener(registration_id)
 
@@ -125,6 +123,11 @@ class _InternalLifecycleService(object):
             return False
 
     def fire_lifecycle_event(self, new_state):
+        """Called when instance's state changes.
+
+        Args:
+            new_state (str): The new state of the instance.
+        """
         self.logger.info(self._git_info + "HazelcastClient is %s", new_state, extra=self._logger_extras)
         for on_state_change in six.itervalues(self._listeners):
             if on_state_change:

--- a/hazelcast/near_cache.py
+++ b/hazelcast/near_cache.py
@@ -8,32 +8,14 @@ from sys import getsizeof
 
 
 def _lru_key_func(x):
-    """
-    Least Recently Used key function.
-
-    :param x: (:class:`~hazelcast.near_cache.DataRecord`)
-    :return: (float), last access time of x.
-    """
     return x.last_access_time
 
 
 def _lfu_key_func(x):
-    """
-    Least Frequently Used key function.
-
-    :param x: (:class:`~hazelcast.near_cache.DataRecord`)
-    :return: (int), access hit count of x.
-    """
     return x.access_hit
 
 
 def _random_key_func(_):
-    """
-    Random key function.
-
-    :param _: (:class:`~hazelcast.near_cache.DataRecord`)
-    :return: (int), 0.
-    """
     return 0
 
 
@@ -46,9 +28,7 @@ _eviction_key_func = {
 
 
 class DataRecord(object):
-    """
-    An expirable and evictable data object which represents a cache entry.
-    """
+    """An expirable and evictable data object which represents a cache entry."""
     def __init__(self, key, value, create_time=None, ttl_seconds=None):
         self.key = key
         self.value = value
@@ -58,11 +38,13 @@ class DataRecord(object):
         self.access_hit = 0
 
     def is_expired(self, max_idle_seconds):
-        """
-        Determines whether this record is expired or not.
+        """Determines whether this record is expired or not.
 
-        :param max_idle_seconds: (long), the maximum idle time of record, maximum time after the last access time.
-        :return: (bool), ``true`` is this record is not expired.
+        Args:
+            max_idle_seconds (int): The maximum idle time of record, maximum time after the last access time.
+
+        Returns:
+            bool: ``True`` is this record is not expired, ``False`` otherwise.
         """
 
         now = current_time()
@@ -75,9 +57,7 @@ class DataRecord(object):
 
 
 class NearCache(dict):
-    """
-    NearCache is a local cache used by :class:`~hazelcast.proxy.map.MapFeatNearCache`.
-    """
+    """NearCache is a local cache used by :class:`~hazelcast.proxy.map.MapFeatNearCache`."""
 
     def __init__(self, name, serialization_service, in_memory_format, time_to_live, max_idle, invalidate_on_change,
                  eviction_policy, eviction_max_size, eviction_sampling_count=None, eviction_sampling_pool_size=None):
@@ -116,9 +96,10 @@ class NearCache(dict):
         self._creation_time_in_seconds = current_time()
 
     def get_statistics(self):
-        """
-        Returns the statistics of the NearCache.
-        :return: (Dict), Dictionary that stores statistics related to this near cache.
+        """Returns the statistics of the NearCache.
+
+        Returns:
+            dict: Dictionary that stores statistics related to this near cache.
         """
         stats = {
             "creation_time": self._creation_time_in_seconds,

--- a/hazelcast/partition.py
+++ b/hazelcast/partition.py
@@ -2,6 +2,7 @@ import logging
 
 from hazelcast.errors import ClientOfflineError
 from hazelcast.hash import hash_to_index
+from hazelcast.serialization.data import Data
 
 
 class _PartitionTable(object):
@@ -21,8 +22,9 @@ class PartitionService(object):
     Allows to retrieve information about the partition count, the partition owner or the partitionId of a key.
     """
 
-    def __init__(self, internal_partition_service):
+    def __init__(self, internal_partition_service, serialization_service):
         self._service = internal_partition_service
+        self._serialization_service = serialization_service
 
     def get_partition_owner(self, partition_id):
         """
@@ -36,16 +38,17 @@ class PartitionService(object):
         """
         return self._service.get_partition_owner(partition_id)
 
-    def get_partition_id(self, key_data):
+    def get_partition_id(self, key):
         """
         Returns the partition id for a key data.
 
         Args:
-            key_data (hazelcast.serialization.data.Data): The key data.
+            key: The given key.
 
         Returns:
             int: The partition id.
         """
+        key_data = self._serialization_service.to_data(key)
         return self._service.get_partition_id(key_data)
 
     def get_partition_count(self):

--- a/hazelcast/partition.py
+++ b/hazelcast/partition.py
@@ -28,11 +28,11 @@ class PartitionService(object):
         """
         Returns the owner of the partition if it's set, ``None`` otherwise.
 
-        :param partition_id: The partition id.
-        :type partition_id: int
+        Args:
+            partition_id (int): The partition id.
 
-        :return: Owner of partition
-        :rtype: :class:`uuid.UUID`
+        Returns:
+            uuid.UUID: Owner of the partition
         """
         return self._service.get_partition_owner(partition_id)
 
@@ -40,11 +40,11 @@ class PartitionService(object):
         """
         Returns the partition id for a key data.
 
-        :param key_data: The key data.
-        :type key_data: :class:`~hazelcast.serialization.data.Data`
+        Args:
+            key_data (hazelcast.serialization.data.Data): The key data.
 
-        :return: The partition id.
-        :rtype: int
+        Returns:
+            int: The partition id.
         """
         return self._service.get_partition_id(key_data)
 
@@ -54,8 +54,8 @@ class PartitionService(object):
 
         If partition table is not fetched yet, this method returns ``0``.
 
-        :return: The partition count
-        :rtype: int
+        Returns:
+            int: The partition count
         """
         return self._service.partition_count
 
@@ -70,9 +70,6 @@ class _InternalPartitionService(object):
         self._partition_table = _PartitionTable(None, -1, dict())
 
     def handle_partitions_view_event(self, connection, partitions, version):
-        """Handles the incoming partition view event and updates the partition table
-        if it is not empty, coming from a new connection or not stale.
-        """
         should_log = self.logger.isEnabledFor(logging.DEBUG)
         if should_log:
             self.logger.debug("Handling new partition table with version: %s" % version,
@@ -102,11 +99,6 @@ class _InternalPartitionService(object):
         return hash_to_index(key.get_partition_hash(), count)
 
     def check_and_set_partition_count(self, partition_count):
-        """
-        :param partition_count: (int)
-        :return: (bool), True if partition count can be set for the first time,
-            or it is equal to one that is already available, returns False otherwise
-        """
         if self.partition_count == 0:
             self.partition_count = partition_count
             return True

--- a/hazelcast/protocol/builtin.py
+++ b/hazelcast/protocol/builtin.py
@@ -44,10 +44,6 @@ class CodecUtil(object):
 
     @staticmethod
     def next_frame_is_null_frame(msg):
-        """Returns whether the next frame is NULL_FRAME or not.
-        If it is, this method consumes the iterator
-        by calling msg.next_frame once to skip the NULL_FRAME.
-        """
         is_null = msg.peek_next_frame().is_null_frame()
         if is_null:
             msg.next_frame()

--- a/hazelcast/proxy/base.py
+++ b/hazelcast/proxy/base.py
@@ -4,7 +4,7 @@ from hazelcast.future import make_blocking
 from hazelcast.invocation import Invocation
 from hazelcast.partition import string_partition_strategy
 from hazelcast import six
-from hazelcast.util import with_reversed_items
+from hazelcast.util import get_attr_name
 
 MAX_SIZE = float('inf')
 
@@ -106,7 +106,6 @@ class TransactionalProxy(object):
         return '%s(name="%s")' % (type(self).__name__, self.name)
 
 
-@with_reversed_items
 class ItemEventType(object):
     """Type of item events."""
 
@@ -121,7 +120,6 @@ class ItemEventType(object):
     """
 
 
-@with_reversed_items
 class EntryEventType(object):
     """Type of entry event."""
 
@@ -206,6 +204,7 @@ class EntryEvent(object):
         uuid (uuid.UUID): UUID of the member that fired the event.
         number_of_affected_entries (int): Number of affected entries by this event.
     """
+
     def __init__(self, to_object, key, value, old_value, merging_value, event_type, uuid,
                  number_of_affected_entries):
         self._to_object = to_object
@@ -239,9 +238,9 @@ class EntryEvent(object):
 
     def __repr__(self):
         return "EntryEvent(key=%s, value=%s, old_value=%s, merging_value=%s, event_type=%s, uuid=%s, " \
-               "number_of_affected_entries=%s)" % (
-                   self.key, self.value, self.old_value, self.merging_value, EntryEventType.reverse[self.event_type],
-                   self.uuid, self.number_of_affected_entries)
+               "number_of_affected_entries=%s)" % (self.key, self.value, self.old_value, self.merging_value,
+                                                   get_attr_name(EntryEventType, self.event_type), self.uuid,
+                                                   self.number_of_affected_entries)
 
 
 class TopicMessage(object):
@@ -252,6 +251,7 @@ class TopicMessage(object):
         publish_time (int): UNIX time that the event is published as seconds.
         member (hazelcast.core.MemberInfo): Member that fired the event.
     """
+
     def __init__(self, name, message_data, publish_time, member, to_object):
         self.name = name
         self._message_data = message_data

--- a/hazelcast/proxy/base.py
+++ b/hazelcast/proxy/base.py
@@ -14,9 +14,8 @@ def _no_op_response_handler(_):
 
 
 class Proxy(object):
-    """
-    Provides basic functionality for Hazelcast Proxies.
-    """
+    """Provides basic functionality for Hazelcast Proxies."""
+
     def __init__(self, service_name, name, context):
         self.service_name = service_name
         self.name = name
@@ -33,10 +32,10 @@ class Proxy(object):
         self._is_smart = context.config.smart_routing
 
     def destroy(self):
-        """
-        Destroys this proxy.
+        """Destroys this proxy.
 
-        :return: (bool), ``true`` if this proxy is deleted successfully, ``false`` otherwise.
+        Returns:
+            bool: ``True`` if this proxy is destroyed successfully, ``False`` otherwise.
         """
         self._on_destroy()
         return self._context.proxy_manager.destroy_proxy(self.service_name, self.name)
@@ -69,17 +68,13 @@ class Proxy(object):
         return invocation.future
 
     def blocking(self):
-        """
-        Returns a version of this proxy with only blocking method calls.
-        :return: (Proxy), a version of this proxy with only blocking method calls.
-        """
+        """Returns a version of this proxy with only blocking method calls."""
         return make_blocking(self)
 
 
 class PartitionSpecificProxy(Proxy):
-    """
-    Provides basic functionality for Partition Specific Proxies.
-    """
+    """Provides basic functionality for Partition Specific Proxies."""
+
     def __init__(self, service_name, name, context):
         super(PartitionSpecificProxy, self).__init__(service_name, name, context)
         partition_key = context.serialization_service.to_data(string_partition_strategy(self.name))
@@ -92,9 +87,8 @@ class PartitionSpecificProxy(Proxy):
 
 
 class TransactionalProxy(object):
-    """
-    Provides an interface for all transactional distributed objects.
-    """
+    """Provides an interface for all transactional distributed objects."""
+
     def __init__(self, name, transaction, context):
         self.name = name
         self.transaction = transaction
@@ -114,9 +108,7 @@ class TransactionalProxy(object):
 
 @with_reversed_items
 class ItemEventType(object):
-    """
-    Type of item events.
-    """
+    """Type of item events."""
 
     ADDED = 1
     """
@@ -131,9 +123,7 @@ class ItemEventType(object):
 
 @with_reversed_items
 class EntryEventType(object):
-    """
-    Type of entry event.
-    """
+    """Type of entry event."""
 
     ADDED = 1
     """
@@ -187,9 +177,14 @@ class EntryEventType(object):
 
 
 class ItemEvent(object):
+    """Map Item event.
+
+    Attributes:
+        name (str): Name of the proxy that fired the event.
+        event_type (ItemEventType): Type of the event.
+        member (hazelcast.core.MemberInfo): Member that fired the event.
     """
-    Map Item event.
-    """
+
     def __init__(self, name, item_data, event_type, member, to_object):
         self.name = name
         self._item_data = item_data
@@ -204,8 +199,12 @@ class ItemEvent(object):
 
 
 class EntryEvent(object):
-    """
-    Map Entry event.
+    """Map Entry event.
+
+    Attributes:
+        event_type (EntryEventType): Type of the event.
+        uuid (uuid.UUID): UUID of the member that fired the event.
+        number_of_affected_entries (int): Number of affected entries by this event.
     """
     def __init__(self, to_object, key, value, old_value, merging_value, event_type, uuid,
                  number_of_affected_entries):
@@ -246,8 +245,12 @@ class EntryEvent(object):
 
 
 class TopicMessage(object):
-    """
-    Topic message.
+    """Topic message.
+
+    Attributes:
+        name (str): Name of the proxy that fired the event.
+        publish_time (int): UNIX time that the event is published as seconds.
+        member (hazelcast.core.MemberInfo): Member that fired the event.
     """
     def __init__(self, name, message_data, publish_time, member, to_object):
         self.name = name

--- a/hazelcast/proxy/executor.py
+++ b/hazelcast/proxy/executor.py
@@ -8,17 +8,17 @@ from hazelcast.util import check_not_none
 
 
 class Executor(Proxy):
-    """
-    An object that executes submitted executable tasks.
-    """
-    # TODO: cancellation
-    def execute_on_key_owner(self, key, task):
-        """
-        Executes a task on the owner of the specified key.
+    """An object that executes submitted executable tasks."""
 
-        :param key: (object), the specified key.
-        :param task: (Task), a task executed on the owner of the specified key.
-        :return: (:class:`~hazelcast.future.Future`), future representing pending completion of the task.
+    def execute_on_key_owner(self, key, task):
+        """Executes a task on the owner of the specified key.
+
+        Args:
+          key: The specified key.
+          task: A task executed on the owner of the specified key.
+
+        Returns:
+          hazelcast.future.Future: future representing pending completion of the task.
         """
         check_not_none(key, "key can't be None")
         check_not_none(task, "task can't be None")
@@ -35,12 +35,14 @@ class Executor(Proxy):
         return self._invoke_on_partition(request, partition_id, handler)
 
     def execute_on_member(self, member, task):
-        """
-        Executes a task on the specified member.
+        """Executes a task on the specified member.
 
-        :param member: (Member), the specified member.
-        :param task: (Task), the task executed on the specified member.
-        :return: (:class:`~hazelcast.future.Future`), Future representing pending completion of the task.
+        Args:
+          member (hazelcast.core.MemberInfo): The specified member.
+          task: The task executed on the specified member.
+
+        Returns:
+          hazelcast.future.Future: Future representing pending completion of the task.
         """
         check_not_none(task, "task can't be None")
         task_data = self._to_data(task)
@@ -48,12 +50,15 @@ class Executor(Proxy):
         return self._execute_on_member(uuid, task_data, member.uuid)
 
     def execute_on_members(self, members, task):
-        """
-        Executes a task on each of the specified members.
+        """Executes a task on each of the specified members.
 
-        :param members: (Collection), the specified members.
-        :param task: (Task), the task executed on the specified members.
-        :return: (Map), :class:`~hazelcast.future.Future` tuples representing pending completion of the task on each member.
+        Args:
+          members (list[hazelcast.core.MemberInfo]): The specified members.
+          task: The task executed on the specified members.
+
+        Returns:
+          list[hazelcast.future.Future]: Futures representing pending completion of the task on each member.
+
         """
         task_data = self._to_data(task)
         futures = []
@@ -64,27 +69,31 @@ class Executor(Proxy):
         return future.combine_futures(*futures)
 
     def execute_on_all_members(self, task):
-        """
-        Executes a task on all of the known cluster members.
+        """Executes a task on all of the known cluster members.
 
-        :param task: (Task), the task executed on the all of the members.
-        :return: (Map), :class:`~hazelcast.future.Future` tuples representing pending completion of the task on each member.
+        Args:
+          task: The task executed on the all of the members.
+
+        Returns:
+          list[hazelcast.future.Future]: Futures representing pending completion of the task on each member.
         """
         return self.execute_on_members(self._context.cluster_service.get_members(), task)
 
     def is_shutdown(self):
-        """
-        Determines whether this executor has been shut down or not.
+        """Determines whether this executor has been shutdown or not.
 
-        :return: (bool), ``true`` if this executor has been shut down.
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if the executor has been shutdown, ``False`` otherwise.
         """
         request = executor_service_is_shutdown_codec.encode_request(self.name)
         return self._invoke(request, executor_service_is_shutdown_codec.decode_response)
 
     def shutdown(self):
-        """
-        Initiates a shutdown process which works orderly. Tasks that were submitted before shutdown are executed but new
-        task will not be accepted.
+        """Initiates a shutdown process which works orderly. Tasks that were submitted
+        before shutdown are executed but new task will not be accepted.
+
+        Returns:
+            hazelcast.future.Future[None]:
         """
         request = executor_service_shutdown_codec.encode_request(self.name)
         return self._invoke(request)

--- a/hazelcast/proxy/list.py
+++ b/hazelcast/proxy/list.py
@@ -26,18 +26,20 @@ from hazelcast.util import check_not_none, ImmutableLazyDataList
 
 
 class List(PartitionSpecificProxy):
-    """
-    Concurrent, distributed implementation of List.
-
+    """Concurrent, distributed implementation of List.
+    
     The Hazelcast List is not a partitioned data-structure. So all the content of the List is stored in a single
     machine (and in the backup). So the List will not scale by adding more members in the cluster.
     """
-    def add(self, item):
-        """
-        Adds the specified item to the end of this list.
 
-        :param item: (object), the specified item to be appended to this list.
-        :return: (bool), ``true`` if item is added, ``false`` otherwise.
+    def add(self, item):
+        """Adds the specified item to the end of this list.
+
+        Args:
+            item: the specified item to be appended to this list.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if item is added, ``False`` otherwise.
         """
         check_not_none(item, "Value can't be None")
         element_data = self._to_data(item)
@@ -45,12 +47,15 @@ class List(PartitionSpecificProxy):
         return self._invoke(request, list_add_codec.decode_response)
 
     def add_at(self, index, item):
-        """
-        Adds the specified item at the specific position in this list. Element in this position and following elements
-        are shifted to the right, if any.
+        """Adds the specified item at the specific position in this list.
+        Element in this position and following elements are shifted to the right, if any.
 
-        :param index: (int), the specified index to insert the item.
-        :param item: (object), the specified item to be inserted.
+        Args:
+            index (int): The specified index to insert the item.
+            item: The specified item to be inserted.
+
+        Returns:
+            hazelcast.future.Future[None]:
         """
         check_not_none(item, "Value can't be None")
         element_data = self._to_data(item)
@@ -59,12 +64,15 @@ class List(PartitionSpecificProxy):
         return self._invoke(request)
 
     def add_all(self, items):
-        """
-        Adds all of the items in the specified collection to the end of this list. The order of new elements is
-        determined by the specified collection's iterator.
+        """Adds all of the items in the specified collection to the end of this list.
 
-        :param items: (Collection), the specified collection which includes the elements to be added to list.
-        :return: (bool), ``true`` if this call changed the list, ``false`` otherwise.
+        The order of new elements is determined by the specified collection's iterator.
+
+        Args:
+            items (list): The specified collection which includes the elements to be added to list.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if this call changed the list, ``False`` otherwise.
         """
         check_not_none(items, "Value can't be None")
         data_items = []
@@ -76,14 +84,17 @@ class List(PartitionSpecificProxy):
         return self._invoke(request, list_add_all_codec.decode_response)
 
     def add_all_at(self, index, items):
-        """
-        Adds all of the elements in the specified collection into this list at the specified position. Elements in this
-        positions and following elements are shifted to the right, if any. The order of new elements is determined by the
-        specified collection's iterator.
+        """Adds all of the elements in the specified collection into this list at the specified position.
 
-        :param index: (int), the specified index at which the first element of specified collection is added.
-        :param items: (Collection), the specified collection which includes the elements to be added to list.
-        :return: (bool), ``true`` if this call changed the list, ``false`` otherwise.
+        Elements in this positions and following elements are shifted to the right, if any.
+        The order of new elements is determined by the specified collection's iterator.
+
+        Args:
+            index (int): The specified index at which the first element of specified collection is added.
+            items (list): The specified collection which includes the elements to be added to list.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if this call changed the list, ``False`` otherwise.
         """
         check_not_none(items, "Value can't be None")
         data_items = []
@@ -95,13 +106,15 @@ class List(PartitionSpecificProxy):
         return self._invoke(request, list_add_all_with_index_codec.decode_response)
 
     def add_listener(self, include_value=False, item_added_func=None, item_removed_func=None):
-        """
-        Adds an item listener for this list. Listener will be notified for all list add/remove events.
+        """Adds an item listener for this list. Listener will be notified for all list add/remove events.
 
-        :param include_value: (bool), whether received events include the updated item or not (optional).
-        :param item_added_func: Function to be called when an item is added to this list (optional).
-        :param item_removed_func: Function to be called when an item is deleted from this list (optional).
-        :return: (str), a registration id which is used as a key to remove the listener.
+        Args:
+            include_value (bool): Whether received events include the updated item or not.
+            item_added_func (function):  To be called when an item is added to this list.
+            item_removed_func (function): To be called when an item is deleted from this list.
+
+        Returns:
+            str: A registration id which is used as a key to remove the listener.
         """
         request = list_add_listener_codec.encode_request(self.name, include_value, self._is_smart)
 
@@ -122,18 +135,24 @@ class List(PartitionSpecificProxy):
                                        lambda m: list_add_listener_codec.handle(m, handle_event_item))
 
     def clear(self):
-        """
-        Clears the list. List will be empty with this call.
+        """Clears the list. 
+        
+        List will be empty with this call.
+        
+        Returns:
+            hazelcast.future.Future[None]:
         """
         request = list_clear_codec.encode_request(self.name)
         return self._invoke(request)
 
     def contains(self, item):
-        """
-        Determines whether this list contains the specified item or not.
+        """Determines whether this list contains the specified item or not.
 
-        :param item: (object), the specified item.
-        :return: (bool), ``true`` if the specified item exists in this list, ``false`` otherwise.
+        Args:
+            item: The specified item.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if the specified item exists in this list, ``False`` otherwise.
         """
         check_not_none(item, "Value can't be None")
         item_data = self._to_data(item)
@@ -142,11 +161,14 @@ class List(PartitionSpecificProxy):
         return self._invoke(request, list_contains_codec.decode_response)
 
     def contains_all(self, items):
-        """
-        Determines whether this list contains all of the items in specified collection or not.
+        """Determines whether this list contains all of the items in specified collection or not.
 
-        :param items: (Collection), the specified collection which includes the items to be searched.
-        :return: (bool), ``true`` if all of the items in specified collection exist in this list, ``false`` otherwise.
+        Args:
+          items (list): The specified collection which includes the items to be searched.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if all of the items in specified collection
+                exist in this list, ``False`` otherwise.
         """
         check_not_none(items, "Items can't be None")
         data_items = []
@@ -158,11 +180,13 @@ class List(PartitionSpecificProxy):
         return self._invoke(request, list_contains_all_codec.decode_response)
 
     def get(self, index):
-        """
-        Returns the item which is in the specified position in this list.
+        """Returns the item which is in the specified position in this list.
 
-        :param index: (int), the specified index of the item to be returned.
-        :return: (object), the item in the specified position in this list.
+        Args:
+          index (int): the specified index of the item to be returned.
+
+        Returns:
+            hazelcast.future.Future[any]: the item in the specified position in this list.
         """
         def handler(message):
             return self._to_object(list_get_codec.decode_response(message))
@@ -171,10 +195,10 @@ class List(PartitionSpecificProxy):
         return self._invoke(request, handler)
 
     def get_all(self):
-        """
-        Returns all of the items in this list.
+        """Returns all of the items in this list.
 
-        :return: (Sequence), list that includes all of the items in this list.
+        Returns:
+            hazelcast.future.Future[list]: All of the items in this list.
         """
         def handler(message):
             return ImmutableLazyDataList(list_get_all_codec.decode_response(message), self._to_object)
@@ -183,10 +207,10 @@ class List(PartitionSpecificProxy):
         return self._invoke(request, handler)
 
     def iterator(self):
-        """
-        Returns an iterator over the elements in this list in proper sequence, same with get_all().
+        """Returns an iterator over the elements in this list in proper sequence, same with ``get_all``.
 
-        :return: (Sequence), an iterator over the elements in this list in proper sequence.
+        Returns:
+            hazelcast.future.Future[list]: All of the items in this list.
         """
         def handler(message):
             return ImmutableLazyDataList(list_iterator_codec.decode_response(message), self._to_object)
@@ -195,12 +219,16 @@ class List(PartitionSpecificProxy):
         return self._invoke(request, handler)
 
     def index_of(self, item):
-        """
-        Returns the first index of specified items's occurrences in this list. If specified item is not present in this
-        list, returns -1.
+        """Returns the first index of specified items's occurrences in this list. 
+        
+        If specified item is not present in this list, returns -1.
 
-        :param item: (object), the specified item to be searched for.
-        :return: (int), the first index of specified items's occurrences, -1 if item is not present in this list.
+        Args:
+            item: The specified item to be searched for.
+
+        Returns:
+             hazelcast.future.Future[int]: The first index of specified items's occurrences,
+                -1 if item is not present in this list.
         """
         check_not_none(item, "Value can't be None")
         item_data = self._to_data(item)
@@ -209,22 +237,26 @@ class List(PartitionSpecificProxy):
         return self._invoke(request, list_index_of_codec.decode_response)
 
     def is_empty(self):
-        """
-        Determines whether this list is empty or not.
+        """Determines whether this list is empty or not.
 
-        :return: (bool), ``true`` if this list contains no elements.
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if the list contains no elements, ``False`` otherwise.
         """
 
         request = list_is_empty_codec.encode_request(self.name)
         return self._invoke(request, list_is_empty_codec.decode_response)
 
     def last_index_of(self, item):
-        """
-        Returns the last index of specified items's occurrences in this list. If specified item is not present in this
-        list, returns -1.
+        """Returns the last index of specified items's occurrences in this list.
 
-        :param item: (object), the specified item to be searched for.
-        :return: (int), the last index of specified items's occurrences, -1 if item is not present in this list.
+        If specified item is not present in this list, returns -1.
+
+        Args:
+            item: The specified item to be searched for.
+
+        Returns:
+            hazelcast.future.Future[int]: The last index of specified items's occurrences,
+                -1 if item is not present in this list.
         """
         check_not_none(item, "Value can't be None")
         item_data = self._to_data(item)
@@ -233,11 +265,15 @@ class List(PartitionSpecificProxy):
         return self._invoke(request, list_last_index_of_codec.decode_response)
 
     def list_iterator(self, index=0):
-        """
-        Returns a list iterator of the elements in this list. If an index is provided, iterator starts from this index.
+        """Returns a list iterator of the elements in this list. 
+        
+        If an index is provided, iterator starts from this index.
 
-        :param index: (int), index of first element to be returned from the list iterator (optional).
-        :return: (Sequence), a list iterator of the elements in this list.
+        Args:
+            index: (int), index of first element to be returned from the list iterator.
+
+        Returns:
+            hazelcast.future.Future[list]: List of the elements in this list.
         """
         def handler(message):
             return ImmutableLazyDataList(list_list_iterator_codec.decode_response(message), self._to_object)
@@ -246,11 +282,14 @@ class List(PartitionSpecificProxy):
         return self._invoke(request, handler)
 
     def remove(self, item):
-        """
-        Removes the specified element's first occurrence from the list if it exists in this list.
+        """Removes the specified element's first occurrence from the list if it exists in this list.
 
-        :param item: (object), the specified element.
-        :return: (bool), ``true`` if the specified element is present in this list.
+        Args:
+            item: The specified element.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if the specified element is present in this list,
+                ``False`` otherwise.
         """
         check_not_none(item, "Value can't be None")
         item_data = self._to_data(item)
@@ -259,12 +298,15 @@ class List(PartitionSpecificProxy):
         return self._invoke(request, list_remove_codec.decode_response)
 
     def remove_at(self, index):
-        """
-        Removes the item at the specified position in this list. Element in this position and following elements are
-        shifted to the left, if any.
+        """Removes the item at the specified position in this list.
+        
+        Element in this position and following elements are shifted to the left, if any.
 
-        :param index: (int), index of the item to be removed.
-        :return: (object), the item previously at the specified index.
+        Args:
+            index (int): Index of the item to be removed.
+
+        Returns:
+            hazelcast.future.Future[any]: The item previously at the specified index.
         """
         def handler(message):
             return self._to_object(list_remove_with_index_codec.decode_response(message))
@@ -273,11 +315,13 @@ class List(PartitionSpecificProxy):
         return self._invoke(request, handler)
 
     def remove_all(self, items):
-        """
-        Removes all of the elements that is present in the specified collection from this list.
+        """Removes all of the elements that is present in the specified collection from this list.
 
-        :param items: (Collection), the specified collection.
-        :return: (bool), ``true`` if this list changed as a result of the call.
+        Args:
+            items (list): The specified collection.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if this list changed as a result of the call, ``False`` otherwise.
         """
         check_not_none(items, "Value can't be None")
         data_items = []
@@ -289,21 +333,28 @@ class List(PartitionSpecificProxy):
         return self._invoke(request, list_compare_and_remove_all_codec.decode_response)
 
     def remove_listener(self, registration_id):
-        """
-        Removes the specified item listener. Returns silently if the specified listener was not added before.
+        """Removes the specified item listener. 
+        
+        Returns silently if the specified listener was not added before.
 
-        :param registration_id: (str), id of the listener to be deleted.
-        :return: (bool), ``true`` if the item listener is removed, ``false`` otherwise.
+        Args:
+            registration_id (str): Id of the listener to be deleted.
+
+        Returns:
+            bool: ``True`` if the item listener is removed, ``False`` otherwise.
         """
         return self._deregister_listener(registration_id)
 
     def retain_all(self, items):
-        """
-        Retains only the items that are contained in the specified collection. It means, items which are not present in
-        the specified collection are removed from this list.
+        """Retains only the items that are contained in the specified collection. 
+        
+        It means, items which are not present in the specified collection are removed from this list.
 
-        :param items: (Collection), collections which includes the elements to be retained in this list.
-        :return: (bool), ``true`` if this list changed as a result of the call.
+        Args:
+            items (list): Collections which includes the elements to be retained in this list.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if this list changed as a result of the call, ``False`` otherwise.
         """
         check_not_none(items, "Value can't be None")
         data_items = []
@@ -315,22 +366,23 @@ class List(PartitionSpecificProxy):
         return self._invoke(request, list_compare_and_retain_all_codec.decode_response)
 
     def size(self):
+        """Returns the number of elements in this list.
+        
+        Returns:
+            hazelcast.future.Future[int]: Number of elements in this list.
         """
-        Returns the number of elements in this list.
-
-        :return: (int), number of the elements in this list.
-        """
-
         request = list_size_codec.encode_request(self.name)
         return self._invoke(request, list_size_codec.decode_response)
 
     def set_at(self, index, item):
-        """
-        Replaces the specified element with the element at the specified position in this list.
+        """Replaces the specified element with the element at the specified position in this list.
 
-        :param index: (int), index of the item to be replaced.
-        :param item: (object), item to be stored.
-        :return: (object), the previous item in the specified index.
+        Args:
+            index (int): Index of the item to be replaced.
+            item: Item to be stored.
+
+        Returns:
+            hazelcast.future.Future[any]: the previous item in the specified index. 
         """
         check_not_none(item, "Value can't be None")
         element_data = self._to_data(item)
@@ -342,14 +394,17 @@ class List(PartitionSpecificProxy):
         return self._invoke(request, handler)
 
     def sub_list(self, from_index, to_index):
-        """
-        Returns a sublist from this list, whose range is specified with from_index(inclusive) and to_index(exclusive).
+        """Returns a sublist from this list, from from_index(inclusive) to to_index(exclusive).
+        
         The returned list is backed by this list, so non-structural changes in the returned list are reflected in this
         list, and vice-versa.
 
-        :param from_index: (int), the start point(inclusive) of the sub_list.
-        :param to_index: (int), th end point(exclusive) of the sub_list.
-        :return: (Sequence), a view of the specified range within this list.
+        Args:
+            from_index (int): The start point(inclusive) of the sub_list.
+            to_index (int): The end point(exclusive) of the sub_list.
+
+        Returns:
+            hazelcast.future.Future[list]: A view of the specified range within this list.
         """
         def handler(message):
             return ImmutableLazyDataList(list_sub_codec.decode_response(message), self._to_object)

--- a/hazelcast/proxy/multi_map.py
+++ b/hazelcast/proxy/multi_map.py
@@ -9,24 +9,26 @@ from hazelcast.util import check_not_none, thread_id, to_millis, ImmutableLazyDa
 
 
 class MultiMap(Proxy):
-    """
-    A specialized map whose keys can be associated with multiple values.
-    """
+    """A specialized map whose keys can be associated with multiple values."""
+
     def __init__(self, service_name, name, context):
         super(MultiMap, self).__init__(service_name, name, context)
         self._reference_id_generator = context.lock_reference_id_generator
 
     def add_entry_listener(self, include_value=False, key=None, added_func=None, removed_func=None, clear_all_func=None):
-        """
-        Adds an entry listener for this multimap. The listener will be notified for all multimap add/remove/clear-all
-        events.
+        """Adds an entry listener for this multimap. 
+        
+        The listener will be notified for all multimap add/remove/clear-all events.
 
-        :param include_value: (bool), whether received event should include the value or not (optional).
-        :param key: (object), key for filtering the events (optional).
-        :param added_func: Function to be called when an entry is added to map (optional).
-        :param removed_func: Function to be called when an entry is removed_func from map (optional).
-        :param clear_all_func: Function to be called when entries are cleared from map (optional).
-        :return: (str), a registration id which is used as a key to remove the listener.
+        Args:
+            include_value (bool): Whether received event should include the value or not.
+            key: Key for filtering the events.
+            added_func (function): Function to be called when an entry is added to map.
+            removed_func (function): Function to be called when an entry is removed from map.
+            clear_all_func (function): Function to be called when entries are cleared from map.
+
+        Returns:
+            str: A registration id which is used as a key to remove the listener.
         """
         if key:
             codec = multi_map_add_entry_listener_to_key_codec
@@ -52,14 +54,18 @@ class MultiMap(Proxy):
             lambda m: codec.handle(m, handle_event_entry))
 
     def contains_key(self, key):
-        """
-        Determines whether this multimap contains an entry with the key.
+        """Determines whether this multimap contains an entry with the key.
+        
+        Warning: 
+            This method uses ``__hash__`` and ``__eq__`` methods of binary form of the key, not the 
+            actual implementations of ``__hash__`` and ``__eq__`` defined in key's class.
 
-        **Warning: This method uses __hash__ and __eq__ methods of binary form of the key, not the actual implementations
-        of __hash__ and __eq__ defined in key's class.**
+        Args:
+            key: The specified key.
 
-        :param key: (object), the specified key.
-        :return: (bool), ``true`` if this multimap contains an entry for the specified key.
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if this multimap contains an entry for the specified key,
+                ``False`` otherwise.
         """
         check_not_none(key, "key can't be None")
         key_data = self._to_data(key)
@@ -68,11 +74,14 @@ class MultiMap(Proxy):
         return self._invoke_on_key(request, key_data, multi_map_contains_key_codec.decode_response)
 
     def contains_value(self, value):
-        """
-        Determines whether this map contains one or more keys for the specified value.
+        """Determines whether this map contains one or more keys for the specified value.
 
-        :param value: (object), the specified value.
-        :return: (bool), ``true`` if this multimap contains an entry for the specified value.
+        Args:
+            value: The specified value.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if this multimap contains an entry for the specified value,
+                ``False`` otherwise.
         """
         check_not_none(value, "value can't be None")
         value_data = self._to_data(value)
@@ -80,12 +89,14 @@ class MultiMap(Proxy):
         return self._invoke(request, multi_map_contains_value_codec.decode_response)
 
     def contains_entry(self, key, value):
-        """
-        Returns whether the multimap contains an entry with the value.
+        """Returns whether the multimap contains an entry with the value.
 
-        :param key: (object), the specified key.
-        :param value: (object), the specified value.
-        :return: (bool), ``true`` if this multimap contains the key-value tuple.
+        Args:
+            key: The specified key.
+            value: The specified value.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if this multimap contains the key-value tuple, ``False`` otherwise.
         """
         check_not_none(key, "key can't be None")
         check_not_none(value, "value can't be None")
@@ -96,20 +107,22 @@ class MultiMap(Proxy):
         return self._invoke_on_key(request, key_data, multi_map_contains_entry_codec.decode_response)
 
     def clear(self):
-        """
-        Clears the multimap. Removes all key-value tuples.
+        """Clears the multimap. Removes all key-value tuples.
+        
+        Returns:
+            hazelcast.future.Future[None]:
         """
         request = multi_map_clear_codec.encode_request(self.name)
         return self._invoke(request)
 
     def entry_set(self):
-        """
-        Returns the list of key-value tuples in the multimap.
-
-        **Warning:
-        The list is NOT backed by the map, so changes to the map are NOT reflected in the list, and vice-versa.**
-
-        :return: (Sequence), the list of key-value tuples in the multimap.
+        """Returns the list of key-value tuples in the multimap.
+        
+        Warning:
+            The list is NOT backed by the map, so changes to the map are NOT reflected in the list, and vice-versa.
+        
+        Returns:
+            hazelcast.future.Future[list]: The list of key-value tuples in the multimap.
         """
         def handler(message):
             return ImmutableLazyDataList(multi_map_entry_set_codec.decode_response(message), self._to_object)
@@ -118,19 +131,21 @@ class MultiMap(Proxy):
         return self._invoke(request, handler)
 
     def get(self, key):
-        """
-        Returns the list of values associated with the key. ``None`` if this map does not contain this key.
+        """Returns the list of values associated with the key. ``None`` if this map does not contain this key.
+        
+        Warning:
+            This method uses ``__hash__`` and ``__eq__`` of the binary form of the key, not the 
+            actual implementations of ``__hash__`` and ``__eq__`` defined in the key's class.
+        
+        Warning-2:
+            The list is NOT backed by the multimap, so changes to the map are list reflected in the collection, and
+            vice-versa.
 
-        **Warning:
-        This method uses hashCode and equals of the binary form of the key, not the actual implementations of hashCode
-        and equals defined in the key's class.**
+        Args:
+            key: The specified key.
 
-        **Warning-2:
-        The list is NOT backed by the multimap, so changes to the map are list reflected in the collection, and
-        vice-versa.**
-
-        :param key: (object), the specified key.
-        :return: (Sequence), the list of the values associated with the specified key.
+        Returns:
+            hazelcast.future.Future[list]: The list of the values associated with the specified key.
         """
         check_not_none(key, "key can't be None")
 
@@ -142,14 +157,17 @@ class MultiMap(Proxy):
         return self._invoke_on_key(request, key_data, handler)
 
     def is_locked(self, key):
-        """
-        Checks the lock for the specified key. If the lock is acquired, returns ``true``. Otherwise, returns false.
+        """Checks the lock for the specified key.
+        
+        Warning: 
+            This method uses ``__hash__`` and ``__eq__`` methods of binary form of the key, not the 
+            actual implementations of ``__hash__`` and ``__eq__`` defined in key's class.
 
-        **Warning: This method uses __hash__ and __eq__ methods of binary form of the key, not the actual implementations
-        of __hash__ and __eq__ defined in key's class.**
+        Args:
+            key: The key that is checked for lock.
 
-        :param key: (object), the key that is checked for lock.
-        :return: (bool), ``true`` if lock is acquired, false otherwise.
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if lock is acquired, ``False`` otherwise.
         """
         check_not_none(key, "key can't be None")
         key_data = self._to_data(key)
@@ -158,14 +176,19 @@ class MultiMap(Proxy):
         return self._invoke_on_key(request, key_data, multi_map_is_locked_codec.decode_response)
 
     def force_unlock(self, key):
-        """
-        Releases the lock for the specified key regardless of the lock owner. It always successfully unlocks the key,
-        never blocks, and returns immediately.
+        """Releases the lock for the specified key regardless of the lock owner. 
+        
+        It always successfully unlocks the key, never blocks, and returns immediately.
+        
+        Warning: 
+            This method uses ``__hash__`` and ``__eq__`` methods of binary form of the key, not the 
+            actual implementations of ``__hash__`` and ``__eq__`` defined in key's class.
 
-        **Warning: This method uses __hash__ and __eq__ methods of binary form of the key, not the actual implementations
-        of __hash__ and __eq__ defined in key's class.**
+        Args:
+            key: The key to lock.
 
-        :param key: (object), the key to lock.
+        Returns:
+            hazelcast.future.Future[None]:
         """
         check_not_none(key, "key can't be None")
         key_data = self._to_data(key)
@@ -174,13 +197,13 @@ class MultiMap(Proxy):
         return self._invoke_on_key(request, key_data)
 
     def key_set(self):
-        """
-        Returns the list of keys in the multimap.
-
-        **Warning:
-        The list is NOT backed by the map, so changes to the map are NOT reflected in the list, and vice-versa.**
-
-        :return: (Sequence), a list of the clone of the keys.
+        """Returns the list of keys in the multimap.
+        
+        Warning:
+            The list is NOT backed by the map, so changes to the map are NOT reflected in the list, and vice-versa.
+        
+        Returns:
+            hazelcast.future.Future[list]: A list of the clone of the keys.
         """
         def handler(message):
             return ImmutableLazyDataList(multi_map_key_set_codec.decode_response(message), self._to_object)
@@ -189,22 +212,26 @@ class MultiMap(Proxy):
         return self._invoke(request, handler)
 
     def lock(self, key, lease_time=-1):
-        """
-        Acquires the lock for the specified key infinitely or for the specified lease time if provided.
-
+        """Acquires the lock for the specified key infinitely or for the specified lease time if provided.
+        
         If the lock is not available, the current thread becomes disabled for thread scheduling purposes and lies
         dormant until the lock has been acquired.
-
+        
         Scope of the lock is this map only. Acquired lock is only for the key in this map.
-
+        
         Locks are re-entrant; so, if the key is locked N times, it should be unlocked N times before another thread can
         acquire it.
+        
+        Warning: 
+            This method uses ``__hash__`` and ``__eq__`` methods of binary form of the key, not the 
+            actual implementations of ``__hash__`` and ``__eq__`` defined in key's class.
 
-        **Warning: This method uses __hash__ and __eq__ methods of binary form of the key, not the actual implementations
-        of __hash__ and __eq__ defined in key's class.**
+        Args:
+            key: The key to lock.
+            lease_time (int): Time in seconds to wait before releasing the lock.
 
-        :param key: (object), the key to lock.
-        :param lease_time: (int), time in seconds to wait before releasing the lock (optional).
+        Returns:
+            hazelcast.future.Future[None]:
         """
         check_not_none(key, "key can't be None")
         key_data = self._to_data(key)
@@ -213,15 +240,19 @@ class MultiMap(Proxy):
         return self._invoke_on_key(request, key_data)
 
     def remove(self, key, value):
-        """
-        Removes the given key-value tuple from the multimap.
+        """Removes the given key-value tuple from the multimap.
+        
+        Warning:
+            This method uses ``__hash__`` and ``__eq__`` methods of binary form of the key, not the
+            actual implementations of ``__hash__`` and ``__eq__`` defined in key's class.
 
-        **Warning: This method uses __hash__ and __eq__ methods of binary form of the key, not the actual implementations
-        of __hash__ and __eq__ defined in key's class.**
+        Args:
+            key: The key of the entry to remove.
+            value: The value of the entry to remove.
 
-        :param key: (object),  the key of the entry to remove.
-        :param value: (object), the value of the entry to remove.
-        :return: (bool), ``true`` if the size of the multimap changed after the remove operation, ``false`` otherwise.
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if the size of the multimap changed after the remove operation,
+                ``False`` otherwise.
         """
         check_not_none(key, "key can't be None")
         check_not_none(key, "value can't be None")
@@ -231,18 +262,21 @@ class MultiMap(Proxy):
         return self._invoke_on_key(request, key_data, multi_map_remove_entry_codec.decode_response)
 
     def remove_all(self, key):
-        """
-        Removes all the entries with the given key and returns the value list associated with this key.
+        """Removes all the entries with the given key and returns the value list associated with this key.
+        
+        Warning: 
+            This method uses ``__hash__`` and ``__eq__`` methods of binary form of the key, not the 
+            actual implementations of ``__hash__`` and ``__eq__`` defined in key's class.
+        
+        Warning:
+            The returned list is NOT backed by the map, so changes to the map are NOT reflected in the list, and
+            vice-versa.
 
-        **Warning: This method uses __hash__ and __eq__ methods of binary form of the key, not the actual implementations
-        of __hash__ and __eq__ defined in key's class.**
+        Args:
+            key: The key of the entries to remove.
 
-        **Warning-2:
-        The returned list is NOT backed by the map, so changes to the map are NOT reflected in the list, and
-        vice-versa.**
-
-        :param key: (object), the key of the entries to remove.
-        :return: (Sequence), the collection of removed values associated with the given key.
+        Returns:
+            hazelcast.future.Future[list]: The collection of removed values associated with the given key.
         """
         check_not_none(key, "key can't be None")
 
@@ -254,16 +288,19 @@ class MultiMap(Proxy):
         return self._invoke_on_key(request, key_data, handler)
 
     def put(self, key, value):
-        """
-        Stores a key-value tuple in the multimap.
+        """Stores a key-value tuple in the multimap.
+        
+        Warning: 
+            This method uses ``__hash__`` and ``__eq__`` methods of binary form of the key, not the 
+            actual implementations of ``__hash__`` and ``__eq__`` defined in key's class.
 
-        **Warning: This method uses __hash__ and __eq__ methods of binary form of the key, not the actual implementations
-        of __hash__ and __eq__ defined in key's class.**
+        Args:
+            key: The key to be stored.
+            value: The value to be stored.
 
-        :param key: (object), the key to be stored.
-        :param value: (object), the value to be stored.
-        :return: (bool), ``true`` if size of the multimap is increased, ``false`` if the multimap already contains the key-value
-        tuple.
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if size of the multimap is increased,
+                ``False`` if the multimap already contains the key-value tuple.
         """
         check_not_none(key, "key can't be None")
         check_not_none(value, "value can't be None")
@@ -273,32 +310,39 @@ class MultiMap(Proxy):
         return self._invoke_on_key(request, key_data, multi_map_put_codec.decode_response)
 
     def remove_entry_listener(self, registration_id):
-        """
-        Removes the specified entry listener. Returns silently if there is no such listener added before.
+        """Removes the specified entry listener. 
+        
+        Returns silently if there is no such listener added before.
 
-        :param registration_id: (str), id of registered listener.
-        :return: (bool), ``true`` if registration is removed, ``false`` otherwise.
+        Args:
+            registration_id (str): Id of registered listener.
+
+        Returns:
+            bool: ``True`` if registration is removed, ``False`` otherwise.
         """
         return self._deregister_listener(registration_id)
 
     def size(self):
-        """
-        Returns the number of entries in this multimap.
-
-        :return: (int), number of entries in this multimap.
+        """Returns the number of entries in this multimap.
+        
+        Returns:
+            hazelcast.future.Future[int]: Number of entries in this multimap.
         """
         request = multi_map_size_codec.encode_request(self.name)
         return self._invoke(request, multi_map_size_codec.decode_response)
 
     def value_count(self, key):
-        """
-        Returns the number of values that match the given key in the multimap.
+        """Returns the number of values that match the given key in the multimap.
+        
+        Warning: 
+            This method uses ``__hash__`` and ``__eq__`` methods of binary form of the key, not the 
+            actual implementations of ``__hash__`` and ``__eq__`` defined in key's class.
 
-        **Warning: This method uses __hash__ and __eq__ methods of binary form of the key, not the actual implementations
-        of __hash__ and __eq__ defined in key's class.**
+        Args:
+            key: The key whose values count is to be returned.
 
-        :param key: (object), the key whose values count is to be returned.
-        :return: (int), the number of values that match the given key in the multimap.
+        Returns:
+            hazelcast.future.Future[int]: The number of values that match the given key in the multimap.
         """
         check_not_none(key, "key can't be None")
         key_data = self._to_data(key)
@@ -306,14 +350,14 @@ class MultiMap(Proxy):
         return self._invoke_on_key(request, key_data, multi_map_value_count_codec.decode_response)
 
     def values(self):
-        """
-        Returns the list of values in the multimap.
+        """Returns the list of values in the multimap.
+        
+        Warning:
+            The returned list is NOT backed by the map, so changes to the map are NOT reflected in the list, and
+            vice-versa.
 
-        **Warning:
-        The returned list is NOT backed by the map, so changes to the map are NOT reflected in the list, and
-        vice-versa.**
-
-        :return: (Sequence), the list of values in the multimap.
+        Returns:
+            hazelcast.future.Future[list]: The list of values in the multimap.
         """
         def handler(message):
             return ImmutableLazyDataList(multi_map_values_codec.decode_response(message), self._to_object)
@@ -322,21 +366,24 @@ class MultiMap(Proxy):
         return self._invoke(request, handler)
 
     def try_lock(self, key, lease_time=-1, timeout=-1):
-        """
-        Tries to acquire the lock for the specified key. When the lock is not available,
-
-            * If timeout is not provided, the current thread doesn't wait and returns ``false`` immediately.
-            * If a timeout is provided, the current thread becomes disabled for thread scheduling purposes and lies
-              dormant until one of the followings happens:
-                * the lock is acquired by the current thread, or
-                * the specified waiting time elapses.
-
+        """Tries to acquire the lock for the specified key. 
+        
+        When the lock is not available:
+            - If timeout is not provided, the current thread doesn't wait and returns ``false`` immediately.
+            - If a timeout is provided, the current thread becomes disabled for thread scheduling purposes and lies
+                dormant until one of the followings happens:
+                    - the lock is acquired by the current thread, or
+                    - the specified waiting time elapses.
+        
         If lease_time is provided, lock will be released after this time elapses.
 
-        :param key: (object), key to lock in this map.
-        :param lease_time: (int), time in seconds to wait before releasing the lock (optional).
-        :param timeout: (int), maximum time in seconds to wait for the lock (optional).
-        :return: (bool), ``true`` if the lock was acquired and otherwise, false.
+        Args:
+            key: Key to lock in this map.
+            lease_time (int): Time in seconds to wait before releasing the lock.
+            timeout (int): Maximum time in seconds to wait for the lock.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if the lock was acquired, ``False`` otherwise.
         """
         check_not_none(key, "key can't be None")
         key_data = self._to_data(key)
@@ -346,13 +393,17 @@ class MultiMap(Proxy):
         return self._invoke_on_key(request, key_data, multi_map_try_lock_codec.decode_response)
 
     def unlock(self, key):
-        """
-        Releases the lock for the specified key. It never blocks and returns immediately.
+        """Releases the lock for the specified key. It never blocks and returns immediately.
+        
+        Warning: 
+            This method uses ``__hash__`` and ``__eq__`` methods of binary form of the key, not the 
+            actual implementations of ``__hash__`` and ``__eq__`` defined in key's class.
 
-        **Warning: This method uses __hash__ and __eq__ methods of binary form of the key, not the actual implementations
-        of __hash__ and __eq__ defined in key's class.**
+        Args:
+            key: The key to lock.
 
-        :param key: (object), the key to lock.
+        Returns:
+            hazelcast.future.Future[None]:
         """
         check_not_none(key, "key can't be None")
         key_data = self._to_data(key)

--- a/hazelcast/proxy/pn_counter.py
+++ b/hazelcast/proxy/pn_counter.py
@@ -12,9 +12,8 @@ from hazelcast.six.moves import range
 
 
 class PNCounter(Proxy):
-    """
-    PN (Positive-Negative) CRDT counter.
-
+    """PN (Positive-Negative) CRDT counter.
+    
     The counter supports adding and subtracting values as well as
     retrieving the current counter value.
     Each replica of this counter can perform operations locally without
@@ -24,19 +23,19 @@ class PNCounter(Proxy):
     identical, and any conflicting updates are merged automatically.
     If no new updates are made to the shared state, all nodes that can
     communicate will eventually have the same data.
-
+    
     When invoking updates from the client, the invocation is remote.
     This may lead to indeterminate state - the update may be applied but the
     response has not been received. In this case, the caller will be notified
     with a TargetDisconnectedError.
-
+    
     The read and write methods provide monotonic read and RYW (read-your-write)
     guarantees. These guarantees are session guarantees which means that if
     no replica with the previously observed state is reachable, the session
     guarantees are lost and the method invocation will throw a
     ConsistencyLostError. This does not mean
     that an update is lost. All of the updates are part of some replica and
-    will be eventually reflected in the state of all other replicas. This
+    will be eventually reflected in the state of all other replicas. This 
     exception just means that you cannot observe your own writes because
     all replicas that contain your updates are currently unreachable.
     After you have received a ConsistencyLostError, you can either
@@ -45,10 +44,10 @@ class PNCounter(Proxy):
     the reset() method. If you have called the reset() method,
     a new session is started with the next invocation to a CRDT replica.
 
-    NOTE:
-    The CRDT state is kept entirely on non-lite (data) members. If there
-    aren't any and the methods here are invoked on a lite member, they will
-    fail with an NoDataMemberInClusterError.
+    Notes:
+        The CRDT state is kept entirely on non-lite (data) members. If there
+        aren't any and the methods here are invoked on a lite member, they will
+        fail with an NoDataMemberInClusterError.
     """
 
     _EMPTY_ADDRESS_LIST = []
@@ -60,121 +59,138 @@ class PNCounter(Proxy):
         self._current_target_replica_address = None
 
     def get(self):
-        """
-        Returns the current value of the counter.
+        """Returns the current value of the counter.
 
-        :raises NoDataMemberInClusterError: if the cluster does not contain any data members.
-        :raises ConsistencyLostError: if the session guarantees have been lost.
+        Returns:
+            hazelcast.future.Future[int]: The current value of the counter.
 
-        :return: (int), the current value of the counter.
+        Raises:
+            NoDataMemberInClusterError: if the cluster does not contain any data members.
+            ConsistencyLostError: if the session guarantees have been lost.
         """
         return self._invoke_internal(pn_counter_get_codec)
 
     def get_and_add(self, delta):
-        """
-        Adds the given value to the current value and returns the previous value.
+        """Adds the given value to the current value and returns the previous value.
 
-        :raises NoDataMemberInClusterError: if the cluster does not contain any data members.
-        :raises ConsistencyLostError: if the session guarantees have been lost.
+        Args:
+          delta (int): The value to add.
 
-        :param delta: (int), the value to add.
-        :return: (int), the previous value.
+        Returns:
+            hazelcast.future.Future[int]: The previous value.
+
+        Raises:
+            NoDataMemberInClusterError: if the cluster does not contain any data members.
+            ConsistencyLostError: if the session guarantees have been lost.
         """
 
         return self._invoke_internal(pn_counter_add_codec, delta=delta, get_before_update=True)
 
     def add_and_get(self, delta):
-        """
-        Adds the given value to the current value and returns the updated value.
+        """Adds the given value to the current value and returns the updated value.
 
-        :raises NoDataMemberInClusterError: if the cluster does not contain any data members.
-        :raises ConsistencyLostError: if the session guarantees have been lost.
+        Args:
+            delta (int): The value to add.
 
-        :param delta: (int), the value to add.
-        :return: (int), the updated value.
+        Returns:
+            hazelcast.future.Future[int]: The updated value.
+
+        Raises:
+            NoDataMemberInClusterError: if the cluster does not contain any data members.
+            ConsistencyLostError: if the session guarantees have been lost.
         """
 
         return self._invoke_internal(pn_counter_add_codec, delta=delta, get_before_update=False)
 
     def get_and_subtract(self, delta):
-        """
-        Subtracts the given value from the current value and returns the previous value.
+        """Subtracts the given value from the current value and returns the previous value.
 
-        :raises NoDataMemberInClusterError: if the cluster does not contain any data members.
-        :raises ConsistencyLostError: if the session guarantees have been lost.
+        Args:
+            delta (int): The value to subtract.
 
-        :param delta: (int), the value to subtract.
-        :return: (int), the previous value.
+        Returns:
+            hazelcast.future.Future[int]: The previous value.
+
+        Raises:
+            NoDataMemberInClusterError: if the cluster does not contain any data members.
+            ConsistencyLostError: if the session guarantees have been lost.
         """
 
         return self._invoke_internal(pn_counter_add_codec, delta=-1 * delta, get_before_update=True)
 
     def subtract_and_get(self, delta):
-        """
-        Subtracts the given value from the current value and returns the updated value.
+        """Subtracts the given value from the current value and returns the updated value.
 
-        :raises NoDataMemberInClusterError: if the cluster does not contain any data members.
-        :raises ConsistencyLostError: if the session guarantees have been lost.
+        Args:
+            delta (int): The value to subtract.
 
-        :param delta: (int), the value to subtract.
-        :return: (int), the updated value.
+        Returns:
+            hazelcast.future.Future[int]: The updated value.
+
+        Raises:
+            NoDataMemberInClusterError: if the cluster does not contain any data members.
+            ConsistencyLostError: if the session guarantees have been lost.
         """
 
         return self._invoke_internal(pn_counter_add_codec, delta=-1 * delta, get_before_update=False)
 
     def get_and_decrement(self):
-        """
-        Decrements the counter value by one and returns the previous value.
+        """Decrements the counter value by one and returns the previous value.
 
-        :raises NoDataMemberInClusterError: if the cluster does not contain any data members.
-        :raises ConsistencyLostError: if the session guarantees have been lost.
+        Returns:
+            hazelcast.future.Future[int]: The previous value.
 
-        :return: (int), the previous value.
+        Raises:
+            NoDataMemberInClusterError: if the cluster does not contain any data members.
+            ConsistencyLostError: if the session guarantees have been lost.
         """
 
         return self._invoke_internal(pn_counter_add_codec, delta=-1, get_before_update=True)
 
     def decrement_and_get(self):
-        """
-        Decrements the counter value by one and returns the updated value.
+        """Decrements the counter value by one and returns the updated value.
 
-        :raises NoDataMemberInClusterError: if the cluster does not contain any data members.
-        :raises ConsistencyLostError: if the session guarantees have been lost.
+        Returns:
+            hazelcast.future.Future[int]: The updated value.
 
-        :return: (int), the updated value.
+        Raises:
+            NoDataMemberInClusterError: if the cluster does not contain any data members.
+            ConsistencyLostError: if the session guarantees have been lost.
         """
 
         return self._invoke_internal(pn_counter_add_codec, delta=-1, get_before_update=False)
 
     def get_and_increment(self):
-        """
-        Increments the counter value by one and returns the previous value.
+        """Increments the counter value by one and returns the previous value.
 
-        :raises NoDataMemberInClusterError: if the cluster does not contain any data members.
-        :raises ConsistencyLostError: if the session guarantees have been lost.
+        Returns:
+            hazelcast.future.Future[int]: The previous value.
 
-        :return: (int), the previous value.
+        Raises:
+            NoDataMemberInClusterError: if the cluster does not contain any data members.
+            ConsistencyLostError: if the session guarantees have been lost.
         """
 
         return self._invoke_internal(pn_counter_add_codec, delta=1, get_before_update=True)
 
     def increment_and_get(self):
-        """
-        Increments the counter value by one and returns the updated value.
+        """Increments the counter value by one and returns the updated value.
 
-        :raises NoDataMemberInClusterError: if the cluster does not contain any data members.
-        :raises UnsupportedOperationError: if the cluster version is less than 3.10.
-        :raises ConsistencyLostError: if the session guarantees have been lost.
+        Returns:
+            hazelcast.future.Future[int]: The updated value.
 
-        :return: (int), the updated value.
+        Raises:
+            NoDataMemberInClusterError: if the cluster does not contain any data members.
+            UnsupportedOperationError: if the cluster version is less than 3.10.
+            ConsistencyLostError: if the session guarantees have been lost.
         """
 
         return self._invoke_internal(pn_counter_add_codec, delta=1, get_before_update=False)
 
     def reset(self):
-        """
-        Resets the observed state by this PN counter. This method may be used
-        after a method invocation has thrown a `ConsistencyLostError`
+        """Resets the observed state by this PN counter.
+
+        This method may be used after a method invocation has thrown a ``ConsistencyLostError``
         to reset the proxy and to be able to start a new session.
         """
 

--- a/hazelcast/proxy/ringbuffer.py
+++ b/hazelcast/proxy/ringbuffer.py
@@ -32,16 +32,18 @@ The maximum number of items to be added to RingBuffer or read from RingBuffer at
 
 
 class Ringbuffer(PartitionSpecificProxy):
-    """
-    A Ringbuffer is a data-structure where the content is stored in a ring like structure. A Ringbuffer has a capacity
-    so it won't grow beyond that capacity and endanger the stability of the system. If that capacity is exceeded, than
-    the oldest item in the Ringbuffer is overwritten. The Ringbuffer has 2 always incrementing sequences:
-        #. tail_sequence: this is the side where the youngest item is found. So the tail is the side of the Ringbuffer
-        where items are added to.
-        #. head_sequence: this is the side where the oldest items are found. So the head is the side where items gets
-        discarded.
+    """A Ringbuffer is a data-structure where the content is stored in a ring like structure. 
+    
+    A Ringbuffer has a capacity so it won't grow beyond that capacity and endanger the stability of the system. 
+    If that capacity is exceeded, than the oldest item in the Ringbuffer is overwritten. 
+    The Ringbuffer has 2 always incrementing sequences:
+        - Tail_sequence: This is the side where the youngest item is found. So the tail is the side of the Ringbuffer
+            where items are added to.
+        - Head_sequence: This is the side where the oldest items are found. So the head is the side where items gets
+            discarded.
+            
     The items in the Ringbuffer can be found by a sequence that is in between (inclusive) the head and tail sequence.
-
+    
     A Ringbuffer currently is not a distributed data-structure. So all data is stored in a single partition; comparable
     to the IQueue implementation. But we'll provide an option to partition the data in the near future. A Ringbuffer
     can be used in a similar way as a queue, but one of the key differences is that a queue.take is destructive,
@@ -53,10 +55,10 @@ class Ringbuffer(PartitionSpecificProxy):
         self._capacity = None
 
     def capacity(self):
-        """
-        Returns the capacity of this Ringbuffer.
-
-        :return: (long), the capacity of Ringbuffer.
+        """Returns the capacity of this Ringbuffer.
+        
+        Returns:
+            hazelcast.future.Future[int]: The capacity of Ringbuffer.
         """
         if not self._capacity:
             def handler(message):
@@ -68,69 +70,80 @@ class Ringbuffer(PartitionSpecificProxy):
         return ImmediateFuture(self._capacity)
 
     def size(self):
-        """
-        Returns number of items in the Ringbuffer.
-
-        :return: (long), the size of Ringbuffer.
+        """Returns number of items in the Ringbuffer.
+        
+        Returns:
+            hazelcast.future.Future[int]: The size of Ringbuffer.
         """
         request = ringbuffer_size_codec.encode_request(self.name)
         return self._invoke(request, ringbuffer_size_codec.decode_response)
 
     def tail_sequence(self):
-        """
-        Returns the sequence of the tail. The tail is the side of the Ringbuffer where the items are added to. The
-        initial value of the tail is -1.
+        """Returns the sequence of the tail. 
+        
+        The tail is the side of the Ringbuffer where the items are added to. The initial value of the tail is -1.
 
-        :return: (long), the sequence of the tail.
+        Returns:
+            hazelcast.future.Future[int]: The sequence of the tail.
         """
         request = ringbuffer_tail_sequence_codec.encode_request(self.name)
         return self._invoke(request, ringbuffer_tail_sequence_codec.decode_response)
 
     def head_sequence(self):
-        """
-        Returns the sequence of the head. The head is the side of the Ringbuffer where the oldest items in the
-        Ringbuffer are found. If the Ringbuffer is empty, the head will be one more than the tail. The initial value of
+        """Returns the sequence of the head. 
+        
+        The head is the side of the Ringbuffer where the oldest items in the Ringbuffer are found. 
+        If the Ringbuffer is empty, the head will be one more than the tail. The initial value of
         the head is 0 (1 more than tail).
-
-        :return: (long), the sequence of the head.
+        
+        Returns:
+            hazelcast.future.Future[int]: The sequence of the head.
         """
         request = ringbuffer_head_sequence_codec.encode_request(self.name)
         return self._invoke(request, ringbuffer_head_sequence_codec.decode_response)
 
     def remaining_capacity(self):
-        """
-        Returns the remaining capacity of the Ringbuffer.
-
-        :return: (long), the remaining capacity of Ringbuffer.
+        """Returns the remaining capacity of the Ringbuffer.
+        
+        Returns:
+            hazelcast.future.Future[int]: The remaining capacity of Ringbuffer.
         """
         request = ringbuffer_remaining_capacity_codec.encode_request(self.name)
         return self._invoke(request, ringbuffer_remaining_capacity_codec.decode_response)
 
     def add(self, item, overflow_policy=OVERFLOW_POLICY_OVERWRITE):
-        """
-        Adds the specified item to the tail of the Ringbuffer. If there is no space in the Ringbuffer, the action is
-        determined by overflow policy as :const:`OVERFLOW_POLICY_OVERWRITE` or :const:`OVERFLOW_POLICY_FAIL`.
+        """Adds the specified item to the tail of the Ringbuffer. 
+        
+        If there is no space in the Ringbuffer, the action is determined by overflow policy 
+        as ``OVERFLOW_POLICY_OVERWRITE`` or ``OVERFLOW_POLICY_FAIL``.
 
-        :param item: (object), the specified item to be added.
-        :param overflow_policy: (int), the OverflowPolicy to be used when there is no space (optional).
-        :return: (long), the sequenceId of the added item, or -1 if the add failed.
+        Args:
+            item: The specified item to be added.
+            overflow_policy (int): the OverflowPolicy to be used when there is no space.
+
+        Returns:
+            hazelcast.future.Future[int]: The sequenceId of the added item, or ``-1`` if the add failed.
         """
         item_data = self._to_data(item)
         request = ringbuffer_add_codec.encode_request(self.name, overflow_policy, item_data)
         return self._invoke(request, ringbuffer_add_codec.decode_response)
 
     def add_all(self, items, overflow_policy=OVERFLOW_POLICY_OVERWRITE):
-        """
-        Adds all of the item in the specified collection to the tail of the Ringbuffer. An add_all is likely to
-        outperform multiple calls to add(object) due to better io utilization and a reduced number of executed
-        operations. The items are added in the order of the Iterator of the collection.
+        """Adds all of the item in the specified collection to the tail of the Ringbuffer. 
+        
+        An add_all is likely to outperform multiple calls to add(object) due to better io utilization 
+        and a reduced number of executed operations. The items are added in the order of the Iterator of the collection.
+        
+        If there is no space in the Ringbuffer, the action is determined by overflow policy 
+        as ``OVERFLOW_POLICY_OVERWRITE`` or ``OVERFLOW_POLICY_FAIL``.
 
-        If there is no space in the Ringbuffer, the action is determined by overflow policy as :const:`OVERFLOW_POLICY_OVERWRITE`
-        or :const:`OVERFLOW_POLICY_FAIL`.
+        Args:
+            items (list): The specified collection which contains the items to be added.
+            overflow_policy (int): The OverflowPolicy to be used when there is no space.
 
-        :param items: (Collection), the specified collection which contains the items to be added.
-        :param overflow_policy: (int), the OverflowPolicy to be used when there is no space (optional).
-        :return: (long), the sequenceId of the last written item, or -1 of the last write is failed.
+        Returns:
+            hazelcast.future.Future[int]: The sequenceId of the last written item, or ``-1`` 
+                of the last write is failed.
         """
         check_not_empty(items, "items can't be empty")
         if len(items) > MAX_BATCH_SIZE:
@@ -145,12 +158,16 @@ class Ringbuffer(PartitionSpecificProxy):
         return self._invoke(request, ringbuffer_add_all_codec.decode_response)
 
     def read_one(self, sequence):
-        """
-        Reads one item from the Ringbuffer. If the sequence is one beyond the current tail, this call blocks until an
-        item is added. Currently it isn't possible to control how long this call is going to block.
+        """Reads one item from the Ringbuffer. 
+        
+        If the sequence is one beyond the current tail, this call blocks until an item is added. 
+        Currently it isn't possible to control how long this call is going to block.
 
-        :param sequence: (long), the sequence of the item to read.
-        :return: (object), the read item.
+        Args:
+            sequence (int): The sequence of the item to read.
+
+        Returns:
+            The read item.
         """
         check_not_negative(sequence, "sequence can't be smaller than 0")
 
@@ -161,16 +178,20 @@ class Ringbuffer(PartitionSpecificProxy):
         return self._invoke(request, handler)
 
     def read_many(self, start_sequence, min_count, max_count):
-        """
-        Reads a batch of items from the Ringbuffer. If the number of available items after the first read item is
-        smaller than the max_count, these items are returned. So it could be the number of items read is smaller than
-        the max_count. If there are less items available than min_count, then this call blocks. Reading a batch of items
+        """Reads a batch of items from the Ringbuffer. 
+        
+        If the number of available items after the first read item is smaller than the max_count, 
+        these items are returned. So it could be the number of items read is smaller than the max_count. 
+        If there are less items available than min_count, then this call blocks. Reading a batch of items
         is likely to perform better because less overhead is involved.
 
-        :param start_sequence: (long),  the start_sequence of the first item to read.
-        :param min_count: (int), the minimum number of items to read.
-        :param max_count: (int), the maximum number of items to read.
-        :return: (Sequence), the list of read items.
+        Args:
+            start_sequence (int): The start_sequence of the first item to read.
+            min_count (int): The minimum number of items to read.
+            max_count (int): The maximum number of items to read.
+
+        Returns:
+            hazelcast.future.Future[list]: The list of read items.
         """
         check_not_negative(start_sequence, "sequence can't be smaller than 0")
         check_true(max_count >= min_count, "max count should be greater or equal to min count")

--- a/hazelcast/proxy/ringbuffer.py
+++ b/hazelcast/proxy/ringbuffer.py
@@ -10,6 +10,7 @@ OVERFLOW_POLICY_OVERWRITE = 0
 Configuration property for DEFAULT overflow policy. When an item is tried to be added on full Ringbuffer, oldest item in
 the Ringbuffer is overwritten and item is added.
 """
+
 OVERFLOW_POLICY_FAIL = 1
 """
 Configuration property for overflow policy. When an item is tried to be added on full Ringbuffer, the call fails and
@@ -17,6 +18,7 @@ item is not added.
 
 The reason that FAIL exist is to give the opportunity to obey the ttl. If blocking behavior is required, this can be
 implemented using retrying in combination with an exponential backoff.
+
     >>> sleepMS = 100;
     >>> while true:
     >>>     result = ringbuffer.add(item, -1)
@@ -37,10 +39,11 @@ class Ringbuffer(PartitionSpecificProxy):
     A Ringbuffer has a capacity so it won't grow beyond that capacity and endanger the stability of the system. 
     If that capacity is exceeded, than the oldest item in the Ringbuffer is overwritten. 
     The Ringbuffer has 2 always incrementing sequences:
-        - Tail_sequence: This is the side where the youngest item is found. So the tail is the side of the Ringbuffer
-            where items are added to.
-        - Head_sequence: This is the side where the oldest items are found. So the head is the side where items gets
-            discarded.
+
+    - Tail_sequence: This is the side where the youngest item is found. So the tail is the side of the Ringbuffer
+      where items are added to.
+    - Head_sequence: This is the side where the oldest items are found. So the head is the side where items gets
+      discarded.
             
     The items in the Ringbuffer can be found by a sequence that is in between (inclusive) the head and tail sequence.
     

--- a/hazelcast/proxy/set.py
+++ b/hazelcast/proxy/set.py
@@ -18,15 +18,16 @@ from hazelcast.util import check_not_none, ImmutableLazyDataList
 
 
 class Set(PartitionSpecificProxy):
-    """
-    Concurrent, distributed implementation of ``Set``.
-    """
+    """Concurrent, distributed implementation of Set"""
+    
     def add(self, item):
-        """
-        Adds the specified item if it is not exists in this set.
+        """Adds the specified item if it is not exists in this set.
 
-        :param item: (object), the specified item to be added.
-        :return: (bool), ``true`` if this set is changed after call, ``false`` otherwise.
+        Args:
+            item: The specified item to be added.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if this set is changed after call, ``False`` otherwise.
         """
         check_not_none(item, "Value can't be None")
         element_data = self._to_data(item)
@@ -34,11 +35,13 @@ class Set(PartitionSpecificProxy):
         return self._invoke(request, set_add_codec.decode_response)
 
     def add_all(self, items):
-        """
-        Adds the elements in the specified collection if they're not exist in this set.
+        """Adds the elements in the specified collection if they're not exist in this set.
 
-        :param items: (Collection), collection which includes the items to be added.
-        :return: (bool), ``true`` if this set is changed after call, ``false`` otherwise.
+        Args:
+            items (list): Collection which includes the items to be added.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if this set is changed after call, ``False`` otherwise.
         """
         check_not_none(items, "Value can't be None")
         data_items = []
@@ -50,13 +53,17 @@ class Set(PartitionSpecificProxy):
         return self._invoke(request, set_add_all_codec.decode_response)
 
     def add_listener(self, include_value=False, item_added_func=None, item_removed_func=None):
-        """
-        Adds an item listener for this container. Listener will be notified for all container add/remove events.
+        """Adds an item listener for this container. 
+        
+        Listener will be notified for all container add/remove events.
 
-        :param include_value: (bool), whether received events include the updated item or not (optional).
-        :param item_added_func: Function to be called when an item is added to this set (optional).
-        :param item_removed_func: Function to be called when an item is deleted from this set (optional).
-        :return: (str), a registration id which is used as a key to remove the listener.
+        Args:
+            include_value (bool): Whether received events include the updated item or not.
+            item_added_func (function): Function to be called when an item is added to this set.
+            item_removed_func (function): Function to be called when an item is deleted from this set.
+
+        Returns:
+            str: A registration id which is used as a key to remove the listener.
         """
         request = set_add_listener_codec.encode_request(self.name, include_value, self._is_smart)
 
@@ -77,18 +84,22 @@ class Set(PartitionSpecificProxy):
                                        lambda m: set_add_listener_codec.handle(m, handle_event_item))
 
     def clear(self):
-        """
-        Clears the set. Set will be empty with this call.
+        """Clears the set. Set will be empty with this call.
+        
+        Returns:
+            hazelcast.future.Future[None]:
         """
         request = set_clear_codec.encode_request(self.name)
         return self._invoke(request)
 
     def contains(self, item):
-        """
-        Determines whether this set contains the specified item or not.
+        """Determines whether this set contains the specified item or not.
 
-        :param item: (object), the specified item to be searched.
-        :return: (bool), ``true`` if the specified item exists in this set, ``false`` otherwise.
+        Args:
+            item: The specified item to be searched.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if the specified item exists in this set, ``False`` otherwise.
         """
         check_not_none(item, "Value can't be None")
         item_data = self._to_data(item)
@@ -96,11 +107,14 @@ class Set(PartitionSpecificProxy):
         return self._invoke(request, set_contains_codec.decode_response)
 
     def contains_all(self, items):
-        """
-        Determines whether this set contains all of the items in the specified collection or not.
+        """Determines whether this set contains all of the items in the specified collection or not.
 
-        :param items: (Collection), the specified collection which includes the items to be searched.
-        :return: (bool), ``true`` if all of the items in the specified collection exist in this set, ``false`` otherwise.
+        Args:
+            items (list): The specified collection which includes the items to be searched.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if all of the items in the specified collection exist in this set, 
+                ``False`` otherwise.
         """
         check_not_none(items, "Value can't be None")
         data_items = []
@@ -112,10 +126,10 @@ class Set(PartitionSpecificProxy):
         return self._invoke(request, set_contains_all_codec.decode_response)
 
     def get_all(self):
-        """
-        Returns all of the items in the set.
-
-        :return: (Sequence), list of the items in this set.
+        """Returns all of the items in the set.
+        
+        Returns:
+            hazelcast.future.Future[list]: List of the items in this set.
         """
         def handler(message):
             return ImmutableLazyDataList(set_get_all_codec.decode_response(message), self._to_object)
@@ -124,20 +138,22 @@ class Set(PartitionSpecificProxy):
         return self._invoke(request, handler)
 
     def is_empty(self):
-        """
-        Determines whether this set is empty or not.
-
-        :return: (bool), ``true`` if this set is empty, ``false`` otherwise.
+        """Determines whether this set is empty or not.
+        
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if this set is empty, ``False`` otherwise.
         """
         request = set_is_empty_codec.encode_request(self.name)
         return self._invoke(request, set_is_empty_codec.decode_response)
 
     def remove(self, item):
-        """
-        Removes the specified element from the set if it exists.
+        """Removes the specified element from the set if it exists.
 
-        :param item: (object), the specified element to be removed.
-        :return: (bool), ``true`` if the specified element exists in this set.
+        Args:
+            item: The specified element to be removed.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if the specified element exists in this set, ``False`` otherwise.
         """
         check_not_none(item, "Value can't be None")
         item_data = self._to_data(item)
@@ -145,11 +161,13 @@ class Set(PartitionSpecificProxy):
         return self._invoke(request, set_remove_codec.decode_response)
 
     def remove_all(self, items):
-        """
-        Removes all of the elements of the specified collection from this set.
+        """Removes all of the elements of the specified collection from this set.
 
-        :param items: (Collection), the specified collection.
-        :return: (bool), ``true`` if the call changed this set, ``false`` otherwise.
+        Args:
+            items (list): The specified collection.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if the call changed this set, ``False`` otherwise.
         """
         check_not_none(items, "Value can't be None")
         data_items = []
@@ -161,21 +179,28 @@ class Set(PartitionSpecificProxy):
         return self._invoke(request, set_compare_and_remove_all_codec.decode_response)
 
     def remove_listener(self, registration_id):
-        """
-        Removes the specified item listener. Returns silently if the specified listener was not added before.
+        """Removes the specified item listener. 
+        
+        Returns silently if the specified listener was not added before.
 
-        :param registration_id: (str), id of the listener to be deleted.
-        :return: (bool), ``true`` if the item listener is removed, ``false`` otherwise.
+        Args:
+            registration_id (str): Id of the listener to be deleted.
+
+        Returns:
+            bool: ``True`` if the item listener is removed, ``False`` otherwise.
         """
         return self._deregister_listener(registration_id)
 
     def retain_all(self, items):
-        """
-        Removes the items which are not contained in the specified collection. In other words, only the items that are
-        contained in the specified collection will be retained.
+        """Removes the items which are not contained in the specified collection. 
+        
+        In other words, only the items that are contained in the specified collection will be retained.
 
-        :param items: (Collection), collection which includes the elements to be retained in this set.
-        :return: (bool), ``true`` if this set changed as a result of the call.
+        Args:
+            items (list): Collection which includes the elements to be retained in this set.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if this set changed as a result of the call, ``False`` otherwise.
         """
         check_not_none(items, "Value can't be None")
         data_items = []
@@ -187,10 +212,10 @@ class Set(PartitionSpecificProxy):
         return self._invoke(request, set_compare_and_retain_all_codec.decode_response)
 
     def size(self):
-        """
-        Returns the number of items in this set.
-
-        :return: (int), number of items in this set.
+        """Returns the number of items in this set.
+        
+        Returns:
+            hazelcast.future.Future[int]: Number of items in this set.
         """
         request = set_size_codec.encode_request(self.name)
         return self._invoke(request, set_size_codec.decode_response)

--- a/hazelcast/proxy/topic.py
+++ b/hazelcast/proxy/topic.py
@@ -6,30 +6,33 @@ from hazelcast.proxy.base import PartitionSpecificProxy, TopicMessage
 
 
 class Topic(PartitionSpecificProxy):
-    """
-    Hazelcast provides distribution mechanism for publishing messages that are delivered to multiple subscribers, which
-    is also known as a publish/subscribe (pub/sub) messaging model. Publish and subscriptions are cluster-wide. When a
-    member subscribes for a topic, it is actually registering for messages published by any member in the cluster,
+    """Hazelcast provides distribution mechanism for publishing messages that are delivered to multiple subscribers, 
+    which is also known as a publish/subscribe (pub/sub) messaging model. 
+    
+    Publish and subscriptions are cluster-wide. When a member subscribes for a topic, 
+    it is actually registering for messages published by any member in the cluster, 
     including the new members joined after you added the listener.
-
+    
     Messages are ordered, meaning that listeners(subscribers) will process the messages in the order they are actually
     published.
-
     """
     def add_listener(self, on_message=None):
-        """
-        Subscribes to this topic. When someone publishes a message on this topic, on_message() function is called if
-        provided.
+        """Subscribes to this topic. 
+        
+        When someone publishes a message on this topic, ``on_message`` function is called if provided.
 
-        :param on_message: (Function), function to be called when a message is published.
-        :return: (str), a registration id which is used as a key to remove the listener.
+        Args:
+            on_message (function): Function to be called when a message is published.
+
+        Returns:
+            str: A registration id which is used as a key to remove the listener.
         """
         codec = topic_add_message_listener_codec
         request = codec.encode_request(self.name, self._is_smart)
 
         def handle(item, publish_time, uuid):
             member = self._context.cluster_service.get_member(uuid)
-            item_event = TopicMessage(self.name, item, publish_time, member, self._to_object)
+            item_event = TopicMessage(self.name, item, publish_time / 1000.0, member, self._to_object)
             on_message(item_event)
 
         return self._register_listener(
@@ -38,21 +41,27 @@ class Topic(PartitionSpecificProxy):
             lambda m: codec.handle(m, handle))
 
     def publish(self, message):
-        """
-        Publishes the message to all subscribers of this topic
+        """Publishes the message to all subscribers of this topic
 
-        :param message: (object), the message to be published.
+        Args:
+            message: The message to be published.
+
+        Returns:
+            hazelcast.future.Future[None]:
         """
         message_data = self._to_data(message)
         request = topic_publish_codec.encode_request(self.name, message_data)
         return self._invoke(request)
 
     def remove_listener(self, registration_id):
-        """
-        Stops receiving messages for the given message listener. If the given listener already removed, this method does
-        nothing.
+        """Stops receiving messages for the given message listener.
 
-        :param registration_id: (str), registration id of the listener to be removed.
-        :return: (bool), ``true`` if the listener is removed, ``false`` otherwise.
+        If the given listener already removed, this method does nothing.
+
+        Args:
+            registration_id (str): Registration id of the listener to be removed.
+
+        Returns:
+            bool: ``True`` if the listener is removed, ``False`` otherwise.
         """
         return self._deregister_listener(registration_id)

--- a/hazelcast/proxy/transactional_list.py
+++ b/hazelcast/proxy/transactional_list.py
@@ -9,11 +9,13 @@ class TransactionalList(TransactionalProxy):
     Transactional implementation of :class:`~hazelcast.proxy.list.List`.
     """
     def add(self, item):
-        """
-        Transactional implementation of :func:`List.add(item) <hazelcast.proxy.list.List.add>`
+        """Transactional implementation of :func:`List.add(item) <hazelcast.proxy.list.List.add>`
 
-        :param item: (object), the new item to be added.
-        :return: (bool), ``true`` if the item is added successfully, ``false`` otherwise.
+        Args:
+            item: The new item to be added.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if the item is added successfully, ``False`` otherwise.
         """
         check_not_none(item, "item can't be none")
         item_data = self._to_data(item)
@@ -21,11 +23,13 @@ class TransactionalList(TransactionalProxy):
         return self._invoke(request, transactional_list_add_codec.decode_response)
 
     def remove(self, item):
-        """
-        Transactional implementation of :func:`List.remove(item) <hazelcast.proxy.list.List.remove>`
+        """Transactional implementation of :func:`List.remove(item) <hazelcast.proxy.list.List.remove>`
 
-        :param item: (object), the specified item to be removed.
-        :return: (bool), ``true`` if the item is removed successfully, ``false`` otherwise.
+        Args:
+            item: The specified item to be removed.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if the item is removed successfully, ``False`` otherwise.
         """
         check_not_none(item, "item can't be none")
         item_data = self._to_data(item)
@@ -33,10 +37,10 @@ class TransactionalList(TransactionalProxy):
         return self._invoke(request, transactional_list_remove_codec.decode_response)
 
     def size(self):
-        """
-        Transactional implementation of :func:`List.size() <hazelcast.proxy.list.List.size>`
-
-        :return: (int), the size of the list.
+        """Transactional implementation of :func:`List.size() <hazelcast.proxy.list.List.size>`
+        
+        Returns:
+            hazelcast.future.Future[int]: The size of the list.
         """
         request = transactional_list_size_codec.encode_request(self.name, self.transaction.id, thread_id())
         return self._invoke(request, transactional_list_size_codec.decode_response)

--- a/hazelcast/proxy/transactional_map.py
+++ b/hazelcast/proxy/transactional_map.py
@@ -9,16 +9,17 @@ from hazelcast.util import check_not_none, to_millis, thread_id, ImmutableLazyDa
 
 
 class TransactionalMap(TransactionalProxy):
-    """
-    Transactional implementation of :class:`~hazelcast.proxy.map.Map`.
-    """
+    """Transactional implementation of :class:`~hazelcast.proxy.map.Map`."""
 
     def contains_key(self, key):
-        """
-        Transactional implementation of :func:`Map.contains_key(key) <hazelcast.proxy.map.Map.contains_key>`
+        """Transactional implementation of :func:`Map.contains_key(key) <hazelcast.proxy.map.Map.contains_key>`
 
-        :param key: (object), the specified key.
-        :return: (bool), ``true`` if this map contains an entry for the specified key, ``false`` otherwise.
+        Args:
+            key: The specified key.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if this map contains an entry for the specified key, 
+                ``False`` otherwise.
         """
         check_not_none(key, "key can't be none")
         key_data = self._to_data(key)
@@ -27,11 +28,13 @@ class TransactionalMap(TransactionalProxy):
         return self._invoke(request, transactional_map_contains_key_codec.decode_response)
 
     def get(self, key):
-        """
-        Transactional implementation of :func:`Map.get(key) <hazelcast.proxy.map.Map.get>`
+        """Transactional implementation of :func:`Map.get(key) <hazelcast.proxy.map.Map.get>`
 
-        :param key: (object), the specified key.
-        :return: (object), the value for the specified key.
+        Args:
+            key: The specified key.
+
+        Returns:
+            hazelcast.future.Future[any]: The value for the specified key.
         """
         check_not_none(key, "key can't be none")
 
@@ -43,15 +46,18 @@ class TransactionalMap(TransactionalProxy):
         return self._invoke(request, handler)
 
     def get_for_update(self, key):
-        """
-        Locks the key and then gets and returns the value to which the specified key is mapped. Lock will be released at
-        the end of the transaction (either commit or rollback).
+        """Locks the key and then gets and returns the value to which the specified key is mapped. 
+        
+        Lock will be released at the end of the transaction (either commit or rollback).
 
-        :param key: (object), the specified key.
-        :return: (object), the value for the specified key.
+        Args:
+            key: The specified key.
 
+        Returns:
+            hazelcast.future.Future[any]: The value for the specified key.
+            
         .. seealso::
-            :func:`Map.get(key) <hazelcast.proxy.map.Map.get>`
+        :func:`Map.get(key) <hazelcast.proxy.map.Map.get>`
         """
         check_not_none(key, "key can't be none")
 
@@ -64,34 +70,37 @@ class TransactionalMap(TransactionalProxy):
         return self._invoke(request, handler)
 
     def size(self):
-        """
-        Transactional implementation of :func:`Map.size() <hazelcast.proxy.map.Map.size>`
+        """Transactional implementation of :func:`Map.size() <hazelcast.proxy.map.Map.size>`
 
-        :return: (int), number of entries in this map.
+        Returns:
+            hazelcast.future.Future[int]: Number of entries in this map.
         """
         request = transactional_map_size_codec.encode_request(self.name, self.transaction.id, thread_id())
         return self._invoke(request, transactional_map_size_codec.decode_response)
 
     def is_empty(self):
-        """
-        Transactional implementation of :func:`Map.is_empty() <hazelcast.proxy.map.Map.is_empty>`
+        """Transactional implementation of :func:`Map.is_empty() <hazelcast.proxy.map.Map.is_empty>`
 
-        :return: (bool), ``true`` if this map contains no key-value mappings, ``false`` otherwise.
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if this map contains no key-value mappings, ``False`` otherwise.
         """
         request = transactional_map_is_empty_codec.encode_request(self.name, self.transaction.id, thread_id())
         return self._invoke(request, transactional_map_is_empty_codec.decode_response)
 
     def put(self, key, value, ttl=-1):
-        """
-        Transactional implementation of :func:`Map.put(key, value, ttl) <hazelcast.proxy.map.Map.put>`
-
+        """Transactional implementation of :func:`Map.put(key, value, ttl) <hazelcast.proxy.map.Map.put>`
+        
         The object to be put will be accessible only in the current transaction context till the transaction is
         committed.
 
-        :param key: (object), the specified key.
-        :param value: (object), the value to associate with the key.
-        :param ttl: (int), maximum time in seconds for this entry to stay (optional).
-        :return: (object), previous value associated with key or ``None`` if there was no mapping for key.
+        Args:
+            key: The specified key.
+            value: The value to associate with the key.
+            ttl (int): Maximum time in seconds for this entry to stay.
+
+        Returns:
+            hazelcast.future.Future[any]: Previous value associated with key or ``None`` 
+                if there was no mapping for key.
         """
         check_not_none(key, "key can't be none")
         check_not_none(value, "value can't be none")
@@ -106,16 +115,17 @@ class TransactionalMap(TransactionalProxy):
         return self._invoke(request, handler)
 
     def put_if_absent(self, key, value):
-        """
-        Transactional implementation of :func:`Map.put_if_absent(key, value)
-        <hazelcast.proxy.map.Map.put_if_absent>`
-
+        """Transactional implementation of :func:`Map.put_if_absent(key, value) <hazelcast.proxy.map.Map.put_if_absent>`
+        
         The object to be put will be accessible only in the current transaction context till the transaction is
         committed.
 
-        :param key: (object), key of the entry.
-        :param value: (object), value of the entry.
-        :return: (object), old value of the entry.
+        Args:
+            key: Key of the entry.
+            value: Value of the entry.
+
+        Returns:
+          hazelcast.future.Future[any]: Old value of the entry.
         """
         check_not_none(key, "key can't be none")
         check_not_none(value, "value can't be none")
@@ -130,14 +140,17 @@ class TransactionalMap(TransactionalProxy):
         return self._invoke(request, handler)
 
     def set(self, key, value):
-        """
-        Transactional implementation of :func:`Map.set(key, value) <hazelcast.proxy.map.Map.set>`
-
+        """Transactional implementation of :func:`Map.set(key, value) <hazelcast.proxy.map.Map.set>`
+        
         The object to be set will be accessible only in the current transaction context till the transaction is
         committed.
 
-        :param key: (object), key of the entry.
-        :param value: (object), value of the entry.
+        Args:
+            key: Key of the entry.
+            value: Value of the entry.
+
+        Returns:
+            hazelcast.future.Future[None]:
         """
         check_not_none(key, "key can't be none")
         check_not_none(value, "value can't be none")
@@ -149,15 +162,18 @@ class TransactionalMap(TransactionalProxy):
         return self._invoke(request)
 
     def replace(self, key, value):
-        """
-        Transactional implementation of :func:`Map.replace(key, value) <hazelcast.proxy.map.Map.replace>`
-
+        """Transactional implementation of :func:`Map.replace(key, value) <hazelcast.proxy.map.Map.replace>`
+        
         The object to be replaced will be accessible only in the current transaction context till the transaction is
         committed.
 
-        :param key: (object), the specified key.
-        :param value: (object), the value to replace the previous value.
-        :return: (object), previous value associated with key, or ``None`` if there was no mapping for key.
+        Args:
+            key: The specified key.
+            value: The value to replace the previous value.
+
+        Returns:
+            hazelcast.future.Future[any]: Previous value associated with key, or ``None`` 
+                if there was no mapping for key.
         """
         check_not_none(key, "key can't be none")
         check_not_none(value, "value can't be none")
@@ -172,17 +188,19 @@ class TransactionalMap(TransactionalProxy):
         return self._invoke(request, handler)
 
     def replace_if_same(self, key, old_value, new_value):
-        """
-        Transactional implementation of :func:`Map.replace_if_same(key, old_value, new_value)
+        """Transactional implementation of :func:`Map.replace_if_same(key, old_value, new_value)
         <hazelcast.proxy.map.Map.replace_if_same>`
-
+        
         The object to be replaced will be accessible only in the current transaction context till the transaction is
         committed.
 
-        :param key: (object), the specified key.
-        :param old_value: (object), replace the key value if it is the old value.
-        :param new_value: (object), the new value to replace the old value.
-        :return: (bool), ``true`` if the value was replaced, ``false`` otherwise.
+        Args:
+            key: The specified key.
+            old_value: Replace the key value if it is the old value.
+            new_value: The new value to replace the old value.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if the value was replaced, ``False`` otherwise.
         """
         check_not_none(key, "key can't be none")
         check_not_none(old_value, "old_value can't be none")
@@ -196,14 +214,17 @@ class TransactionalMap(TransactionalProxy):
         return self._invoke(request, transactional_map_replace_if_same_codec.decode_response)
 
     def remove(self, key):
-        """
-        Transactional implementation of :func:`Map.remove(key) <hazelcast.proxy.map.Map.remove>`
-
+        """Transactional implementation of :func:`Map.remove(key) <hazelcast.proxy.map.Map.remove>`
+        
         The object to be removed will be removed from only the current transaction context until the transaction is
         committed.
 
-        :param key: (object), key of the mapping to be deleted.
-        :return: (object), the previous value associated with key, or ``None`` if there was no mapping for key.
+        Args:
+            key: Key of the mapping to be deleted.
+
+        Returns:
+            hazelcast.future.Future[any]: The previous value associated with key, or ``None`` 
+                if there was no mapping for key.
         """
         check_not_none(key, "key can't be none")
 
@@ -215,18 +236,19 @@ class TransactionalMap(TransactionalProxy):
         return self._invoke(request, handler)
 
     def remove_if_same(self, key, value):
-        """
-        Transactional implementation of :func:`Map.remove_if_same(key, value)
+        """Transactional implementation of :func:`Map.remove_if_same(key, value)
         <hazelcast.proxy.map.Map.remove_if_same>`
-
+        
         The object to be removed will be removed from only the current transaction context until the transaction is
         committed.
 
-        :param key: (object), the specified key.
-        :param value: (object), remove the key if it has this value.
-        :return: (bool), ``true`` if the value was removed, ``false`` otherwise.
-        """
+        Args:
+            key: The specified key.
+            value: Remove the key if it has this value.
 
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if the value was removed, ``False`` otherwise.
+        """
         check_not_none(key, "key can't be none")
         check_not_none(value, "value can't be none")
 
@@ -237,13 +259,16 @@ class TransactionalMap(TransactionalProxy):
         return self._invoke(request, transactional_map_remove_if_same_codec.decode_response)
 
     def delete(self, key):
-        """
-        Transactional implementation of :func:`Map.delete(key) <hazelcast.proxy.map.Map.delete>`
-
+        """Transactional implementation of :func:`Map.delete(key) <hazelcast.proxy.map.Map.delete>`
+        
         The object to be deleted will be removed from only the current transaction context until the transaction is
         committed.
 
-        :param key: (object), key of the mapping to be deleted.
+        Args:
+            key: Key of the mapping to be deleted.
+
+        Returns:
+            hazelcast.future.Future[None]:
         """
         check_not_none(key, "key can't be none")
 
@@ -252,14 +277,13 @@ class TransactionalMap(TransactionalProxy):
         return self._invoke(request)
 
     def key_set(self, predicate=None):
-        """
-        Transactional implementation of :func:`Map.key_set(predicate) <hazelcast.proxy.map.Map.key_set>`
+        """Transactional implementation of :func:`Map.key_set(predicate) <hazelcast.proxy.map.Map.key_set>`
 
-        :param predicate: (Predicate), predicate to filter the entries (optional).
-        :return: (Sequence), a list of the clone of the keys.
+        Args:
+            predicate (hazelcast.serialization.predicate.Predicate): Predicate to filter the entries.
 
-        .. seealso::
-            :class:`~hazelcast.serialization.predicate.Predicate` for more info about predicates.
+        Returns:
+            hazelcast.future.Future[list]: A list of the clone of the keys.
         """
         if predicate:
             def handler(message):
@@ -278,14 +302,13 @@ class TransactionalMap(TransactionalProxy):
         return self._invoke(request, handler)
 
     def values(self, predicate=None):
-        """
-        Transactional implementation of :func:`Map.values(predicate) <hazelcast.proxy.map.Map.values>`
+        """Transactional implementation of :func:`Map.values(predicate) <hazelcast.proxy.map.Map.values>`
 
-        :param predicate: (Predicate), predicate to filter the entries (optional).
-        :return: (Sequence), a list of clone of the values contained in this map.
+        Args:
+            predicate (hazelcast.serialization.predicate.Predicate): Predicate to filter the entries.
 
-        .. seealso::
-            :class:`~hazelcast.serialization.predicate.Predicate` for more info about predicates.
+        Returns:
+            hazelcast.future.Future[list]: A list of clone of the values contained in this map.
         """
         if predicate:
             def handler(message):

--- a/hazelcast/proxy/transactional_map.py
+++ b/hazelcast/proxy/transactional_map.py
@@ -56,8 +56,8 @@ class TransactionalMap(TransactionalProxy):
         Returns:
             hazelcast.future.Future[any]: The value for the specified key.
             
-        .. seealso::
-        :func:`Map.get(key) <hazelcast.proxy.map.Map.get>`
+        See Also:
+            :func:`Map.get(key) <hazelcast.proxy.map.Map.get>`
         """
         check_not_none(key, "key can't be none")
 

--- a/hazelcast/proxy/transactional_multi_map.py
+++ b/hazelcast/proxy/transactional_multi_map.py
@@ -6,18 +6,18 @@ from hazelcast.util import check_not_none, thread_id, ImmutableLazyDataList
 
 
 class TransactionalMultiMap(TransactionalProxy):
-    """
-    Transactional implementation of :class:`~hazelcast.proxy.multi_map.MultiMap`.
-    """
+    """Transactional implementation of :class:`~hazelcast.proxy.multi_map.MultiMap`."""
 
     def put(self, key, value):
-        """
-        Transactional implementation of :func:`MultiMap.put(key, value) <hazelcast.proxy.multi_map.MultiMap.put>`
+        """Transactional implementation of :func:`MultiMap.put(key, value) <hazelcast.proxy.multi_map.MultiMap.put>`
 
-        :param key: (object), the key to be stored.
-        :param value: (object), the value to be stored.
-        :return: (bool), ``true`` if the size of the multimap is increased, ``false`` if the multimap already contains
-            the key-value tuple.
+        Args:
+            key: The key to be stored.
+            value: The value to be stored.
+
+        Returns:
+          hazelcast.future.Future[bool]: ``True`` if the size of the multimap is increased, 
+            ``False`` if the multimap already contains the key-value tuple.
         """
         check_not_none(key, "key can't be none")
         check_not_none(value, "value can't be none")
@@ -29,11 +29,13 @@ class TransactionalMultiMap(TransactionalProxy):
         return self._invoke(request, transactional_multi_map_put_codec.decode_response)
 
     def get(self, key):
-        """
-        Transactional implementation of :func:`MultiMap.get(key) <hazelcast.proxy.multi_map.MultiMap.get>`
+        """Transactional implementation of :func:`MultiMap.get(key) <hazelcast.proxy.multi_map.MultiMap.get>`
 
-        :param key: (object), the key whose associated values are returned.
-        :return: (Sequence), the collection of the values associated with the key.
+        Args:
+            key: The key whose associated values are returned.
+
+        Returns:
+            hazelcast.future.Future[list]: The collection of the values associated with the key.
         """
         check_not_none(key, "key can't be none")
 
@@ -46,13 +48,15 @@ class TransactionalMultiMap(TransactionalProxy):
         return self._invoke(request, handler)
 
     def remove(self, key, value):
-        """
-        Transactional implementation of :func:`MultiMap.remove(key, value)
+        """Transactional implementation of :func:`MultiMap.remove(key, value)
         <hazelcast.proxy.multi_map.MultiMap.remove>`
 
-        :param key: (object), the key of the entry to remove.
-        :param value: (object), the value of the entry to remove.
-        :return: (bool), True if the item is removed, False otherwise
+        Args:
+            key: The key of the entry to remove.
+            value: The value of the entry to remove.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if the item is removed, ``False`` otherwise
         """
         check_not_none(key, "key can't be none")
         check_not_none(value, "value can't be none")
@@ -64,12 +68,14 @@ class TransactionalMultiMap(TransactionalProxy):
         return self._invoke(request, transactional_multi_map_remove_entry_codec.decode_response)
 
     def remove_all(self, key):
-        """
-        Transactional implementation of :func:`MultiMap.remove_all(key)
+        """Transactional implementation of :func:`MultiMap.remove_all(key)
         <hazelcast.proxy.multi_map.MultiMap.remove_all>`
 
-        :param key: (object), the key of the entries to remove.
-        :return: (list), the collection of the values associated with the key.
+        Args:
+            key: The key of the entries to remove.
+
+        Returns:
+            hazelcast.future.Future[list]: The collection of the values associated with the key.
         """
         check_not_none(key, "key can't be none")
 
@@ -82,12 +88,14 @@ class TransactionalMultiMap(TransactionalProxy):
         return self._invoke(request, handler)
 
     def value_count(self, key):
-        """
-        Transactional implementation of :func:`MultiMap.value_count(key)
+        """Transactional implementation of :func:`MultiMap.value_count(key)
         <hazelcast.proxy.multi_map.MultiMap.value_count>`
 
-        :param key: (object), the key whose number of values is to be returned.
-        :return: (int), the number of values matching the given key in the multimap.
+        Args:
+            key: The key whose number of values is to be returned.
+
+        Returns:
+            hazelcast.future.Future[int]: The number of values matching the given key in the multimap.
         """
         check_not_none(key, "key can't be none")
 
@@ -97,10 +105,10 @@ class TransactionalMultiMap(TransactionalProxy):
         return self._invoke(request, transactional_multi_map_value_count_codec.decode_response)
 
     def size(self):
-        """
-        Transactional implementation of :func:`MultiMap.size() <hazelcast.proxy.multi_map.MultiMap.size>`
-
-        :return: (int), the number of key-value tuples in the multimap.
+        """Transactional implementation of :func:`MultiMap.size() <hazelcast.proxy.multi_map.MultiMap.size>`
+        
+        Returns:
+            hazelcast.future.Future[int]: the number of key-value tuples in the multimap.
         """
         request = transactional_multi_map_size_codec.encode_request(self.name, self.transaction.id, thread_id())
         return self._invoke(request, transactional_multi_map_size_codec.decode_response)

--- a/hazelcast/proxy/transactional_queue.py
+++ b/hazelcast/proxy/transactional_queue.py
@@ -5,16 +5,16 @@ from hazelcast.util import check_not_none, to_millis, thread_id
 
 
 class TransactionalQueue(TransactionalProxy):
-    """
-    Transactional implementation of :class:`~hazelcast.proxy.queue.Queue`.
-    """
+    """Transactional implementation of :class:`~hazelcast.proxy.queue.Queue`."""
     def offer(self, item, timeout=0):
-        """
-        Transactional implementation of :func:`Queue.offer(item, timeout) <hazelcast.proxy.queue.Queue.offer>`
+        """Transactional implementation of :func:`Queue.offer(item, timeout) <hazelcast.proxy.queue.Queue.offer>`
 
-        :param item: (object), the item to be added.
-        :param timeout: (long), maximum time in seconds to wait for addition (optional).
-        :return: (bool), ``true`` if the element was added to this queue, ``false`` otherwise.
+        Args:
+            item: The item to be added.
+            timeout (int): Maximum time in seconds to wait for addition.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if the element was added to this queue, ``False`` otherwise.
         """
         check_not_none(item, "item can't be none")
 
@@ -24,10 +24,10 @@ class TransactionalQueue(TransactionalProxy):
         return self._invoke(request, transactional_queue_offer_codec.decode_response)
 
     def take(self):
-        """
-        Transactional implementation of :func:`Queue.take() <hazelcast.proxy.queue.Queue.take>`
-
-        :return: (object), the head of this queue.
+        """Transactional implementation of :func:`Queue.take() <hazelcast.proxy.queue.Queue.take>`
+        
+        Returns:
+            hazelcast.future.Future[any]: The head of this queue.
         """
         def handler(message):
             return self._to_object(transactional_queue_take_codec.decode_response(message))
@@ -36,12 +36,14 @@ class TransactionalQueue(TransactionalProxy):
         return self._invoke(request, handler)
 
     def poll(self, timeout=0):
-        """
-        Transactional implementation of :func:`Queue.poll(timeout) <hazelcast.proxy.queue.Queue.poll>`
+        """Transactional implementation of :func:`Queue.poll(timeout) <hazelcast.proxy.queue.Queue.poll>`
 
-        :param timeout: (long), maximum time in seconds to wait for addition (optional).
-        :return: (object), the head of this queue, or ``None`` if this queue is empty or specified timeout elapses
-            before an item is added to the queue.
+        Args:
+            timeout (int): Maximum time in seconds to wait for addition.
+
+        Returns:
+            hazelcast.future.Future[any]: The head of this queue, or ``None`` if this queue is empty 
+                or specified timeout elapses before an item is added to the queue.
         """
         def handler(message):
             return self._to_object(transactional_queue_poll_codec.decode_response(message))
@@ -51,12 +53,14 @@ class TransactionalQueue(TransactionalProxy):
         return self._invoke(request, handler)
 
     def peek(self, timeout=0):
-        """
-        Transactional implementation of :func:`Queue.peek(timeout) <hazelcast.proxy.queue.Queue.peek>`
+        """Transactional implementation of :func:`Queue.peek(timeout) <hazelcast.proxy.queue.Queue.peek>`
 
-        :param timeout: (long), maximum time in seconds to wait for addition (optional).
-        :return: (object), the head of this queue, or ``None`` if this queue is empty or specified timeout elapses
-            before an item is added to the queue.
+        Args:
+            timeout (int): Maximum time in seconds to wait for addition.
+
+        Returns:
+            hazelcast.future.Future[any]: The head of this queue, or ``None`` if this queue is empty 
+                or specified timeout elapses before an item is added to the queue.
         """
         def handler(message):
             return self._to_object(transactional_queue_peek_codec.decode_response(message))
@@ -66,10 +70,10 @@ class TransactionalQueue(TransactionalProxy):
         return self._invoke(request, handler)
 
     def size(self):
-        """
-        Transactional implementation of :func:`Queue.size() <hazelcast.proxy.queue.Queue.size>`
-
-        :return: (int), size of the queue.
+        """Transactional implementation of :func:`Queue.size() <hazelcast.proxy.queue.Queue.size>`
+        
+        Returns:
+            hazelcast.future.Future[int]: Size of the queue.
         """
         request = transactional_queue_size_codec.encode_request(self.name, self.transaction.id, thread_id())
         return self._invoke(request, transactional_queue_size_codec.decode_response)

--- a/hazelcast/proxy/transactional_set.py
+++ b/hazelcast/proxy/transactional_set.py
@@ -5,15 +5,16 @@ from hazelcast.util import check_not_none, thread_id
 
 
 class TransactionalSet(TransactionalProxy):
-    """
-    Transactional implementation of :class:`~hazelcast.proxy.set.Set`.
-    """
+    """Transactional implementation of :class:`~hazelcast.proxy.set.Set`."""
+    
     def add(self, item):
-        """
-        Transactional implementation of :func:`Set.add(item) <hazelcast.proxy.set.Set.add>`
+        """Transactional implementation of :func:`Set.add(item) <hazelcast.proxy.set.Set.add>`
 
-        :param item: (object), the new item to be added.
-        :return: (bool), ``true`` if item is added successfully, ``false`` otherwise.
+        Args:
+            item: The new item to be added.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if item is added successfully, ``False`` otherwise.
         """
         check_not_none(item, "item can't be none")
         item_data = self._to_data(item)
@@ -21,11 +22,13 @@ class TransactionalSet(TransactionalProxy):
         return self._invoke(request, transactional_set_add_codec.decode_response)
 
     def remove(self, item):
-        """
-        Transactional implementation of :func:`Set.remove(item) <hazelcast.proxy.set.Set.remove>`
+        """Transactional implementation of :func:`Set.remove(item) <hazelcast.proxy.set.Set.remove>`
 
-        :param item: (object), the specified item to be deleted.
-        :return: (bool), ``true`` if item is remove successfully, ``false`` otherwise.
+        Args:
+            item: The specified item to be deleted.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if item is remove successfully, ``False`` otherwise.
         """
         check_not_none(item, "item can't be none")
         item_data = self._to_data(item)
@@ -33,10 +36,10 @@ class TransactionalSet(TransactionalProxy):
         return self._invoke(request, transactional_set_remove_codec.decode_response)
 
     def size(self):
-        """
-        Transactional implementation of :func:`Set.size() <hazelcast.proxy.set.Set.size>`
-
-        :return: (int), size of the set.
+        """Transactional implementation of :func:`Set.size() <hazelcast.proxy.set.Set.size>`
+        
+        Returns:
+            hazelcast.future.Future[int]: Size of the set.
         """
         request = transactional_set_size_codec.encode_request(self.name, self.transaction.id, thread_id())
         return self._invoke(request, transactional_set_size_codec.decode_response)

--- a/hazelcast/serialization/api.py
+++ b/hazelcast/serialization/api.py
@@ -4,1002 +4,1037 @@ User API for Serialization.
 
 
 class ObjectDataOutput(object):
-    """
-    ObjectDataOutput provides an interface to convert any of primitive types or arrays of them to series of bytes and
+    """ObjectDataOutput provides an interface to convert any of primitive types or arrays of them to series of bytes and
     write them on a stream.
     """
-    def write_from(self, buff, offset=None, length=None):
-        """
-        Writes the content of the buffer to this output stream.
 
-        :param buff: input buffer.
-        :param offset: (int), offset of the buffer where copy begin (optional).
-        :param length: (int), length of data to be copied from the offset into stream (optional).
+    def write_from(self, buff, offset=None, length=None):
+        """Writes the content of the buffer to this output stream.
+
+        Args:
+            buff (bytearray): Input buffer.
+            offset (int): Offset of the buffer where copy begin.
+            length (int): Length of data to be copied from the offset into stream.
         """
         raise NotImplementedError()
 
     def write_boolean(self, val):
-        """
-        Writes a bool value to this output stream. Single byte value 1 represent True, 0 represent False
+        """Writes a bool value to this output stream.
 
-        :param val: (bool), the bool to be written.
+        Single byte value 1 represent True, 0 represent False
+
+        Args:
+            val (bool): The bool to be written.
         """
         raise NotImplementedError()
 
     def write_byte(self, val):
-        """
-        Writes a byte value to this output stream.
+        """Writes a byte value to this output stream.
 
-        :param val: (byte), the byte value to be written.
+        Args:
+            val (int): The byte value to be written.
         """
         raise NotImplementedError()
 
     def write_short(self, val):
-        """
-        Writes a short value to this output stream.
+        """Writes a short value to this output stream.
 
-        :param val: (short), the short value to be written.
+        Args:
+            val (int): The short value to be written.
         """
         raise NotImplementedError()
 
     def write_char(self, val):
-        """
-        Writes a char value to this output stream.
+        """Writes a char value to this output stream.
 
-        :param val: (char), the char value to be written.
+        Args:
+            val (str): The char value to be written.
         """
         raise NotImplementedError()
 
     def write_int(self, val):
-        """
-        Writes a int value to this output stream.
+        """Writes a int value to this output stream.
 
-        :param val: (int), the int value to be written.
+        Args:
+            val (int): The int value to be written.
         """
         raise NotImplementedError()
 
     def write_long(self, val):
-        """
-        Writes a long value to this output stream.
+        """Writes a long value to this output stream.
 
-        :param val: (long), the long value to be written.
+        Args:
+            val (int): The long value to be written.
         """
         raise NotImplementedError()
 
     def write_float(self, val):
-        """
-        Writes a float value to this output stream.
+        """Writes a float value to this output stream.
 
-        :param val: (float), the float value to be written.
+        Args:
+            val (float): The float value to be written.
         """
         raise NotImplementedError()
 
     def write_double(self, val):
-        """
-        Writes a double value to this output stream.
+        """Writes a double value to this output stream.
 
-        :param val: (double), the double value to be written.
+        Args:
+            val (float): The double value to be written.
         """
         raise NotImplementedError()
 
-    def write_bytes(self, string):
-        """
-        Writes a string to this output stream.
+    def write_bytes(self, val):
+        """Writes a string to this output stream.
 
-        :param val: (str), the string to be written.
+        Args:
+            val (str): The string to be written.
         """
         raise NotImplementedError()
 
     def write_chars(self, val):
-        """
-        Writes every character of string to this output stream.
+        """Writes every character of string to this output stream.
 
-        :param val: (str), the string to be written.
+        Args:
+            val (str): The string to be written.
         """
         raise NotImplementedError()
 
     def write_utf(self, val):
-        """
-        Writes 2 bytes of length information and UTF-8 string to this output stream.
+        """Writes UTF-8 string to this output stream.
 
-        :param val: (UTF-8 str), the UTF-8 string to be written.
+        Args:
+            val (str): The UTF-8 string to be written.
         """
         raise NotImplementedError()
 
     def write_byte_array(self, val):
-        """
-        Writes a byte array to this output stream.
+        """Writes a byte array to this output stream.
 
-        :param val: (byte array), the byte array to be written.
+        Args:
+            val (bytearray): The byte array to be written.
         """
         raise NotImplementedError()
 
     def write_boolean_array(self, val):
-        """
-        Writes a bool array to this output stream.
+        """Writes a bool array to this output stream.
 
-        :param val: (bool array), the bool array to be written.
+        Args:
+            val (list[bool]): The bool array to be written.
         """
         raise NotImplementedError()
 
     def write_char_array(self, val):
-        """
-        Writes a char array to this output stream.
+        """Writes a char array to this output stream.
 
-        :param val: (char array), the char array to be written.
+        Args:
+            val  (list[str]): The char array to be written.
         """
         raise NotImplementedError()
 
     def write_int_array(self, val):
-        """
-        Writes a int array to this output stream.
+        """Writes a int array to this output stream.
 
-        :param val: (int array), the int array to be written.
+        Args:
+            val (list[int]): The int array to be written.
         """
         raise NotImplementedError()
 
     def write_long_array(self, val):
-        """
-        Writes a long array to this output stream.
+        """Writes a long array to this output stream.
 
-        :param val: (long array), the long array to be written.
+        Args:
+            val (list[int]): The long array to be written.
         """
         raise NotImplementedError()
 
     def write_double_array(self, val):
-        """
-        Writes a double array to this output stream.
+        """Writes a double array to this output stream.
 
-        :param val: (double array), the double array to be written.
+        Args:
+            val (list[float]): The double array to be written.
         """
         raise NotImplementedError()
 
     def write_float_array(self, val):
-        """
-        Writes a float array to this output stream.
+        """Writes a float array to this output stream.
 
-        :param val: (float array), the float array to be written.
+        Args:
+            val (list[float]): The float array to be written.
         """
         raise NotImplementedError()
 
     def write_short_array(self, val):
-        """
-        Writes a short array to this output stream.
+        """Writes a short array to this output stream.
 
-        :param val: (short array), the short array to be written.
+        Args:
+            val (list[int]): The short array to be written.
         """
         raise NotImplementedError()
 
     def write_utf_array(self, val):
-        """
-        Writes a UTF-8 String array to this output stream.
+        """Writes a UTF-8 String array to this output stream.
 
-        :param val: (UTF-8 String array), the UTF-8 String array to be written.
+        Args:
+            val (list[str]): The UTF-8 String array to be written.
         """
         raise NotImplementedError()
 
     def write_object(self, val):
-        """
-        Writes an object to this output stream.
+        """Writes an object to this output stream.
 
-        :param val: (object), the object to be written.
+        Args:
+            val: The object to be written.
         """
         raise NotImplementedError()
 
     def write_data(self, val):
-        """
-        Writes a data to this output stream.
+        """Writes a data to this output stream.
 
-        :param val: (Data), the data to be written.
+        Args:
+            val (hazelcast.serialization.data.Data): The data to be written.
         """
         raise NotImplementedError()
 
     def to_byte_array(self):
-        """
-        Returns a copy of internal byte array.
+        """Returns a copy of internal byte array.
 
-        :return: (byte array), the copy of internal byte array.
+        Returns:
+            bytearray: The copy of internal byte array
         """
         raise NotImplementedError()
 
     def get_byte_order(self):
-        """
-        Returns the order of bytes, as BIG_ENDIAN or LITTLE_ENDIAN.
-
-        :return: the order of bytes, as BIG_ENDIAN or LITTLE_ENDIAN.
-        """
+        """Returns the order of bytes, as BIG_ENDIAN or LITTLE_ENDIAN."""
         raise NotImplementedError()
 
 
 class ObjectDataInput(object):
-    """
-    ObjectDataInput provides an interface to read bytes from a stream and reconstruct it to any of primitive types or
+    """ObjectDataInput provides an interface to read bytes from a stream and reconstruct it to any of primitive types or
     arrays of them.
     """
-    def read_into(self, buff, offset=None, length=None):
-        """
-        Reads the content of the buffer into an array of bytes.
 
-        :param buff: input buffer.
-        :param offset: (int), offset of the buffer where the read begin (optional).
-        :param length: (int), length of data to be read (optional).
-        :return: (byte array), the read data.
+    def read_into(self, buff, offset=None, length=None):
+        """Reads the content of the buffer into an array of bytes.
+
+        Args:
+            buff (bytearray): Input buffer.
+            offset (int): Offset of the buffer where the read begin.
+            length (int): Length of data to be read.
+
+        Returns:
+            bytearray: The read data.
         """
         raise NotImplementedError()
 
     def skip_bytes(self, count):
-        """
-        Skips over given number of bytes from input stream.
+        """Skips over given number of bytes from input stream.
 
-        :param count: (long), number of bytes to be skipped.
-        :return: (long), the actual number of bytes skipped.
+        Args:
+            count (int): Number of bytes to be skipped.
+
+        Returns:
+            int: The actual number of bytes skipped.
         """
         raise NotImplementedError()
 
     def read_boolean(self):
-        """
-        Reads 1 byte from input stream and convert it to a bool value.
-
-        :return: (bool), the bool value read.
+        """Reads 1 byte from input stream and convert it to a bool value.
+        
+        Returns:
+            bool: The bool value read.
         """
         raise NotImplementedError()
 
     def read_byte(self):
-        """
-        Reads 1 byte from input stream and returns it.
+        """Reads 1 byte from input stream and returns it.
 
-        :return: (byte), the byte value read.
+        Returns:
+            int: The byte value read.
         """
         raise NotImplementedError()
 
     def read_unsigned_byte(self):
-        """
-        Reads 1 byte from input stream, zero-extends it and returns.
-
-        :return: (unsigned byte), the unsigned byte value read.
+        """Reads 1 byte from input stream, zero-extends it and returns.
+        
+        Returns:
+            int: The unsigned byte value read.
         """
         raise NotImplementedError()
 
     def read_short(self):
-        """
-        Reads 2 bytes from input stream and returns a short value.
-
-        :return: (short), the short value read.
+        """Reads 2 bytes from input stream and returns a short value.
+        
+        Returns:
+            int: The short value read.
         """
         raise NotImplementedError()
 
     def read_unsigned_short(self):
-        """
-        Reads 2 bytes from input stream and returns an int value.
-
-        :return: (unsigned short), the unsigned short value read.
+        """Reads 2 bytes from input stream and returns an int value.
+        
+        Returns:
+            int: The unsigned short value read.
         """
         raise NotImplementedError()
 
     def read_int(self):
-        """
-        Reads 4 bytes from input stream and returns an int value.
-
-        :return: (int), the int value read.
+        """Reads 4 bytes from input stream and returns an int value.
+        
+        Returns:
+            int: The int value read.
         """
         raise NotImplementedError()
 
     def read_long(self):
-        """
-        Reads 8 bytes from input stream and returns a long value.
-
-        :return: (long), the int value read.
+        """Reads 8 bytes from input stream and returns a long value.
+        
+        Returns:
+            int: The int value read.
         """
         raise NotImplementedError()
 
     def read_float(self):
-        """
-        Reads 4 bytes from input stream and returns a float value.
-
-        :return: (float), the float value read.
+        """Reads 4 bytes from input stream and returns a float value.
+        
+        Returns:
+            float: The float value read.
         """
         raise NotImplementedError()
 
     def read_double(self):
-        """
-        Reads 8 bytes from input stream and returns a double value.
-
-        :return: (long), the double value read.
+        """Reads 8 bytes from input stream and returns a double value.
+        
+        Returns:
+            float: The double value read.
         """
         raise NotImplementedError()
 
     def read_utf(self):
-        """
-        Reads a UTF-8 string from input stream and returns it.
-
-        :return: (UTF-8 str), the UTF-8 string read.
+        """Reads a UTF-8 string from input stream and returns it.
+        
+        Returns:
+            str: The UTF-8 string read.
         """
         raise NotImplementedError()
 
     def read_byte_array(self):
-        """
-        Reads a byte array from input stream and returns it.
-
-        :return: (byte array), the byte array read.
+        """Reads a byte array from input stream and returns it.
+        
+        Returns:
+            bytearray: The byte array read.
         """
         raise NotImplementedError()
 
     def read_boolean_array(self):
-        """
-        Reads a bool array from input stream and returns it.
-
-        :return: (bool array), the bool array read.
+        """Reads a bool array from input stream and returns it.
+        
+        Returns:
+            list[bool]: The bool array read.
         """
         raise NotImplementedError()
 
     def read_char_array(self):
-        """
-        Reads a char array from input stream and returns it.
-
-        :return: (char array), the char array read.
+        """Reads a char array from input stream and returns it.
+        
+        Returns:
+            list[str]: The char array read.
         """
         raise NotImplementedError()
 
     def read_int_array(self):
-        """
-        Reads a int array from input stream and returns it.
-
-        :return: (int array), the int array read.
+        """Reads a int array from input stream and returns it.
+        
+        Returns:
+            list[int]: The int array read.
         """
         raise NotImplementedError()
 
     def read_long_array(self):
-        """
-        Reads a long array from input stream and returns it.
-
-        :return: (long array), the long array read.
+        """Reads a long array from input stream and returns it.
+        
+        Returns:
+            list[int]: The long array read.
         """
         raise NotImplementedError()
 
     def read_double_array(self):
-        """
-        Reads a double array from input stream and returns it.
-
-        :return: (double array), the double array read.
+        """Reads a double array from input stream and returns it.
+        
+        Returns:
+            list[float]: The double array read.
         """
         raise NotImplementedError()
 
     def read_float_array(self):
-        """
-        Reads a float array from input stream and returns it.
-
-        :return: (float array), the float array read.
+        """Reads a float array from input stream and returns it.
+        
+        Returns:
+            list[float]: The float array read.
         """
         raise NotImplementedError()
 
     def read_short_array(self):
-        """
-        Reads a short array from input stream and returns it.
-
-        :return: (short array), the short array read.
+        """Reads a short array from input stream and returns it.
+        
+        Returns:
+            list[int]: The short array read.
         """
         raise NotImplementedError()
 
     def read_utf_array(self):
-        """
-        Reads a UTF-8 String array from input stream and returns it.
-
-        :return: (UTF-8 String  array), the UTF-8 String array read.
+        """Reads a UTF-8 string array from input stream and returns it.
+        
+        Returns:
+            list[str]: The UTF-8 string array read.
         """
         raise NotImplementedError()
 
     def read_object(self):
-        """
-        Reads a object from input stream and returns it.
-
-        :return: (object), the object read.
+        """Reads a object from input stream and returns it.
+        
+        Returns:
+            The object read.
         """
         raise NotImplementedError()
 
     def read_data(self):
-        """
-        Reads a data from input stream and returns it.
-
-        :return: (Data), the data read.
+        """Reads a data from input stream and returns it.
+        
+        Returns:
+            hazelcast.serialization.data.Data: The data read.
         """
         raise NotImplementedError()
 
     def get_byte_order(self):
-        """
-        Returns the order of bytes, as BIG_ENDIAN or LITTLE_ENDIAN.
-
-        :return: the order of bytes, as BIG_ENDIAN or LITTLE_ENDIAN.
-        """
+        """Returns the order of bytes, as BIG_ENDIAN or LITTLE_ENDIAN."""
         raise NotImplementedError()
 
     def position(self):
-        """
-        Returns current position in buffer.
-
-        :return: current position in buffer.
+        """Returns current position in buffer.
+        
+        Returns:
+            int: Current position in buffer.
         """
         raise NotImplementedError()
 
     def size(self):
-        """
-        Returns size of buffer.
-
-        :return: size of buffer.
+        """Returns size of buffer.
+        
+        Returns:
+            int: size of buffer.
         """
         raise NotImplementedError()
 
 
 class IdentifiedDataSerializable(object):
-    """
-    IdentifiedDataSerializable is an alternative serialization method to Python pickle, which also avoids reflection
-    during de-serialization. Each IdentifiedDataSerializable is created by a registered DataSerializableFactory.
-    """
-    def write_data(self, object_data_output):
-        """
-        Writes object fields to output stream.
+    """IdentifiedDataSerializable is an alternative serialization method to Python pickle, which also avoids reflection
+    during de-serialization.
 
-        :param object_data_output: (:class:`hazelcast.serialization.api.ObjectDataOutput`), the output.
+    Each IdentifiedDataSerializable is created by a registered DataSerializableFactory.
+    """
+
+    def write_data(self, object_data_output):
+        """Writes object fields to output stream.
+
+        Args:
+            object_data_output (hazelcast.serialization.api.ObjectDataOutput): The output.
         """
         raise NotImplementedError("read_data must be implemented to serialize this IdentifiedDataSerializable")
 
     def read_data(self, object_data_input):
-        """
-        Reads fields from the input stream.
+        """Reads fields from the input stream.
 
-        :param object_data_input: (:class:`hazelcast.serialization.api.ObjectDataInput`), the input.
+        Args:
+            object_data_input (hazelcast.serialization.api.ObjectDataInput): The input.
         """
         raise NotImplementedError("read_data must be implemented to deserialize this IdentifiedDataSerializable")
 
     def get_factory_id(self):
-        """
-        Returns DataSerializableFactory factory id for this class.
-
-        :return: (int), the factory id.
+        """Returns DataSerializableFactory factory id for this class.
+        
+        Returns:
+            int: The factory id.
         """
         raise NotImplementedError("This method must return the factory ID for this IdentifiedDataSerializable")
 
     def get_class_id(self):
-        """
-        Returns type identifier for this class. Id should be unique per DataSerializableFactory.
-
-        :return: (int), the type id.
+        """Returns type identifier for this class. Id should be unique per DataSerializableFactory.
+        
+        Returns:
+            int: The type id.
         """
         raise NotImplementedError("This method must return the class ID for this IdentifiedDataSerializable")
 
 
 class Portable(object):
-    """
-    Portable provides an alternative serialization method. Instead of relying on reflection, each Portable is created by
-    a registered PortableFactory. Portable serialization has the following advantages:
+    """Portable provides an alternative serialization method.
 
-        * Support multiversion of the same object type.
-        * Fetching individual fields without having to rely on reflection.
-        * Querying and indexing support without de-serialization and/or reflection.
+    Instead of relying on reflection, each Portable is created by a registered PortableFactory.
+    Portable serialization has the following advantages:
+
+    - Support multiversion of the same object type.
+    - Fetching individual fields without having to rely on reflection.
+    - Querying and indexing support without de-serialization and/or reflection.
     """
+
     def write_portable(self, writer):
-        """
-        Serialize this portable object using given PortableWriter.
+        """Serialize this portable object using given PortableWriter.
 
-        :param writer: :class:`hazelcast.serialization.api.PortableWriter`, the PortableWriter.
+        Args:
+            writer (hazelcast.serialization.api.PortableWriter): The PortableWriter.
         """
         raise NotImplementedError()
 
     def read_portable(self, reader):
-        """
-        Read portable fields using PortableReader.
+        """Read portable fields using PortableReader.
 
-        :param reader: :class:`hazelcast.serialization.api.PortableReader`, the PortableReader.
+        Args:
+            reader (hazelcast.serialization.api.PortableReader): The PortableReader.
         """
         raise NotImplementedError()
 
     def get_factory_id(self):
-        """
-        Returns PortableFactory id for this portable class
-
-        :return: (int), the factory id.
+        """Returns PortableFactory id for this portable class
+        
+        Returns:
+            int: The factory id.
         """
         raise NotImplementedError()
 
     def get_class_id(self):
-        """
-        Returns class identifier for this portable class. Class id should be unique per PortableFactory.
-
-        :return: (int), the class id.
+        """Returns class identifier for this portable class. Class id should be unique per PortableFactory.
+        
+        Returns:
+            int: The class id.
         """
         raise NotImplementedError()
 
 
 class StreamSerializer(object):
-    """
-    A base class for custom serialization. User can register custom serializer like following:
-        >>> class CustomSerializer(StreamSerializer):
-        >>>     def __init__(self):
-        >>>         super(CustomSerializer, self).__init__()
-        >>>
-        >>>     def read(self, inp):
-        >>>         pass
-        >>>
-        >>>     def write(self, out, obj):
-        >>>         pass
-        >>>
-        >>>     def get_type_id(self):
-        >>>         pass
-        >>>
-        >>>     def destroy(self):
-        >>>         pass
+    """A base class for custom serialization."""
 
-    """
     def write(self, out, obj):
-        """
-        Writes object to ObjectDataOutput
+        """Writes object to ObjectDataOutput
 
-        :param out: (:class:`hazelcast.serialization.api.ObjectDataOutput`), stream that object will be written to.
-        :param obj: (object), the object to be written.
+        Args:
+            out (hazelcast.serialization.api.ObjectDataOutput): Stream that object will be written to.
+            obj: The object to be written.
         """
         raise NotImplementedError("write method must be implemented")
 
     def read(self, inp):
-        """
-        Reads object from objectDataInputStream
+        """Reads object from objectDataInputStream
 
-        :param inp: (:class:`hazelcast.serialization.api.ObjectDataInput`) stream that object will read from.
-        :return: (object), the read object.
+        Args:
+            inp (hazelcast.serialization.api.ObjectDataInput): Stream that object will read from.
+
+        Returns:
+            The read object.
         """
         raise NotImplementedError("write method must be implemented")
 
     def get_type_id(self):
-        """
-        Returns typeId of serializer.
-        :return: (int), typeId of serializer.
+        """Returns typeId of serializer.
+
+        Returns:
+            int: The type id of the serializer.
         """
         raise NotImplementedError("get_type_id must be implemented")
 
     def destroy(self):
-        """
-        Called when instance is shutting down. It can be used to clear used resources.
+        """Called when instance is shutting down.
+
+        It can be used to clear used resources.
         """
         raise NotImplementedError()
 
 
 class PortableReader(object):
+    """Provides a mean of reading portable fields from binary in form of Python primitives and arrays of these
+    primitives, nested portable fields and array of portable fields.
     """
-    Provides a mean of reading portable fields from binary in form of Python primitives and arrays of these primitives,
-    nested portable fields and array of portable fields.
-    """
-    def get_version(self):
-        """
-        Returns the global version of portable classes.
 
-        :return: (int), global version of portable classes.
+    def get_version(self):
+        """Returns the global version of portable classes.
+        
+        Returns:
+            int: Global version of portable classes.
         """
         raise NotImplementedError()
 
     def has_field(self, field_name):
-        """
-        Determine whether the field name exists in this portable class or not.
+        """Determine whether the field name exists in this portable class or not.
 
-        :param field_name: (str), name of the field (does not support nested paths).
-        :return: (bool), ``true`` if the field name exists in class, ``false`` otherwise.
+        Args:
+            field_name (str): name of the field (does not support nested paths).
+
+        Returns:
+            bool: ``True`` if the field name exists in class, ``False`` otherwise.
         """
         raise NotImplementedError()
 
     def get_field_names(self):
-        """
-        Returns the set of field names on this portable class.
-
-        :return: (Set), set of field names on this portable class.
+        """Returns the set of field names on this portable class.
+        
+        Returns:
+            set: Set of field names on this portable class.
         """
         raise NotImplementedError()
 
     def get_field_type(self, field_name):
-        """
-        Returns the field type of given field name.
+        """Returns the field type of given field name.
 
-        :param field_name: (str), name of the field.
-        :return: the field type.
+        Args:
+            field_name (str): Name of the field.
+
+        Returns:
+            hazelcast.serialization.portable.classdef.FieldType: The field type.
         """
         raise NotImplementedError()
 
     def get_field_class_id(self, field_name):
-        """
-        Returns the class id of given field.
+        """Returns the class id of given field.
 
-        :param field_name: (str), name of the field.
-        :return: (int), class id of given field.
+        Args:
+          field_name (str): Name of the field.
+
+        Returns:
+            int: class id of given field.
         """
         raise NotImplementedError()
 
     def read_int(self, field_name):
-        """
-        Reads a primitive int.
+        """Reads a primitive int.
 
-        :param field_name: (str), name of the field.
-        :return: (int), the int value read.
+        Args:
+            field_name (str): Name of the field.
+
+        Returns:
+            int: The int value read.
         """
         raise NotImplementedError()
 
     def read_long(self, field_name):
-        """
-        Reads a primitive long.
+        """Reads a primitive long.
 
-        :param field_name: (str), name of the field.
-        :return: (long), the long value read.
+        Args:
+            field_name (str): Name of the field.
+
+        Returns:
+            int: The long value read.
         """
         raise NotImplementedError()
 
     def read_utf(self, field_name):
-        """
-        Reads a UTF-8 String.
+        """Reads a UTF-8 String.
 
-        :param field_name: (str), name of the field.
-        :return: (UTF-8 str), the UTF-8 String read.
+        Args:
+            field_name (str): Name of the field.
+
+        Returns:
+            str: The UTF-8 String read.
         """
         raise NotImplementedError()
 
     def read_boolean(self, field_name):
-        """
-        Reads a primitive bool.
+        """Reads a primitive bool.
 
-        :param field_name: (str), name of the field.
-        :return: (bool), the bool value read.
+        Args:
+            field_name (str): Name of the field.
+
+        Returns:
+            bool: The bool value read.
         """
         raise NotImplementedError()
 
     def read_byte(self, field_name):
-        """
-        Reads a primitive byte.
+        """Reads a primitive byte.
 
-        :param field_name: (str), name of the field.
-        :return: (byte), the byte value read.
+        Args:
+            field_name (str): Name of the field.
+
+        Returns:
+            int: The byte value read.
         """
         raise NotImplementedError()
 
     def read_char(self, field_name):
-        """
-        Reads a primitive char.
+        """Reads a primitive char.
 
-        :param field_name: (str), name of the field.
-        :return: (char), the char value read.
+        Args:
+            field_name (str): Name of the field.
+
+        Returns:
+            str: The char value read.
         """
         raise NotImplementedError()
 
     def read_double(self, field_name):
-        """
-        Reads a primitive double.
+        """Reads a primitive double.
 
-        :param field_name: (str), name of the field.
-        :return: (double), the double value read.
+        Args:
+            field_name (str): Name of the field.
+
+        Returns:
+            float: The double value read.
         """
         raise NotImplementedError()
 
     def read_float(self, field_name):
-        """
-        Reads a primitive float.
+        """Reads a primitive float.
 
-        :param field_name: (str), name of the field.
-        :return: (float), the float value read.
+        Args:
+            field_name (str): Name of the field.
+
+        Returns:
+            float: The float value read.
         """
         raise NotImplementedError()
 
     def read_short(self, field_name):
-        """
-        Reads a primitive short.
+        """Reads a primitive short.
 
-        :param field_name: (str), name of the field.
-        :return: (short), the short value read.
+        Args:
+            field_name (str): Name of the field.
+
+        Returns:
+            int: The short value read.
         """
         raise NotImplementedError()
 
     def read_portable(self, field_name):
-        """
-        Reads a portable.
+        """Reads a portable.
 
-        :param field_name: (str), name of the field.
-        :return: (:class:`hazelcast.serialization.api.Portable`, the portable read.
+        Args:
+            field_name (str): Name of the field.
+
+        Returns:
+            hazelcast.serialization.api.Portable: The portable read.
         """
         raise NotImplementedError()
 
     def read_byte_array(self, field_name):
-        """
-        Reads a primitive byte array.
+        """Reads a primitive byte array.
 
-        :param field_name: (str), name of the field.
-        :return: (byte array), the byte array read.
+        Args:
+            field_name (str): Name of the field.
+
+        Returns:
+            bytearray: The byte array read.
         """
         raise NotImplementedError()
 
     def read_boolean_array(self, field_name):
-        """
-        Reads a primitive bool array.
+        """Reads a primitive bool array.
 
-        :param field_name: (str), name of the field.
-        :return: (bool array), the bool array read.
+        Args:
+            field_name (str): Name of the field.
+
+        Returns:
+            list[bool]): The bool array read.
         """
         raise NotImplementedError()
 
     def read_char_array(self, field_name):
-        """
-        Reads a primitive char array.
+        """Reads a primitive char array.
 
-        :param field_name: (str), name of the field.
-        :return: (char array), the char array read.
+        Args:
+            field_name (str): Name of the field.
+
+        Returns:
+            list[str]): The char array read.
         """
         raise NotImplementedError()
 
     def read_int_array(self, field_name):
-        """
-        Reads a primitive int array.
+        """Reads a primitive int array.
 
-        :param field_name: (str), name of the field.
-        :return: (int array), the int array read.
+        Args:
+            field_name (str): Name of the field.
+
+        Returns:
+            list[int]: The int array read.
         """
         raise NotImplementedError()
 
     def read_long_array(self, field_name):
-        """
-        Reads a primitive long array.
+        """Reads a primitive long array.
 
-        :param field_name: (str), name of the field.
-        :return: (long array), the long array read.
+        Args:
+            field_name (str): Name of the field.
+
+        Returns:
+            list[int]: The long array read.
         """
         raise NotImplementedError()
 
     def read_double_array(self, field_name):
-        """
-        Reads a primitive double array.
+        """Reads a primitive double array.
 
-        :param field_name: (str), name of the field.
-        :return: (double array), the double array read.
+        Args:
+            field_name (str): Name of the field.
+
+        Returns:
+            list[float]: The double array read.
         """
         raise NotImplementedError()
 
     def read_float_array(self, field_name):
-        """
-        Reads a primitive float array.
+        """Reads a primitive float array.
 
-        :param field_name: (str), name of the field.
-        :return: (float array), the float array read.
+        Args:
+            field_name (str): Name of the field.
+
+        Returns:
+            list[float]: The float array read.
         """
         raise NotImplementedError()
 
     def read_short_array(self, field_name):
-        """
-        Reads a primitive short array.
+        """Reads a primitive short array.
 
-        :param field_name: (str), name of the field.
-        :return: (short array), the short array read.
+        Args:
+            field_name (str): Name of the field.
+
+        Returns:
+            list[int]: The short array read.
         """
         raise NotImplementedError()
 
     def read_utf_array(self, field_name):
-        """
-        Reads a UTF-8 String array.
+        """Reads a UTF-8 String array.
 
-        :param field_name: (str), name of the field.
-        :return: (UTF-8 String array), the UTF-8 String array read.
+        Args:
+            field_name (str): Name of the field.
+
+        Returns:
+            str: The UTF-8 String array read.
         """
         raise NotImplementedError()
 
     def read_portable_array(self, field_name):
-        """
-        Reads a portable array.
+        """Reads a portable array.
 
-        :param field_name: (str), name of the field.
-        :return: (Portable array), the portable array read.
+        Args:
+            field_name (str): Name of the field.
+
+        Returns:
+            list[hazelcast.serialization.api.Portable]: The portable array read.
         """
         raise NotImplementedError()
 
     def get_raw_data_input(self):
-        """
-        After reading portable fields, one can read remaining fields in old fashioned way consecutively from the end of
-        stream. After get_raw_data_input() called, no data can be read.
-
-        :return: (:class:`hazelcast.serialization.api.ObjectDataInput`), the input.
+        """After reading portable fields, one can read remaining fields in old fashioned way
+        consecutively from the end of stream. After get_raw_data_input() called, no data can be read.
+        
+        Returns:
+            hazelcast.serialization.api.ObjectDataInput: The input.
         """
         raise NotImplementedError()
 
 
 class PortableWriter(object):
+    """Provides a mean of writing portable fields to a binary in form of Python primitives and arrays of these
+    primitives, nested portable fields and array of portable fields.
     """
-    Provides a mean of writing portable fields to a binary in form of Python primitives and arrays of these primitives,
-    nested portable fields and array of portable fields.
-    """
-    def write_int(self, field_name, value):
-        """
-        Writes a primitive int.
 
-        :param field_name: (str), name of the field.
-        :param value: (int), int value to be written.
+    def write_int(self, field_name, value):
+        """Writes a primitive int.
+
+        Args:
+            field_name (str): Name of the field.
+            value (int): Int value to be written.
         """
         raise NotImplementedError()
 
     def write_long(self, field_name, value):
-        """
-        Writes a primitive long.
+        """Writes a primitive long.
 
-        :param field_name: (str), name of the field.
-        :param value: (long), long value to be written.
+        Args:
+            field_name (str): Name of the field.
+            value (int): Long value to be written.
         """
         raise NotImplementedError()
 
     def write_utf(self, field_name, value):
-        """
-        Writes an UTF string.
+        """Writes an UTF string.
 
-        :param field_name: (str), name of the field.
-        :param value: (UTF str), UTF string value to be written.
+        Args:
+            field_name (str): Name of the field.
+            value (str): UTF string value to be written.
         """
         raise NotImplementedError()
 
     def write_boolean(self, field_name, value):
-        """
-        Writes a primitive bool.
+        """Writes a primitive bool.
 
-        :param field_name: (str), name of the field.
-        :param value: (bool), bool value to be written.
+        Args:
+            field_name (str): Name of the field.
+            value (bool): Bool value to be written.
         """
         raise NotImplementedError()
 
     def write_byte(self, field_name, value):
-        """
-        Writes a primitive byte.
+        """Writes a primitive byte.
 
-        :param field_name: (str), name of the field.
-        :param value: (byte), byte value to be written.
+        Args:
+            field_name (str): Name of the field.
+            value (int): Byte value to be written.
         """
         raise NotImplementedError()
 
     def write_char(self, field_name, value):
-        """
-        Writes a primitive char.
+        """Writes a primitive char.
 
-        :param field_name: (str), name of the field.
-        :param value: (char), char value to be written.
+        Args:
+            field_name (str): Name of the field.
+            value (str): Char value to be written.
         """
         raise NotImplementedError()
 
     def write_double(self, field_name, value):
-        """
-        Writes a primitive double.
+        """Writes a primitive double.
 
-        :param field_name: (str), name of the field.
-        :param value: (Dobule), double value to be written.
+        Args:
+            field_name (str): Name of the field.
+            value (float): Double value to be written.
         """
         raise NotImplementedError()
 
     def write_float(self, field_name, value):
-        """
-        Writes a primitive float.
+        """Writes a primitive float.
 
-        :param field_name: (str), name of the field.
-        :param value: (float), float value to be written.
+        Args:
+            field_name (str): Name of the field.
+            value (float): Float value to be written.
         """
         raise NotImplementedError()
 
     def write_short(self, field_name, value):
-        """
-        Writes a primitive short.
+        """Writes a primitive short.
 
-        :param field_name: (str), name of the field.
-        :param value: (short), short value to be written.
+        Args:
+            field_name (str): Name of the field.
+            value (int): Short value to be written.
         """
         raise NotImplementedError()
 
     def write_portable(self, field_name, portable):
-        """
-        Writes a Portabl
+        """Writes a Portable.
 
-        :param field_name: (str), name of the field.
-        :param portable: (:class:`hazelcast.serialization.api.Portable`, portable to be written.
+        Args:
+            field_name (str): Name of the field.
+            portable (hazelcast.serialization.api.Portable): Portable to be written.
         """
         raise NotImplementedError()
 
     def write_null_portable(self, field_name, factory_id, class_id):
-        """
-        To write a null portable value, user needs to provide class and factoryIds of related class.
+        """To write a null portable value, user needs to provide class and factory ids of related class.
 
-        :param field_name: (str), name of the field.
-        :param factory_id: (int), factory id of related portable class.
-        :param class_id: (int), class id of related portable class.
+        Args:
+            field_name (str): Name of the field.
+            factory_id (int): Factory id of related portable class.
+            class_id (int): Class id of related portable class.
         """
         raise NotImplementedError()
 
     def write_byte_array(self, field_name, values):
-        """
-        Writes a primitive byte array.
+        """Writes a primitive byte array.
 
-        :param field_name: (str), name of the field.
-        :param values: (byte array), byte array to be written.
+        Args:
+            field_name (str): Name of the field.
+            values (bytearray): Bytearray to be written.
         """
         raise NotImplementedError()
 
     def write_boolean_array(self, field_name, values):
-        """
-        Writes a primitive bool array.
+        """Writes a primitive bool array.
 
-        :param field_name: (str), name of the field.
-        :param values: (bool array), bool array to be written.
+        Args:
+            field_name (str): Name of the field.
+            values (list[bool]): Bool array to be written.
         """
         raise NotImplementedError()
 
     def write_char_array(self, field_name, values):
-        """
-        Writes a primitive char array.
+        """Writes a primitive char array.
 
-        :param field_name: (str), name of the field.
-        :param values: (char array), char array to be written.
+        Args:
+            field_name (str): Name of the field.
+            values (list[str]): Char array to be written.
         """
         raise NotImplementedError()
 
     def write_int_array(self, field_name, values):
-        """
-        Writes a primitive int array.
+        """Writes a primitive int array.
 
-        :param field_name: (str), name of the field.
-        :param values: (int array), int array to be written.
+        Args:
+            field_name (str): Name of the field.
+            values (list[int]): Int array to be written.
         """
         raise NotImplementedError()
 
     def write_long_array(self, field_name, values):
-        """
-        Writes a primitive long array.
+        """Writes a primitive long array.
 
-        :param field_name: (str), name of the field.
-        :param values: (long array), long array to be written.
+        Args:
+            field_name (str): Name of the field.
+            values (list[int]): Long array to be written.
         """
         raise NotImplementedError()
 
     def write_double_array(self, field_name, values):
-        """
-        Writes a primitive double array.
+        """Writes a primitive double array.
 
-        :param field_name: (str), name of the field.
-        :param values: (double array), double array to be written.
+        Args:
+            field_name (str): Name of the field.
+            values (list[float]): Double array to be written.
         """
         raise NotImplementedError()
 
     def write_float_array(self, field_name, values):
-        """
-        Writes a primitive float array.
+        """Writes a primitive float array.
 
-        :param field_name: (str), name of the field.
-        :param values: (float array), float array to be written.
+        Args:
+            field_name (str): Name of the field.
+            values (list[float]): Float array to be written.
         """
         raise NotImplementedError()
 
     def write_short_array(self, field_name, values):
-        """
-        Writes a primitive short array.
+        """Writes a primitive short array.
 
-        :param field_name: (str), name of the field.
-        :param values: (short array), short array to be written.
+        Args:
+            field_name (str): Name of the field.
+            values: (list[int]): Short array to be written.
         """
         raise NotImplementedError()
 
     def write_utf_array(self, field_name, values):
-        """
-        Writes a UTF-8 String array.
+        """Writes a UTF-8 String array.
 
-        :param field_name: (str), name of the field.
-        :param values: (UTF-8 String array), UTF-8 String array to be written.
+        Args:
+            field_name (str): Name of the field.
+            values: (str): UTF-8 String array to be written.
         """
         raise NotImplementedError()
 
     def write_portable_array(self, field_name, values):
-        """
-        Writes a portable array.
+        """Writes a portable array.
 
-        :param field_name: (str), name of the field.
-        :param values: (Portable array), portable array to be written.
+        Args:
+            field_name (str): Name of the field.
+            values (list[hazelcast.serialization.api.Portable]): Portable array to be written.
         """
         raise NotImplementedError()
 
     def get_raw_data_output(self):
-        """
-        After writing portable fields, one can write remaining fields in old fashioned way consecutively at the end of
-        stream. After get_raw_data_output() called, no data can be written.
-
-        :return: (:class:`hazelcast.serialization.api.ObjectDataOutput`), the output.
+        """After writing portable fields, one can write remaining fields in old fashioned way
+        consecutively at the end of stream. After get_raw_data_output() called, no data can be written.
+        
+        Returns:
+            hazelcast.serialization.api.ObjectDataOutput: The output.
         """
         raise NotImplementedError()
 

--- a/hazelcast/serialization/api.py
+++ b/hazelcast/serialization/api.py
@@ -188,14 +188,6 @@ class ObjectDataOutput(object):
         """
         raise NotImplementedError()
 
-    def write_data(self, val):
-        """Writes a data to this output stream.
-
-        Args:
-            val (hazelcast.serialization.data.Data): The data to be written.
-        """
-        raise NotImplementedError()
-
     def to_byte_array(self):
         """Returns a copy of internal byte array.
 
@@ -395,14 +387,6 @@ class ObjectDataInput(object):
         
         Returns:
             The object read.
-        """
-        raise NotImplementedError()
-
-    def read_data(self):
-        """Reads a data from input stream and returns it.
-        
-        Returns:
-            hazelcast.serialization.data.Data: The data read.
         """
         raise NotImplementedError()
 

--- a/hazelcast/serialization/base.py
+++ b/hazelcast/serialization/base.py
@@ -44,11 +44,14 @@ class BaseSerializationService(object):
         self._active = True
 
     def to_data(self, obj, partitioning_strategy=None):
-        """
-        Serialize the input object into byte array representation
-        :param obj: input object
-        :param partitioning_strategy: function in the form of lambda key:partitioning_key
-        :return: Data object
+        """Serialize the input object into byte array representation
+
+        Args:
+            obj: Input object
+            partitioning_strategy (function): Function in the form of ``lambda key: partitioning_key``.
+
+        Returns:
+            hazelcast.serialization.data.Data: Data object
         """
         if obj is None:
             return None
@@ -72,10 +75,13 @@ class BaseSerializationService(object):
             # return out to pool
 
     def to_object(self, data):
-        """
-        Deserialize input data
-        :param data: serialized input Data object
-        :return: Deserialized object
+        """Deserialize input data
+
+        Args:
+            data (hazelcast.serialization.data.Data): Serialized input Data object
+
+        Returns:
+            any: Deserialized object
         """
         if not isinstance(data, Data):
             return data
@@ -159,10 +165,13 @@ class SerializerRegistry(object):
         self.int_type = int_type
 
     def serializer_by_type_id(self, type_id):
-        """
-        Find and return the serializer for the type-id
-        :param type_id: type-id the serializer
-        :return: the serializer
+        """Find and return the serializer for the type-id
+
+        Args:
+            type_id (int): Type id of the serializer
+
+        Returns:
+          The serializer
         """
         if type_id <= 0:
             indx = index_for_default_type(type_id)
@@ -172,18 +181,21 @@ class SerializerRegistry(object):
         return self._id_dic.get(type_id, None)
 
     def serializer_for(self, obj):
-        """
-            Searches for a serializer for the provided object
-            Serializers will be  searched in this order;
+        """Searches for a serializer for the provided object
 
-            1-NULL serializer
-            2-Default serializers, like primitives, arrays, string and some default types
-            3-Custom registered types by user
-            4-Global serializer if registered by user
-            4-pickle serialization as a fallback
+        Serializers will be  searched in this order;
 
-        :param obj: input object
-        :return: Serializer
+        - NULL serializer
+        - Default serializers, like primitives, arrays, string and some default types
+        - Custom registered types by user
+        - Global serializer if registered by user
+        - pickle serialization as a fallback
+
+        Args:
+            obj: Input object
+
+        Returns:
+            The serializer
         """
         # 1-NULL serializer
         if obj is None:

--- a/hazelcast/serialization/data.py
+++ b/hazelcast/serialization/data.py
@@ -10,83 +10,86 @@ HEAP_DATA_OVERHEAD = DATA_OFFSET
 
 
 class Data(object):
-    """
-    Data is basic unit of serialization. It stores binary form of an object serialized by serialization service
+    """Data is basic unit of serialization.
+
+    It stores binary form of an object serialized by serialization service.
     """
 
     def __init__(self, buff=None):
         self._buffer = buff
 
     def to_bytes(self):
-        """
-        Returns byte array representation of internal binary format.
-
-        :return:  (byte array), byte array representation of internal binary format.
+        """Returns byte array representation of internal binary format.
+        
+        Returns:
+            bytearray: The byte array representation of internal binary format.
         """
         return self._buffer
 
     def get_type(self):
-        """
-        Returns serialization type of binary form.
-
-        :return: Serialization type of binary form.
+        """Returns serialization type of binary form.
+        
+        Returns:
+            int: Serialization type of binary form.
         """
         if self.total_size() == 0:
             return CONSTANT_TYPE_NULL
         return BE_INT.unpack_from(self._buffer, TYPE_OFFSET)[0]
 
     def total_size(self):
-        """
-        Returns the total size of Data in bytes.
-
-        :return: (int), total size of Data in bytes.
+        """Returns the total size of Data in bytes.
+        
+        Returns:
+            int: Total size of Data in bytes.
         """
         return len(self._buffer) if self._buffer is not None else 0
 
     def data_size(self):
-        """
-        Returns size of internal binary data in bytes.
-
-        :return: (int), size of internal binary data in bytes.
+        """Returns size of internal binary data in bytes.
+        
+        Returns:
+            int: Size of internal binary data in bytes.
         """
         return max(self.total_size() - HEAP_DATA_OVERHEAD, 0)
 
     def get_partition_hash(self):
-        """
-        Returns partition hash calculated for serialized object.
-            Partition hash is used to determine partition of a Data and is calculated using
-                * PartitioningStrategy during serialization.
-                * If partition hash is not set then hash_code() is used.
+        """Returns partition hash calculated for serialized object.
 
-        :return: partition hash
+        Partition hash is used to determine partition of a Data and is calculated using:
+            - PartitioningStrategy during serialization.
+            - If partition hash is not set then hash_code() is used.
+        
+        Returns:
+            int: Partition hash.
         """
         if self.has_partition_hash():
             return BE_INT.unpack_from(self._buffer, PARTITION_HASH_OFFSET)[0]
         return self.hash_code()
 
     def is_portable(self):
-        """
-        Determines whether this Data is created from a :class:`~hazelcast.serialization.api.Portable`. object or not.
-
-        :return: (bool), ``true`` if source object is Portable, ``false`` otherwise.
+        """Determines whether this Data is created from a ``Portable`` object or not.
+        
+        Returns:
+            bool: ``True`` if source object is Portable, ``False`` otherwise.
         """
         return CONSTANT_TYPE_PORTABLE == self.get_type()
 
     def has_partition_hash(self):
-        """
-        Determines whether this Data has partition hash or not.
+        """Determines whether this ``Data`` has partition hash or not.
+        
+        Returns:
+            bool: ``True`` if ``Data`` has partition hash, ``False`` otherwise.
 
-        :return: (bool), ``true`` if Data has partition hash, ``false`` otherwise.
         """
         return self._buffer is not None \
                and len(self._buffer) >= HEAP_DATA_OVERHEAD \
                and BE_INT.unpack_from(self._buffer, PARTITION_HASH_OFFSET)[0] != 0
 
     def hash_code(self):
-        """
-        Returns the murmur hash of the internal data.
-
-        :return: the murmur hash of the internal data.
+        """Returns the murmur hash of the internal data.
+        
+        Returns:
+            int: The murmur hash of the internal data.
         """
         return murmur_hash3_x86_32(self._buffer, DATA_OFFSET, self.data_size())
 

--- a/hazelcast/serialization/input.py
+++ b/hazelcast/serialization/input.py
@@ -124,10 +124,6 @@ class _ObjectDataInput(ObjectDataInput):
     def read_object(self):
         return self._service.read_object(self)
 
-    def read_data(self):
-        buff = self.read_byte_array()
-        return Data(buff) if buff is not None else None
-
     def is_big_endian(self):
         return self._is_big_endian
 

--- a/hazelcast/serialization/output.py
+++ b/hazelcast/serialization/output.py
@@ -118,10 +118,6 @@ class _ObjectDataOutput(ObjectDataOutput):
     def write_object(self, val):
         self._service.write_object(self, val)
 
-    def write_data(self, data):
-        payload = data.to_bytes() if data is not None else None
-        self.write_byte_array(payload)
-
     def to_byte_array(self):
         if self._buffer is None or self._pos == 0:
             return bytearray()

--- a/hazelcast/serialization/portable/classdef.py
+++ b/hazelcast/serialization/portable/classdef.py
@@ -1,9 +1,7 @@
 from hazelcast.errors import HazelcastSerializationError
 from hazelcast import six
-from hazelcast.util import with_reversed_items
 
 
-@with_reversed_items
 class FieldType(object):
     PORTABLE = 0
     BYTE = 1

--- a/hazelcast/transaction.py
+++ b/hazelcast/transaction.py
@@ -41,9 +41,7 @@ RETRY_COUNT = 20
 
 
 class TransactionManager(object):
-    """
-    Manages the execution of client transactions and provides Transaction objects.
-    """
+    """Manages the execution of client transactions and provides Transaction objects."""
     logger = logging.getLogger("HazelcastClient.TransactionManager")
 
     def __init__(self, context, logger_extras):
@@ -63,22 +61,24 @@ class TransactionManager(object):
                 raise IllegalStateError("No active connection is found")
 
     def new_transaction(self, timeout, durability, transaction_type):
-        """
-        Creates a Transaction object with given timeout, durability and transaction type.
+        """Creates a Transaction object with given timeout, durability and transaction type.
 
-        :param timeout: (long), the timeout in seconds determines the maximum lifespan of a transaction.
-        :param durability: (int), the durability is the number of machines that can take over if a member fails during a
-            transaction commit or rollback
-        :param transaction_type: (Transaction Type), the transaction type which can be :const:`~hazelcast.transaction.TWO_PHASE` or :const:`~hazelcast.transaction.ONE_PHASE`
-        :return: (:class:`~hazelcast.transaction.Transaction`), new created Transaction.
+        Args:
+            timeout (int): The timeout in seconds determines the maximum lifespan of a transaction.
+            durability (int): The durability is the number of machines that can take over if a member fails during a
+                transaction commit or rollback
+            transaction_type (int): the transaction type which can be ``hazelcast.transaction.TWO_PHASE``
+                or ``hazelcast.transaction.ONE_PHASE``
+
+        Returns:
+          hazelcast.transaction.Transaction: New created Transaction.
         """
         connection = self._connect()
         return Transaction(self._context, connection, timeout, durability, transaction_type)
 
 
 class Transaction(object):
-    """
-    Provides transactional operations: beginning/committing transactions, but also retrieving
+    """Provides transactional operations: beginning/committing transactions, but also retrieving
     transactional data-structures like the TransactionalMap.
     """
     state = _STATE_NOT_STARTED
@@ -96,9 +96,7 @@ class Transaction(object):
         self._objects = {}
 
     def begin(self):
-        """
-        Begins this transaction.
-        """
+        """Begins this transaction."""
         if hasattr(self._locals, 'transaction_exists') and self._locals.transaction_exists:
             raise TransactionError("Nested transactions are not allowed.")
         if self.state != _STATE_NOT_STARTED:
@@ -122,9 +120,7 @@ class Transaction(object):
             raise
 
     def commit(self):
-        """
-        Commits this transaction.
-        """
+        """Commits this transaction."""
         self._check_thread()
         if self.state != _STATE_ACTIVE:
             raise TransactionError("Transaction is not active.")
@@ -143,9 +139,7 @@ class Transaction(object):
             self._locals.transaction_exists = False
 
     def rollback(self):
-        """
-        Rollback of this current transaction.
-        """
+        """Rollback of this current transaction."""
         self._check_thread()
         if self.state not in (_STATE_ACTIVE, _STATE_PARTIAL_COMMIT):
             raise TransactionError("Transaction is not active.")
@@ -161,47 +155,62 @@ class Transaction(object):
             self._locals.transaction_exists = False
 
     def get_list(self, name):
-        """
-        Returns the transactional list instance with the specified name.
+        """Returns the transactional list instance with the specified name.
 
-        :param name: (str), the specified name.
-        :return: (:class:`~hazelcast.proxy.transactional_list.TransactionalList`), the instance of Transactional List with the specified name.
+        Args:
+            name (str): The specified name.
+
+        Returns:
+            hazelcast.proxy.transactional_list.TransactionalList`: The instance of Transactional List
+                with the specified name.
         """
         return self._get_or_create_object(name, TransactionalList)
 
     def get_map(self, name):
-        """
-        Returns the transactional map instance with the specified name.
+        """Returns the transactional map instance with the specified name.
 
-        :param name: (str), the specified name.
-        :return: (:class:`~hazelcast.proxy.transactional_map.TransactionalMap`), the instance of Transactional Map with the specified name.
+        Args:
+            name (str): The specified name.
+
+        Returns:
+            hazelcast.proxy.transactional_map.TransactionalMap: The instance of Transactional Map
+                with the specified name.
         """
         return self._get_or_create_object(name, TransactionalMap)
 
     def get_multi_map(self, name):
-        """
-        Returns the transactional multimap instance with the specified name.
+        """Returns the transactional multimap instance with the specified name.
 
-        :param name: (str), the specified name.
-        :return: (:class:`~hazelcast.proxy.transactional_multi_map.TransactionalMultiMap`), the instance of Transactional MultiMap with the specified name.
+        Args:
+            name (str): The specified name.
+
+        Returns:
+            hazelcast.proxy.transactional_multi_map.TransactionalMultiMap: The instance of Transactional MultiMap
+                with the specified name.
         """
         return self._get_or_create_object(name, TransactionalMultiMap)
 
     def get_queue(self, name):
-        """
-        Returns the transactional queue instance with the specified name.
+        """Returns the transactional queue instance with the specified name.
 
-        :param name: (str), the specified name.
-        :return: (:class:`~hazelcast.proxy.transactional_queue.TransactionalQueue`), the instance of Transactional Queue with the specified name.
+        Args:
+            name (str): The specified name.
+
+        Returns:
+            hazelcast.proxy.transactional_queue.TransactionalQueue: The instance of Transactional Queue
+                with the specified name.
         """
         return self._get_or_create_object(name, TransactionalQueue)
 
     def get_set(self, name):
-        """
-        Returns the transactional set instance with the specified name.
+        """Returns the transactional set instance with the specified name.
 
-        :param name: (str), the specified name.
-        :return: (:class:`~hazelcast.proxy.transactional_set.TransactionalSet`), the instance of Transactional Set with the specified name.
+        Args:
+            name (str): The specified name.
+
+        Returns:
+            hazelcast.proxy.transactional_set.TransactionalSet: The instance of Transactional Set
+                with the specified name.
         """
         return self._get_or_create_object(name, TransactionalSet)
 

--- a/hazelcast/util.py
+++ b/hazelcast/util.py
@@ -15,129 +15,67 @@ NANOSECONDS_IN_SECONDS = 1e9
 
 
 def check_not_none(val, message):
-    """
-    Tests if an argument is not ``None``.
-
-    :param val: (object), the argument tested to see if it is not ``None``.
-    :param message: (str), the error message.
-    """
     if val is None:
         raise AssertionError(message)
 
 
 def check_true(val, message):
-    """
-    Tests whether the provided expression is ``true``.
-
-    :param val: (bool), the expression tested to see if it is ``true``.
-    :param message: (str), the error message.
-    """
     if not val:
         raise AssertionError(message)
 
 
 def check_not_negative(val, message):
-    """
-    Tests if a value is not negative.
-
-    :param val: (Number), the value tested to see if it is not negative.
-    :param message: (str), the error message.
-    """
     if val < 0:
         raise AssertionError(message)
 
 
 def check_not_empty(collection, message):
-    """
-    Tests if a collection is not empty.
-
-    :param collection: (Collection), the collection tested to see if it is not empty.
-    :param message: (str), the error message.
-    """
     if not collection:
         raise AssertionError(message)
 
 
 def current_time():
-    """
-    Returns the current time of the system.
-
-    :return: (float), current time of the system.
-    """
     return time.time()
 
 
 def current_time_in_millis():
-    """
-    Returns the current time of the system in millis.
-    :return: (int), current time of the system in millis.
-    """
     return to_millis(current_time())
 
 
 def thread_id():
-    """
-    Returns the current thread's id.
-
-    :return: (int), current thread's id.
-    """
     return threading.currentThread().ident
 
 
 def to_millis(seconds):
-    """
-    Converts the time parameter in seconds to milliseconds.
-
-    :param seconds: (Number), the given time in seconds.
-    :return: (int), result of the conversation in milliseconds.
-    """
     return int(seconds * MILLISECONDS_IN_SECONDS)
 
 
 def to_nanos(seconds):
-    """
-    Converts the time parameter in seconds to nanoseconds.
-
-    :param seconds: (Number), the given time in seconds.
-    :return: (int), result of the conversation in nanoseconds.
-    """
     return int(seconds * NANOSECONDS_IN_SECONDS)
 
 
 def validate_type(_type):
-    """
-    Validates the type.
-
-    :param _type: (Type), the type to be validated.
-    """
     if not isinstance(_type, type):
         raise ValueError("Serializer should be an instance of %s" % _type.__name__)
 
 
 def validate_serializer(serializer, _type):
-    """
-    Validates the serializer for given type.
-
-    :param serializer: (Serializer), the serializer to be validated.
-    :param _type: (Type), type to be used for serializer validation.
-    """
     if not issubclass(serializer, _type):
         raise ValueError("Serializer should be an instance of %s" % _type.__name__)
 
 
 class AtomicInteger(object):
-    """
-    AtomicInteger is an Integer which can work atomically.
-    """
+    """An Integer which can work atomically."""
+
     def __init__(self, initial=0):
         self._mux = threading.RLock()
         self._counter = initial
 
     def get_and_increment(self):
-        """
-        Returns the current value and increment it.
-
-        :return: (int), current value of AtomicInteger.
+        """Returns the current value and increment it.
+        
+        Returns:
+            int: current value of AtomicInteger.
         """
         with self._mux:
             res = self._counter
@@ -193,30 +131,6 @@ def get_portable_version(portable, default_version):
     except AttributeError:
         version = default_version
     return version
-
-
-class TimeUnit(object):
-    """
-    Represents the time durations at given units in seconds.
-    """
-    NANOSECOND = 1e-9
-    MICROSECOND = 1e-6
-    MILLISECOND = 1e-3
-    SECOND = 1.0
-    MINUTE = 60.0
-    HOUR = 3600.0
-
-    @staticmethod
-    def to_seconds(value, time_unit):
-        """
-        :param value: (Number), value to be translated to seconds
-        :param time_unit: Time duration in seconds
-        :return: Value of the value in seconds
-        """
-        if isinstance(value, bool):
-            # bool is a subclass of int. Don't let bool and float multiplication.
-            raise TypeError
-        return float(value) * time_unit
 
 
 # Version utilities
@@ -339,23 +253,23 @@ none_type = type(None)
 class LoadBalancer(object):
     """Load balancer allows you to send operations to one of a number of endpoints (Members).
     It is up to the implementation to use different load balancing policies.
-
+    
     If the client is configured with smart routing,
     only the operations that are not key based will be routed to the endpoint
-    returned by the load balancer. If it is not, the load balancer will not be used.
     """
     def init(self, cluster_service):
-        """
-        Initializes the load balancer.
+        """Initializes the load balancer.
 
-        :param cluster_service: (:class:`~hazelcast.cluster.ClusterService`), The cluster service to select members from
+        Args:
+            cluster_service (hazelcast.cluster.ClusterService): The cluster service to select members from
         """
         raise NotImplementedError("init")
 
     def next(self):
-        """
-        Returns the next member to route to.
-        :return: (:class:`~hazelcast.core.Member`), Returns the next member or None if no member is available
+        """Returns the next member to route to.
+
+        Returns:
+            hazelcast.core.MemberInfo: the next member or ``None`` if no member is available.
         """
         raise NotImplementedError("next")
 
@@ -377,7 +291,7 @@ class _AbstractLoadBalancer(LoadBalancer):
 class RoundRobinLB(_AbstractLoadBalancer):
     """A load balancer implementation that relies on using round robin
     to a next member to send a request to.
-
+    
     Round robin is done based on best effort basis, the order of members for concurrent calls to
     the next() is not guaranteed.
     """
@@ -398,8 +312,7 @@ class RoundRobinLB(_AbstractLoadBalancer):
 
 
 class RandomLB(_AbstractLoadBalancer):
-    """A load balancer that selects a random member to route to.
-    """
+    """A load balancer that selects a random member to route to."""
 
     def next(self):
         members = self._members

--- a/hazelcast/util.py
+++ b/hazelcast/util.py
@@ -234,16 +234,11 @@ def to_signed(unsigned, bit_len):
     return unsigned & mask
 
 
-def with_reversed_items(cls):
-    reversed_mappings = {}
+def get_attr_name(cls, value):
     for attr_name, attr_value in six.iteritems(vars(cls)):
-        if not (attr_name.startswith("_") or callable(getattr(cls, attr_name))):
-            reversed_mappings[attr_value] = attr_name
-
-    class ClsWithReservedItems(cls):
-        reverse = reversed_mappings
-
-    return ClsWithReservedItems
+        if attr_value == value:
+            return attr_name
+    return None
 
 
 number_types = (six.integer_types, float)

--- a/tests/proxy/flake_id_generator_test.py
+++ b/tests/proxy/flake_id_generator_test.py
@@ -40,11 +40,6 @@ class FlakeIdGeneratorTest(SingleMemberTestCase):
         flake_id = self.flake_id_generator.new_id()
         self.assertIsNotNone(flake_id)
 
-    def test_init(self):
-        current_id = self.flake_id_generator.new_id()
-        self.assertTrue(self.flake_id_generator.init(current_id / 2))
-        self.assertFalse(self.flake_id_generator.init(current_id * 2))
-
     def test_new_id_generates_unique_ids(self):
         id_set = set()
 

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,36 +1,7 @@
 from hazelcast.config import IndexConfig, IndexUtil, IndexType, QueryConstants, \
     UniqueKeyTransformation
-from hazelcast.util import TimeUnit, calculate_version
+from hazelcast.util import calculate_version
 from unittest import TestCase
-
-
-class TimeUnitTest(TestCase):
-    def test_nano_to_second(self):
-        self.assertEqual(0.1, TimeUnit.to_seconds(0.1e9, TimeUnit.NANOSECOND))
-
-    def test_micro_to_second(self):
-        self.assertEqual(2, TimeUnit.to_seconds(2e6, TimeUnit.MICROSECOND))
-
-    def test_milli_to_second(self):
-        self.assertEqual(3, TimeUnit.to_seconds(3e3, TimeUnit.MILLISECOND))
-
-    def test_second_to_second(self):
-        self.assertEqual(5.5, TimeUnit.to_seconds(5.5, TimeUnit.SECOND))
-
-    def test_minute_to_second(self):
-        self.assertEqual(60, TimeUnit.to_seconds(1, TimeUnit.MINUTE))
-
-    def test_hour_to_second(self):
-        self.assertEqual(1800, TimeUnit.to_seconds(0.5, TimeUnit.HOUR))
-
-    def test_numeric_string_to_second(self):
-        self.assertEqual(1, TimeUnit.to_seconds("1000", TimeUnit.MILLISECOND))
-
-    def test_unsupported_types_to_second(self):
-        types = ["str", True, None, list(), set(), dict()]
-        for type in types:
-            with self.assertRaises((TypeError, ValueError)):
-                TimeUnit.to_seconds(type, TimeUnit.SECOND)
 
 
 class VersionUtilTest(TestCase):


### PR DESCRIPTION
Migrated reSt docstrings to Google style docstrings to make them more readable. 

Also, with this change, Pycharm is able to understand our type definitions, which makes the development much easier.

Also updated the API documentation files we use. Formerly, we were generating API documentation even for private classes like ConnectionManager or InvocationService.

Lastly, the use of class decorators is removed from the enum-like classes to make sphinx be able to get docstrings out of them. We still use reverse mappings of enum-like classes in the config validation process but we don't store the reverse mappings on the classes anymore. Since trying to access reverse mappings of enum-like classes happens very rarely, this shouldn't be a problem.

