### PR TITLE
Implement boomerang backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
   * [5.4. Setting Connection Timeout](#54-setting-connection-timeout)
   * [5.5. Enabling Client TLS/SSL](#55-enabling-client-tlsssl)
   * [5.6. Enabling Hazelcast Cloud Discovery](#56-enabling-hazelcast-cloud-discovery)
+  * [5.7. Configuring Backup Acknowledgment](#57-configuring-backup-acknowledgment)
 * [6. Client Connection Strategy](#6-client-connection-strategy)
   * [6.1. Configuring Client Connection Retry](#61-configuring-client-connection-retry)
 * [7. Using Python Client with Hazelcast IMDG](#7-using-python-client-with-hazelcast-imdg)
@@ -1055,6 +1056,33 @@ client = hazelcast.HazelcastClient(
 
 If you have enabled encryption for your cluster, you should also enable TLS/SSL configuration for the client to secure communication between your 
 client and cluster members as described in the [TLS/SSL for Hazelcast Python Client section](#812-tlsssl-for-hazelcast-python-clients).
+
+## 5.7. Configuring Backup Acknowledgment
+
+When an operation with sync backup is sent by a client to the Hazelcast member(s), the 
+acknowledgment of the operation's backup is sent to the client by the backup replica member(s). 
+This improves the performance of the client operations.
+
+To disable backup acknowledgement, you should use the `backup_ack_to_client_enabled` configuration option.
+
+```python
+client = hazelcast.HazelcastClient(
+    backup_ack_to_client_enabled=False,
+)
+```
+
+Its default value is `True`. This option has no effect for unisocket clients.
+
+You can also fine-tune this feature using the config options as described below:
+
+- `operation_backup_timeout`: Default value is `5` seconds. If an operation has
+backups, this property specifies how long the invocation waits for acks from the backup replicas. 
+If acks are not received from some of the backups, there will not be any rollback on the other successful replicas.
+
+- `fail_on_indeterminate_operation_state`: Default value is `False`. 
+When it is `True`, if an operation has sync backups and acks are not received from backup replicas in time, or the 
+member which owns primary replica of the target partition leaves the cluster, then the invocation fails. 
+However, even if the invocation fails, there will not be any rollback on other successful replicas.
 
 # 6. Client Connection Strategy
 

--- a/hazelcast/client.py
+++ b/hazelcast/client.py
@@ -335,10 +335,9 @@ class HazelcastClient(object):
     def _start(self):
         self._reactor.start()
         try:
+            self._invocation_service.init(self._internal_partition_service, self._connection_manager,
+                                          self._listener_service)
             self._internal_lifecycle_service.start()
-            self._invocation_service.start(self._internal_partition_service, self._connection_manager,
-                                           self._listener_service)
-            self._load_balancer.init(self.cluster_service)
             membership_listeners = self.config.membership_listeners
             self._internal_cluster_service.start(self._connection_manager, membership_listeners)
             self._cluster_view_listener.start()
@@ -348,6 +347,8 @@ class HazelcastClient(object):
                 self._connection_manager.connect_to_all_cluster_members()
 
             self._listener_service.start()
+            self._invocation_service.start()
+            self._load_balancer.init(self.cluster_service)
             self._statistics.start()
         except:
             self.shutdown()

--- a/hazelcast/client.py
+++ b/hazelcast/client.py
@@ -277,6 +277,22 @@ class HazelcastClient(object):
             logging module of the standard library.
         logging_level (int): Sets the logging level for the default logging
             configuration. By default, set to ``logging.INFO``.
+        backup_ack_to_client_enabled (bool): Enables client to get backup
+            acknowledgements directly from the member that backups are applied,
+            which reduces number of hops and increases performance for smart clients.
+            This option has no effect for unisocket clients. By default, set
+            to ``True`` (enabled).
+        operation_backup_timeout (float): If an operation has backups, defines
+            how long the invocation will wait for acks from the backup replicas
+            in seconds. If acks are not received from some backups, there won't
+            be any rollback on other successful replicas. By default, set to ``5.0``.
+        fail_on_indeterminate_operation_state (bool): When enabled, if an operation
+            has sync backups and acks are not received from backup replicas in time,
+            or the member which owns primary replica of the target partition leaves
+            the cluster, then the invocation fails with
+            :class:`hazelcast.errors.IndeterminateOperationStateError`. However,
+            even if the invocation fails, there will not be any rollback on other
+            successful replicas. By default, set to ``False`` (do not fail).
     """
 
     _CLIENT_ID = AtomicInteger()

--- a/hazelcast/config.py
+++ b/hazelcast/config.py
@@ -458,8 +458,8 @@ class _Config(object):
                  "_labels", "_heartbeat_interval", "_heartbeat_timeout",
                  "_invocation_timeout", "_invocation_retry_pause", "_statistics_enabled",
                  "_statistics_period", "_shuffle_member_list", "_logging_config",
-                 "_logging_level", "_backup_ack_to_client_enabled", "_clean_resources_period",
-                 "_operation_backup_timeout", "_fail_on_indeterminate_operation_state")
+                 "_logging_level", "_backup_ack_to_client_enabled", "_operation_backup_timeout",
+                 "_fail_on_indeterminate_operation_state")
 
     def __init__(self):
         self._cluster_members = []
@@ -509,8 +509,7 @@ class _Config(object):
         self._logging_config = None
         self._logging_level = logging.INFO
         self._backup_ack_to_client_enabled = True
-        self._clean_resources_period = 0.1
-        self._operation_backup_timeout = 5
+        self._operation_backup_timeout = 5.0
         self._fail_on_indeterminate_operation_state = False
 
     @property
@@ -1146,20 +1145,6 @@ class _Config(object):
             self._backup_ack_to_client_enabled = value
         else:
             raise TypeError("backup_ack_to_client_enabled must be a boolean")
-
-    @property
-    def clean_resources_period(self):
-        return self._clean_resources_period
-
-    @clean_resources_period.setter
-    def clean_resources_period(self, value):
-        if isinstance(value, number_types):
-            if value > 0:
-                self._clean_resources_period = value
-            else:
-                raise ValueError("clean_resources_period must be positive")
-        else:
-            raise TypeError("clean_resources_period must be a number")
 
     @property
     def operation_backup_timeout(self):

--- a/hazelcast/config.py
+++ b/hazelcast/config.py
@@ -458,7 +458,8 @@ class _Config(object):
                  "_labels", "_heartbeat_interval", "_heartbeat_timeout",
                  "_invocation_timeout", "_invocation_retry_pause", "_statistics_enabled",
                  "_statistics_period", "_shuffle_member_list", "_logging_config",
-                 "_logging_level")
+                 "_logging_level", "_backup_ack_to_client_enabled", "_clean_resources_period",
+                 "_operation_backup_timeout", "_fail_on_indeterminate_operation_state")
 
     def __init__(self):
         self._cluster_members = []
@@ -507,6 +508,10 @@ class _Config(object):
         self._shuffle_member_list = True
         self._logging_config = None
         self._logging_level = logging.INFO
+        self._backup_ack_to_client_enabled = True
+        self._clean_resources_period = 0.1
+        self._operation_backup_timeout = 5
+        self._fail_on_indeterminate_operation_state = False
 
     @property
     def cluster_members(self):
@@ -1130,6 +1135,56 @@ class _Config(object):
             self._logging_level = value
         else:
             raise TypeError("logging_level must be a valid value")
+
+    @property
+    def backup_ack_to_client_enabled(self):
+        return self._backup_ack_to_client_enabled
+
+    @backup_ack_to_client_enabled.setter
+    def backup_ack_to_client_enabled(self, value):
+        if isinstance(value, bool):
+            self._backup_ack_to_client_enabled = value
+        else:
+            raise TypeError("backup_ack_to_client_enabled must be a boolean")
+
+    @property
+    def clean_resources_period(self):
+        return self._clean_resources_period
+
+    @clean_resources_period.setter
+    def clean_resources_period(self, value):
+        if isinstance(value, number_types):
+            if value > 0:
+                self._clean_resources_period = value
+            else:
+                raise ValueError("clean_resources_period must be positive")
+        else:
+            raise TypeError("clean_resources_period must be a number")
+
+    @property
+    def operation_backup_timeout(self):
+        return self._operation_backup_timeout
+
+    @operation_backup_timeout.setter
+    def operation_backup_timeout(self, value):
+        if isinstance(value, number_types):
+            if value > 0:
+                self._operation_backup_timeout = value
+            else:
+                raise ValueError("operation_backup_timeout must be positive")
+        else:
+            raise TypeError("operation_backup_timeout must be a number")
+
+    @property
+    def fail_on_indeterminate_operation_state(self):
+        return self._fail_on_indeterminate_operation_state
+
+    @fail_on_indeterminate_operation_state.setter
+    def fail_on_indeterminate_operation_state(self, value):
+        if isinstance(value, bool):
+            self._fail_on_indeterminate_operation_state = value
+        else:
+            raise TypeError("fail_on_indeterminate_operation_state must be a boolean")
 
     @classmethod
     def from_dict(cls, d):

--- a/hazelcast/connection.py
+++ b/hazelcast/connection.py
@@ -629,7 +629,7 @@ class Connection(object):
         self.start_time = 0
         self.server_version = UNKNOWN_VERSION
         self.live = True
-        self.close_cause = None
+        self.close_reason = None
         self.logger = logging.getLogger("HazelcastClient.Connection[%s]" % connection_id)
 
         self._connection_manager = connection_manager
@@ -664,6 +664,7 @@ class Connection(object):
             return
 
         self.live = False
+        self.close_reason = reason
         self._log_close(reason, cause)
         try:
             self._inner_close()

--- a/hazelcast/errors.py
+++ b/hazelcast/errors.py
@@ -17,7 +17,7 @@ class HazelcastError(Exception):
         message, cause = self.args
         if cause:
             return "%s\nCaused by: %s" % (message, str(cause))
-        return message
+        return message or self.__class__.__name__
 
 
 class ArrayIndexOutOfBoundsError(HazelcastError):

--- a/hazelcast/future.py
+++ b/hazelcast/future.py
@@ -239,6 +239,9 @@ def combine_futures(*futures):
     """
     expected = len(futures)
     results = []
+    if expected == 0:
+        return ImmediateFuture(results)
+
     completed = AtomicInteger()
     combined = Future()
 

--- a/hazelcast/invocation.py
+++ b/hazelcast/invocation.py
@@ -51,6 +51,7 @@ class Invocation(object):
 
 class InvocationService(object):
     logger = logging.getLogger("HazelcastClient.InvocationService")
+    _CLEAN_RESOURCES_PERIOD = 0.1
 
     def __init__(self, client, reactor, logger_extras):
         config = client.config
@@ -74,7 +75,6 @@ class InvocationService(object):
         self._invocation_retry_pause = config.invocation_retry_pause
         self._backup_ack_to_client_enabled = smart_routing and config.backup_ack_to_client_enabled
         self._fail_on_indeterminate_state = config.fail_on_indeterminate_operation_state
-        self._clean_resources_period = config.clean_resources_period
         self._backup_timeout = config.operation_backup_timeout
         self._clean_resources_timer = None
         self._shutdown = False
@@ -318,9 +318,9 @@ class InvocationService(object):
                 if self._backup_ack_to_client_enabled:
                     self._detect_and_handle_backup_timeout(invocation, now)
 
-            self._clean_resources_timer = self._reactor.add_timer(self._clean_resources_period, run)
+            self._clean_resources_timer = self._reactor.add_timer(self._CLEAN_RESOURCES_PERIOD, run)
 
-        self._clean_resources_timer = self._reactor.add_timer(self._clean_resources_period, run)
+        self._clean_resources_timer = self._reactor.add_timer(self._CLEAN_RESOURCES_PERIOD, run)
 
     def _detect_and_handle_backup_timeout(self, invocation, now):
         if not invocation.pending_response:

--- a/hazelcast/invocation.py
+++ b/hazelcast/invocation.py
@@ -4,8 +4,9 @@ import functools
 
 from hazelcast.errors import create_error_from_message, HazelcastInstanceNotActiveError, is_retryable_error, \
     HazelcastTimeoutError, TargetDisconnectedError, HazelcastClientNotActiveError, TargetNotMemberError, \
-    EXCEPTION_MESSAGE_TYPE
+    EXCEPTION_MESSAGE_TYPE, IndeterminateOperationStateError
 from hazelcast.future import Future
+from hazelcast.protocol.codec import client_local_backup_listener_codec
 from hazelcast.util import AtomicInteger
 from hazelcast import six
 
@@ -16,7 +17,8 @@ def _no_op_response_handler(_):
 
 class Invocation(object):
     __slots__ = ("request", "timeout", "partition_id", "uuid", "connection", "event_handler",
-                 "future", "sent_connection", "urgent", "response_handler")
+                 "future", "sent_connection", "urgent", "response_handler", "backup_acks_received",
+                 "backup_acks_expected", "pending_response", "pending_response_received_time")
 
     def __init__(self, request, partition_id=-1, uuid=None, connection=None,
                  event_handler=None, urgent=False, timeout=None, response_handler=_no_op_response_handler):
@@ -31,6 +33,10 @@ class Invocation(object):
         self.timeout = None
         self.sent_connection = None
         self.response_handler = response_handler
+        self.backup_acks_received = 0
+        self.backup_acks_expected = -1
+        self.pending_response = None
+        self.pending_response_received_time = -1
 
     def set_response(self, response):
         try:
@@ -48,7 +54,8 @@ class InvocationService(object):
 
     def __init__(self, client, reactor, logger_extras):
         config = client.config
-        if config.smart_routing:
+        smart_routing = config.smart_routing
+        if smart_routing:
             self.invoke = self._invoke_smart
         else:
             self.invoke = self._invoke_non_smart
@@ -65,36 +72,52 @@ class InvocationService(object):
         self._is_redo_operation = config.redo_operation
         self._invocation_timeout = config.invocation_timeout
         self._invocation_retry_pause = config.invocation_retry_pause
+        self._backup_ack_to_client_enabled = smart_routing and config.backup_ack_to_client_enabled
+        self._fail_on_indeterminate_state = config.fail_on_indeterminate_operation_state
+        self._clean_resources_period = config.clean_resources_period
+        self._backup_timeout = config.operation_backup_timeout
+        self._clean_resources_timer = None
         self._shutdown = False
 
-    def start(self, partition_service, connection_manager, listener_service):
+    def init(self, partition_service, connection_manager, listener_service):
         self._partition_service = partition_service
         self._connection_manager = connection_manager
         self._listener_service = listener_service
         self._check_invocation_allowed_fn = connection_manager.check_invocation_allowed
 
+    def start(self):
+        self._start_clean_resources_timer()
+        if self._backup_ack_to_client_enabled:
+            self._register_backup_listener()
+
     def handle_client_message(self, message):
         correlation_id = message.get_correlation_id()
 
-        if message.start_frame.has_event_flag():
+        start_frame = message.start_frame
+        if start_frame.has_event_flag() or start_frame.has_backup_event_flag():
             self._listener_service.handle_client_message(message, correlation_id)
             return
 
-        invocation = self._pending.pop(correlation_id, None)
+        invocation = self._pending.get(correlation_id, None)
         if not invocation:
             self.logger.warning("Got message with unknown correlation id: %s", message, extra=self._logger_extras)
             return
 
         if message.get_message_type() == EXCEPTION_MESSAGE_TYPE:
             error = create_error_from_message(message)
-            return self._handle_exception(invocation, error)
+            return self._notify_error(invocation, error)
 
-        invocation.set_response(message)
+        self._notify(invocation, message)
 
     def shutdown(self):
+        if self._shutdown:
+            return
+
         self._shutdown = True
+        if self._clean_resources_timer:
+            self._clean_resources_timer.cancel()
         for invocation in list(six.itervalues(self._pending)):
-            self._handle_exception(invocation, HazelcastClientNotActiveError())
+            self._notify_error(invocation, HazelcastClientNotActiveError())
 
     def _invoke_on_partition_owner(self, invocation, partition_id):
         owner_uuid = self._partition_service.get_partition_owner(partition_id)
@@ -129,7 +152,7 @@ class InvocationService(object):
             if connection:
                 invoked = self._send(invocation, connection)
                 if not invoked:
-                    self._handle_exception(invocation, IOError("Could not invoke on connection %s" % connection))
+                    self._notify_error(invocation, IOError("Could not invoke on connection %s" % connection))
                 return
 
             if invocation.partition_id != -1:
@@ -143,9 +166,9 @@ class InvocationService(object):
                 invoked = self._invoke_on_random_connection(invocation)
 
             if not invoked:
-                self._handle_exception(invocation, IOError("No connection found to invoke"))
+                self._notify_error(invocation, IOError("No connection found to invoke"))
         except Exception as e:
-            self._handle_exception(invocation, e)
+            self._notify_error(invocation, e)
 
     def _invoke_non_smart(self, invocation):
         if not invocation.timeout:
@@ -159,17 +182,20 @@ class InvocationService(object):
             if connection:
                 invoked = self._send(invocation, connection)
                 if not invoked:
-                    self._handle_exception(invocation, IOError("Could not invoke on connection %s" % connection))
+                    self._notify_error(invocation, IOError("Could not invoke on connection %s" % connection))
                 return
 
             if not self._invoke_on_random_connection(invocation):
-                self._handle_exception(invocation, IOError("No connection found to invoke"))
+                self._notify_error(invocation, IOError("No connection found to invoke"))
         except Exception as e:
-            self._handle_exception(invocation, e)
+            self._notify_error(invocation, e)
 
     def _send(self, invocation, connection):
         if self._shutdown:
             raise HazelcastClientNotActiveError()
+
+        if self._backup_ack_to_client_enabled:
+            invocation.request.set_backup_aware_flag()
 
         correlation_id = self._next_correlation_id.get_and_increment()
         message = invocation.request
@@ -186,29 +212,28 @@ class InvocationService(object):
             if invocation.event_handler:
                 self._listener_service.remove_event_handler(correlation_id)
             return False
+
+        invocation.sent_connection = connection
         return True
 
-    def _handle_exception(self, invocation, error, traceback=None):
-        if self.logger.isEnabledFor(logging.DEBUG):
-            self.logger.debug("Got exception for request %s, error: %s" % (invocation.request, error),
-                              extra=self._logger_extras)
+    def _notify_error(self, invocation, error):
+        self.logger.debug("Got exception for request %s, error: %s" % (invocation.request, error),
+                          extra=self._logger_extras)
 
         if not self._client.lifecycle_service.is_running():
-            invocation.set_exception(HazelcastClientNotActiveError(), traceback)
-            self._pending.pop(invocation.request.get_correlation_id(), None)
+            self._complete_with_error(invocation, HazelcastClientNotActiveError())
             return
 
         if not self._should_retry(invocation, error):
-            invocation.set_exception(error, traceback)
-            self._pending.pop(invocation.request.get_correlation_id(), None)
+            self._complete_with_error(invocation, error)
             return
 
         if invocation.timeout < time.time():
             self.logger.debug("Error will not be retried because invocation timed out: %s", error,
                               extra=self._logger_extras)
-            invocation.set_exception(HazelcastTimeoutError("Request timed out because an error occurred after "
-                                                           "invocation timeout: %s" % error, traceback))
-            self._pending.pop(invocation.request.get_correlation_id(), None)
+            error = HazelcastTimeoutError("Request timed out because an error occurred "
+                                          "after invocation timeout: %s" % error)
+            self._complete_with_error(invocation, error)
             return
 
         invoke_func = functools.partial(self.invoke, invocation)
@@ -228,3 +253,90 @@ class InvocationService(object):
             return invocation.request.retryable or self._is_redo_operation
 
         return False
+
+    def _complete_with_error(self, invocation, error):
+        invocation.set_exception(error, None)
+        correlation_id = invocation.request.get_correlation_id()
+        self._pending.pop(correlation_id, None)
+
+    def _register_backup_listener(self):
+        codec = client_local_backup_listener_codec
+        request = codec.encode_request()
+        self._listener_service.register_listener(request,
+                                                 codec.decode_response,
+                                                 lambda reg_id: None,
+                                                 lambda m: codec.handle(m, self._backup_event_handler))
+
+    def _backup_event_handler(self, correlation_id):
+        invocation = self._pending.get(correlation_id, None)
+        if not invocation:
+            self.logger.debug("Invocation not found for backup event, invocation id %s" % correlation_id,
+                              extra=self._logger_extras)
+            return
+        self._notify_backup_complete(invocation)
+
+    def _notify(self, invocation, client_message):
+        expected_backups = client_message.get_number_of_backup_acks()
+        if expected_backups > invocation.backup_acks_received:
+            invocation.pending_response_received_time = time.time()
+            invocation.backup_acks_expected = expected_backups
+            invocation.pending_response = client_message
+            return
+
+        self._complete(invocation, client_message)
+
+    def _notify_backup_complete(self, invocation):
+        invocation.backup_acks_received += 1
+        if not invocation.pending_response:
+            return
+
+        if invocation.backup_acks_expected != invocation.backup_acks_received:
+            return
+
+        self._complete(invocation, invocation.pending_response)
+
+    def _complete(self, invocation, client_message):
+        invocation.set_response(client_message)
+        correlation_id = invocation.request.get_correlation_id()
+        self._pending.pop(correlation_id, None)
+
+    def _start_clean_resources_timer(self):
+        def run():
+            if self._shutdown:
+                return
+
+            now = time.time()
+            for invocation in list(self._pending.values()):
+                connection = invocation.sent_connection
+                if not connection:
+                    continue
+
+                if not connection.live:
+                    error = TargetDisconnectedError(connection.close_reason)
+                    self._notify_error(invocation, error)
+
+                if self._backup_ack_to_client_enabled:
+                    self._detect_and_handle_backup_timeout(invocation, now)
+
+            self._clean_resources_timer = self._reactor.add_timer(self._clean_resources_period, run)
+
+        self._clean_resources_timer = self._reactor.add_timer(self._clean_resources_period, run)
+
+    def _detect_and_handle_backup_timeout(self, invocation, now):
+        if not invocation.pending_response:
+            return
+
+        if invocation.backup_acks_expected == invocation.backup_acks_received:
+            return
+
+        expiration_time = invocation.pending_response_received_time + self._backup_timeout
+        timeout_reached = 0 < expiration_time < now
+        if not timeout_reached:
+            return
+
+        if self._fail_on_indeterminate_state:
+            error = IndeterminateOperationStateError("Invocation failed because the backup acks are missed")
+            self._complete_with_error(invocation, error)
+            return
+
+        self._complete(invocation, invocation.pending_response)

--- a/setup.py
+++ b/setup.py
@@ -58,5 +58,5 @@ setup(
         package_data={'hazelcast': ["git_info.json"]},
         install_requires=[],
         extras_require=extras,
-        tests_require=['thrift', 'nose', 'coverage', 'psutil'],
+        tests_require=['thrift', 'nose', 'coverage', 'psutil', 'mock'],
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,4 @@ thrift==0.13.0
 nose==1.3.7
 coverage==4.5.1
 psutil>=5.4.8
+mock==3.0.5

--- a/tests/backup_acks_test.py
+++ b/tests/backup_acks_test.py
@@ -1,0 +1,98 @@
+from mock import MagicMock
+
+from hazelcast import HazelcastClient
+from hazelcast.errors import IndeterminateOperationStateError
+from tests.base import HazelcastTestCase
+
+
+class BackupAcksTest(HazelcastTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.rc = cls.create_rc()
+        cls.cluster = cls.rc.createCluster(None, None)
+        cls.rc.startMember(cls.cluster.id)
+        cls.rc.startMember(cls.cluster.id)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.rc.terminateCluster(cls.cluster.id)
+        cls.rc.exit()
+
+    def setUp(self):
+        self.client = None
+
+    def tearDown(self):
+        if self.client:
+            self.client.shutdown()
+
+    def test_smart_mode(self):
+        self.client = HazelcastClient(
+            cluster_name=self.cluster.id,
+            fail_on_indeterminate_operation_state=True,
+        )
+        m = self.client.get_map("test")
+
+        # it's enough for this operation to succeed
+        m.set(1, 2).result()
+
+    def test_lost_backups_on_smart_mode_with_fail_on_indeterminate_operation_state(self):
+        self.client = HazelcastClient(
+            cluster_name=self.cluster.id,
+            operation_backup_timeout=0.3,
+            fail_on_indeterminate_operation_state=True,
+        )
+
+        client = self.client
+        # replace backup ack handler with a mock to emulate backup acks loss
+        client._invocation_service._backup_event_handler = MagicMock()
+
+        m = client.get_map("test")
+        with self.assertRaises(IndeterminateOperationStateError):
+            m.set(1, 2).result()
+
+    def test_lost_backups_on_smart_mode_without_fail_on_indeterminate_operation_state(self):
+        self.client = HazelcastClient(
+            cluster_name=self.cluster.id,
+            operation_backup_timeout=0.3,
+            fail_on_indeterminate_operation_state=False,
+        )
+
+        client = self.client
+        # replace backup ack handler with a mock to emulate backup acks loss
+        client._invocation_service._backup_event_handler = MagicMock()
+
+        m = client.get_map("test")
+
+        # it's enough for this operation to succeed
+        m.set(1, 2).result()
+
+    def test_backup_acks_disabled(self):
+        self.client = HazelcastClient(
+            cluster_name=self.cluster.id,
+            backup_ack_to_client_enabled=False,
+        )
+        m = self.client.get_map("test")
+
+        # it's enough for this operation to succeed
+        m.set(1, 2).result()
+
+    def test_unisocket_mode(self):
+        self.client = HazelcastClient(
+            cluster_name=self.cluster.id,
+            smart_routing=False,
+        )
+        m = self.client.get_map("test")
+
+        # it's enough for this operation to succeed
+        m.set(1, 2).result()
+
+    def test_unisocket_mode_with_disabled_backup_acks(self):
+        self.client = HazelcastClient(
+            cluster_name=self.cluster.id,
+            smart_routing=False,
+            backup_ack_to_client_enabled=False,
+        )
+        m = self.client.get_map("test")
+
+        # it's enough for this operation to succeed
+        m.set(1, 2).result()

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -748,19 +748,6 @@ class ConfigTest(unittest.TestCase):
         config.backup_ack_to_client_enabled = False
         self.assertFalse(config.backup_ack_to_client_enabled)
 
-    def test_clean_resources_period(self):
-        config = self.config
-        self.assertEqual(0.1, config.clean_resources_period)
-
-        with self.assertRaises(ValueError):
-            config.clean_resources_period = 0
-
-        with self.assertRaises(TypeError):
-            config.clean_resources_period = None
-
-        config.clean_resources_period = 1.0
-        self.assertEqual(1.0, config.clean_resources_period)
-
     def test_operation_backup_timeout(self):
         config = self.config
         self.assertEqual(5.0, config.operation_backup_timeout)

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -738,6 +738,52 @@ class ConfigTest(unittest.TestCase):
         config.logging_level = logging.DEBUG
         self.assertEqual(logging.DEBUG, config.logging_level)
 
+    def test_backup_ack_to_client_enabled(self):
+        config = self.config
+        self.assertTrue(config.backup_ack_to_client_enabled)
+
+        with self.assertRaises(TypeError):
+            config.backup_ack_to_client_enabled = None
+
+        config.backup_ack_to_client_enabled = False
+        self.assertFalse(config.backup_ack_to_client_enabled)
+
+    def test_clean_resources_period(self):
+        config = self.config
+        self.assertEqual(0.1, config.clean_resources_period)
+
+        with self.assertRaises(ValueError):
+            config.clean_resources_period = 0
+
+        with self.assertRaises(TypeError):
+            config.clean_resources_period = None
+
+        config.clean_resources_period = 1.0
+        self.assertEqual(1.0, config.clean_resources_period)
+
+    def test_operation_backup_timeout(self):
+        config = self.config
+        self.assertEqual(5.0, config.operation_backup_timeout)
+
+        with self.assertRaises(ValueError):
+            config.operation_backup_timeout = 0
+
+        with self.assertRaises(TypeError):
+            config.operation_backup_timeout = None
+
+        config.operation_backup_timeout = 10
+        self.assertEqual(10, config.operation_backup_timeout)
+
+    def test_fail_on_indeterminate_operation_state(self):
+        config = self.config
+        self.assertFalse(config.fail_on_indeterminate_operation_state)
+
+        with self.assertRaises(TypeError):
+            config.fail_on_indeterminate_operation_state = None
+
+        config.fail_on_indeterminate_operation_state = True
+        self.assertTrue(config.fail_on_indeterminate_operation_state)
+
 
 class IndexConfigTest(unittest.TestCase):
     def test_defaults(self):

--- a/tests/future_test.py
+++ b/tests/future_test.py
@@ -384,6 +384,16 @@ class CombineFutureTest(unittest.TestCase):
 
         self.assertEqual(e, combined.exception())
 
+    def test_combine_futures_with_empty_list(self):
+        combined = combine_futures()
+        combined2 = combine_futures(*[])
+
+        self.assertTrue(combined.done())
+        self.assertTrue(combined2.done())
+
+        self.assertEqual([], combined.result())
+        self.assertEqual([], combined2.result())
+
 
 class MakeBlockingTest(unittest.TestCase):
     class Calculator(object):

--- a/tests/invocation_test.py
+++ b/tests/invocation_test.py
@@ -4,11 +4,10 @@ import unittest
 from mock import MagicMock
 
 import hazelcast
-from hazelcast import HazelcastClient
 from hazelcast.config import _Config
 from hazelcast.errors import HazelcastTimeoutError, IndeterminateOperationStateError
 from hazelcast.invocation import Invocation, InvocationService
-from hazelcast.protocol.client_message import OutboundMessage, InboundMessage
+from hazelcast.protocol.client_message import OutboundMessage
 from hazelcast.serialization import LE_INT
 from tests.base import HazelcastTestCase
 
@@ -54,7 +53,7 @@ class InvocationTest(unittest.TestCase):
 
     def test_notify_with_no_expected_backups(self):
         _, service = self._start_service()
-        response = MagicMock(InboundMessage)()
+        response = MagicMock()
         response.get_number_of_backup_acks = MagicMock(return_value=0)
         invocation = MagicMock(backup_acks_received=0)
         service._notify(invocation, response)
@@ -133,9 +132,7 @@ class InvocationTest(unittest.TestCase):
         self.assertIsInstance(invocation.set_exception.call_args[0][0], IndeterminateOperationStateError)
 
     def _start_service(self, config=_Config()):
-        client_cls = MagicMock(HazelcastClient, config=config)
-        c = client_cls()
-        c.config = config
+        c = MagicMock(config=config)
         invocation_service = InvocationService(c, c._reactor, None)
         self.service = invocation_service
         invocation_service.init(c._internal_partition_service, c._connection_manager, c._listener_service)

--- a/tests/invocation_test.py
+++ b/tests/invocation_test.py
@@ -1,13 +1,149 @@
 import time
+import unittest
+
+from mock import MagicMock
 
 import hazelcast
-from hazelcast.errors import HazelcastTimeoutError
-from hazelcast.invocation import Invocation
-from hazelcast.protocol.client_message import OutboundMessage
+from hazelcast import HazelcastClient
+from hazelcast.config import _Config
+from hazelcast.errors import HazelcastTimeoutError, IndeterminateOperationStateError
+from hazelcast.invocation import Invocation, InvocationService
+from hazelcast.protocol.client_message import OutboundMessage, InboundMessage
+from hazelcast.serialization import LE_INT
 from tests.base import HazelcastTestCase
 
 
-class InvocationTest(HazelcastTestCase):
+class InvocationTest(unittest.TestCase):
+    def setUp(self):
+        self.service = None
+
+    def tearDown(self):
+        if self.service:
+            self.service.shutdown()
+
+    def test_smart_mode_and_enabled_backups(self):
+        client, service = self._start_service()
+        self.assertIsNotNone(service._clean_resources_timer)
+        listener_service = client._listener_service
+        listener_service.register_listener.assert_called_once()
+
+    def test_smart_mode_and_disabled_backups(self):
+        config = _Config()
+        config.backup_ack_to_client_enabled = False
+        client, service = self._start_service(config)
+        self.assertIsNotNone(service._clean_resources_timer)
+        listener_service = client._listener_service
+        listener_service.register_listener.assert_not_called()
+
+    def test_unisocket_mode_and_enabled_backups(self):
+        config = _Config()
+        config.smart_routing = False
+        client, service = self._start_service(config)
+        self.assertIsNotNone(service._clean_resources_timer)
+        listener_service = client._listener_service
+        listener_service.register_listener.assert_not_called()
+
+    def test_unisocket_mode_and_disabled_backups(self):
+        config = _Config()
+        config.smart_routing = False
+        config.backup_ack_to_client_enabled = False
+        client, service = self._start_service(config)
+        self.assertIsNotNone(service._clean_resources_timer)
+        listener_service = client._listener_service
+        listener_service.register_listener.assert_not_called()
+
+    def test_notify_with_no_expected_backups(self):
+        _, service = self._start_service()
+        response = MagicMock(InboundMessage)()
+        response.get_number_of_backup_acks = MagicMock(return_value=0)
+        invocation = MagicMock(backup_acks_received=0)
+        service._notify(invocation, response)
+        invocation.set_response.assert_called_once_with(response)
+
+    def test_notify_with_expected_backups(self):
+        _, service = self._start_service()
+        response = MagicMock()
+        response.get_number_of_backup_acks = MagicMock(return_value=1)
+        invocation = MagicMock(backup_acks_received=0)
+        service._notify(invocation, response)
+        invocation.set_response.assert_not_called()
+        self.assertTrue(invocation.pending_response_received_time > 0)
+        self.assertEqual(1, invocation.backup_acks_expected)
+        self.assertEqual(response, invocation.pending_response)
+
+    def test_notify_with_equal_expected_and_received_acks(self):
+        _, service = self._start_service()
+        response = MagicMock()
+        response.get_number_of_backup_acks = MagicMock(return_value=1)
+        invocation = MagicMock(backup_acks_received=1)
+        service._notify(invocation, response)
+        invocation.set_response.assert_called_once_with(response)
+
+    def test_notify_backup_complete_with_no_pending_response(self):
+        _, service = self._start_service()
+        invocation = MagicMock(backup_acks_received=0)
+        service._notify_backup_complete(invocation)
+        invocation.set_response.assert_not_called()
+        self.assertEqual(1, invocation.backup_acks_received)
+
+    def test_notify_backup_complete_with_pending_acks(self):
+        _, service = self._start_service()
+        invocation = MagicMock(backup_acks_received=1, backup_acks_expected=3, pending_response="x")
+        service._notify_backup_complete(invocation)
+        invocation.set_response.assert_not_called()
+        self.assertEqual(2, invocation.backup_acks_received)
+
+    def test_notify_backup_complete_when_all_acks_are_received(self):
+        _, service = self._start_service()
+        message = "x"
+        invocation = MagicMock(backup_acks_received=1, backup_acks_expected=2, pending_response=message)
+        service._notify_backup_complete(invocation)
+        invocation.set_response.assert_called_once_with(message)
+        self.assertEqual(2, invocation.backup_acks_received)
+
+    def test_backup_handler_when_all_acks_are_received(self):
+        _, service = self._start_service()
+        invocation = MagicMock(backup_acks_received=1, backup_acks_expected=1, pending_response="x")
+        service._detect_and_handle_backup_timeout(invocation, 0)
+        invocation.set_response.assert_not_called()
+
+    def test_backup_handler_when_all_acks_are_not_received_and_not_reached_timeout(self):
+        _, service = self._start_service()
+        invocation = MagicMock(backup_acks_received=1, backup_acks_expected=2, pending_response="x",
+                               pending_response_received_time=40)
+        service._detect_and_handle_backup_timeout(invocation, 1)  # expiration_time = 40 + 5 > 1
+        invocation.set_response.assert_not_called()
+
+    def test_backup_handler_when_all_acks_are_not_received_and_reached_timeout(self):
+        _, service = self._start_service()
+        message = "x"
+        invocation = MagicMock(backup_acks_received=1, backup_acks_expected=2, pending_response=message,
+                               pending_response_received_time=40)
+        service._detect_and_handle_backup_timeout(invocation, 46)  # expiration_time = 40 + 5 < 46
+        invocation.set_response.assert_called_once_with(message)
+
+    def test_backup_handler_when_all_acks_are_not_received_and_reached_timeout_with_fail_on_indeterminate_state(self):
+        _, service = self._start_service()
+        service._fail_on_indeterminate_state = True
+        invocation = MagicMock(backup_acks_received=1, backup_acks_expected=2, pending_response="x",
+                               pending_response_received_time=40)
+        service._detect_and_handle_backup_timeout(invocation, 46)  # expiration_time = 40 + 5 < 46
+        invocation.set_response.assert_not_called()
+        invocation.set_exception.assert_called_once()
+        self.assertIsInstance(invocation.set_exception.call_args[0][0], IndeterminateOperationStateError)
+
+    def _start_service(self, config=_Config()):
+        client_cls = MagicMock(HazelcastClient, config=config)
+        c = client_cls()
+        c.config = config
+        invocation_service = InvocationService(c, c._reactor, None)
+        self.service = invocation_service
+        invocation_service.init(c._internal_partition_service, c._connection_manager, c._listener_service)
+        invocation_service.start()
+        return c, invocation_service
+
+
+class InvocationTimeoutTest(HazelcastTestCase):
     @classmethod
     def setUpClass(cls):
         cls.rc = cls.create_rc()
@@ -39,15 +175,17 @@ class InvocationTest(HazelcastTestCase):
             time.sleep(2)
             return False
 
-        invocation_service._invoke_on_partition_owner = mock
-        invocation_service._invoke_on_random_connection = lambda _: False
+        invocation_service._invoke_on_partition_owner = MagicMock(side_effect=mock)
+        invocation_service._invoke_on_random_connection = MagicMock(return_value=False)
 
         invocation_service.invoke(invocation)
         with self.assertRaises(HazelcastTimeoutError):
             invocation.future.result()
 
     def test_invocation_not_timed_out_when_there_is_no_exception(self):
-        request = OutboundMessage(bytearray(22), True)
+        buf = bytearray(22)
+        LE_INT.pack_into(buf, 0, 22)
+        request = OutboundMessage(buf, True)
         invocation_service = self.client._invocation_service
         invocation = Invocation(request)
         invocation_service.invoke(invocation)


### PR DESCRIPTION
Boomerang backups implementation, documentation, tests, required configuration options, namely,
`backup_ack_to_client_enabled`, `operation_backup_timeout` and
`fail_on_indeterminate_operation_state` are added.

Also, another test dependency is added to make mocking the failure scenarios easier.
Added dependency, `mock`, comes with the standard library on Python3.3+, but due to
support for Python2.7, it is added.

depends on #221