### PR TITLE
CP Subsytem - Atomic Reference

### DIFF
--- a/examples/cp/atomic_reference_example.py
+++ b/examples/cp/atomic_reference_example.py
@@ -1,0 +1,17 @@
+import hazelcast
+
+client = hazelcast.HazelcastClient()
+
+my_ref = client.cp_subsystem.get_atomic_reference("my-ref").blocking()
+my_ref.set(42)
+
+value = my_ref.get()
+print("Value:", value)
+
+result = my_ref.compare_and_set(42, "value")
+print("CAS result:", result)
+
+final_value = my_ref.get()
+print("Final value:", final_value)
+
+client.shutdown()

--- a/hazelcast/cp.py
+++ b/hazelcast/cp.py
@@ -1,6 +1,7 @@
 from hazelcast.invocation import Invocation
 from hazelcast.protocol.codec import cp_group_create_cp_group_codec
 from hazelcast.proxy.cp.atomic_long import AtomicLong
+from hazelcast.proxy.cp.atomic_reference import AtomicReference
 from hazelcast.util import check_true
 
 
@@ -53,6 +54,26 @@ class CPSubsystem(object):
         """
         return self._proxy_manager.get_or_create(ATOMIC_LONG_SERVICE, name)
 
+    def get_atomic_reference(self, name):
+        """Returns the distributed AtomicReference instance with given name.
+
+        The instance is created on CP Subsystem.
+
+        If no group name is given within the ``name`` argument, then the
+        AtomicLong instance will be created on the DEFAULT CP group.
+        If a group name is given, like ``.get_atomic_reference("myRef@group1")``,
+        the given group will be initialized first, if not initialized
+        already, and then the instance will be created on this group.
+
+        Args:
+            name (str): Name of the AtomicReference.
+
+        Returns:
+            hazelcast.proxy.cp.atomic_reference.AtomicReference: The AtomicReference
+                proxy for the given name.
+        """
+        return self._proxy_manager.get_or_create(ATOMIC_REFERENCE_SERVICE, name)
+
 
 _DEFAULT_GROUP_NAME = "default"
 
@@ -83,6 +104,7 @@ def _get_object_name_for_proxy(name):
 
 
 ATOMIC_LONG_SERVICE = "hz:raft:atomicLongService"
+ATOMIC_REFERENCE_SERVICE = "hz:raft:atomicRefService"
 
 
 class CPProxyManager(object):
@@ -96,6 +118,8 @@ class CPProxyManager(object):
         group_id = self._get_group_id(proxy_name)
         if service_name == ATOMIC_LONG_SERVICE:
             return AtomicLong(self._context, group_id, service_name, proxy_name, object_name)
+        elif service_name == ATOMIC_REFERENCE_SERVICE:
+            return AtomicReference(self._context, group_id, service_name, proxy_name, object_name)
 
     def _get_group_id(self, proxy_name):
         codec = cp_group_create_cp_group_codec

--- a/hazelcast/proxy/cp/atomic_long.py
+++ b/hazelcast/proxy/cp/atomic_long.py
@@ -2,7 +2,7 @@ from hazelcast.protocol.codec import atomic_long_add_and_get_codec, atomic_long_
     atomic_long_get_codec, atomic_long_get_and_add_codec, atomic_long_get_and_set_codec, atomic_long_alter_codec, \
     atomic_long_apply_codec
 from hazelcast.proxy.cp import BaseCPProxy
-from hazelcast.util import check_not_none
+from hazelcast.util import check_not_none, check_is_int
 
 
 class AtomicLong(BaseCPProxy):
@@ -32,6 +32,7 @@ class AtomicLong(BaseCPProxy):
             hazelcast.future.Future[int]: The updated value, the given value added
                 to the current value
         """
+        check_is_int(delta)
         codec = atomic_long_add_and_get_codec
         request = codec.encode_request(self._group_id, self._object_name, delta)
         return self._invoke(request, codec.decode_response)
@@ -48,6 +49,8 @@ class AtomicLong(BaseCPProxy):
             hazelcast.future.Future[bool]: ``True`` if successful; or ``False`` if
                 the actual value was not equal to the expected value.
         """
+        check_is_int(expect)
+        check_is_int(update)
         codec = atomic_long_compare_and_set_codec
         request = codec.encode_request(self._group_id, self._object_name, expect, update)
         return self._invoke(request, codec.decode_response)
@@ -88,6 +91,7 @@ class AtomicLong(BaseCPProxy):
         Returns:
             hazelcast.future.Future[int]: The old value before the add.
         """
+        check_is_int(delta)
         codec = atomic_long_get_and_add_codec
         request = codec.encode_request(self._group_id, self._object_name, delta)
         return self._invoke(request, codec.decode_response)
@@ -101,6 +105,7 @@ class AtomicLong(BaseCPProxy):
         Returns:
             hazelcast.future.Future[int]: The old value.
         """
+        check_is_int(new_value)
         codec = atomic_long_get_and_set_codec
         request = codec.encode_request(self._group_id, self._object_name, new_value)
         return self._invoke(request, codec.decode_response)
@@ -131,6 +136,7 @@ class AtomicLong(BaseCPProxy):
         Returns:
             hazelcast.future.Future[None]:
         """
+        check_is_int(new_value)
         codec = atomic_long_get_and_set_codec
         request = codec.encode_request(self._group_id, self._object_name, new_value)
         return self._invoke(request)
@@ -177,6 +183,7 @@ class AtomicLong(BaseCPProxy):
         Returns:
             hazelcast.future.Future[int]: The new value.
         """
+        check_not_none(function, "Function cannot be None")
         function_data = self._to_data(function)
         codec = atomic_long_alter_codec
         # 1 means return the new value.

--- a/hazelcast/proxy/cp/atomic_reference.py
+++ b/hazelcast/proxy/cp/atomic_reference.py
@@ -1,0 +1,242 @@
+from hazelcast.protocol.codec import atomic_ref_compare_and_set_codec, atomic_ref_get_codec, atomic_ref_set_codec, \
+    atomic_ref_contains_codec, atomic_ref_apply_codec
+from hazelcast.proxy.cp import BaseCPProxy
+from hazelcast.util import check_true, check_not_none
+
+
+class AtomicReference(BaseCPProxy):
+    """A distributed, highly available object reference with atomic operations.
+
+    AtomicReference offers linearizability during crash failures and network
+    partitions. It is CP with respect to the CAP principle. If a network
+    partition occurs, it remains available on at most one side of the partition.
+
+    The following are some considerations you need to know when you use AtomicReference:
+
+    - AtomicReference works based on the byte-content and not on the object-reference.
+      If you use the ``compare_and_set()`` method, do not change to the original
+      value because its serialized content will then be different.
+    - All methods returning an object return a private copy. You can modify the private
+      copy, but the rest of the world is shielded from your changes. If you want these
+      changes to be visible to the rest of the world, you need to write the change back
+      to the AtomicReference; but be careful about introducing a data-race.
+    - The in-memory format of an AtomicReference is ``binary``. The receiving side
+      does not need to have the class definition available unless it needs to be
+      deserialized on the other side., e.g., because a method like `alter()` is executed.
+      This deserialization is done for every call that needs to have the object instead
+      of the binary content, so be careful with expensive object graphs that need to be
+      deserialized.
+    - If you have an object with many fields or an object graph and you only need to
+      calculate some information or need a subset of fields, you can use the `apply()`
+      method. With the `apply()` method, the whole object does not need to be sent over
+      the line; only the information that is relevant is sent.
+
+    IAtomicReference does not offer exactly-once / effectively-once
+    execution semantics. It goes with at-least-once execution semantics
+    by default and can cause an API call to be committed multiple times
+    in case of CP member failures. It can be tuned to offer at-most-once
+    execution semantics. Please see `fail-on-indeterminate-operation-state`
+    server-side setting.
+    """
+
+    def compare_and_set(self, expect, update):
+        """Atomically sets the value to the given updated value
+        only if the current value is equal to the expected value.
+
+        Args:
+            expect: The expected value.
+            update: The new value.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if successful, or ``False``
+            if the actual value was not equal to the expected value.
+        """
+        expected_data = self._to_data(expect)
+        new_data = self._to_data(update)
+        codec = atomic_ref_compare_and_set_codec
+        request = codec.encode_request(self._group_id, self._object_name, expected_data, new_data)
+        return self._invoke(request, codec.decode_response)
+
+    def get(self):
+        """Gets the current value.
+
+        Returns:
+            hazelcast.future.Future[any]: The current value.
+        """
+        codec = atomic_ref_get_codec
+        request = codec.encode_request(self._group_id, self._object_name)
+
+        def handler(response):
+            return self._to_object(codec.decode_response(response))
+
+        return self._invoke(request, handler)
+
+    def set(self, new_value):
+        """Atomically sets the given value.
+
+        Args:
+            new_value: The new value.
+
+        Returns:
+            hazelcast.future.Future[None]:
+        """
+        new_value_data = self._to_data(new_value)
+        codec = atomic_ref_set_codec
+        request = codec.encode_request(self._group_id, self._object_name, new_value_data, False)
+        return self._invoke(request)
+
+    def get_and_set(self, new_value):
+        """Gets the old value and sets the new value.
+
+        Args:
+            new_value: The new value.
+
+        Returns:
+            hazelcast.future.Future[any]: The old value.
+        """
+        new_value_data = self._to_data(new_value)
+        codec = atomic_ref_set_codec
+        request = codec.encode_request(self._group_id, self._object_name, new_value_data, True)
+
+        def handler(response):
+            return self._to_object(codec.decode_response(response))
+
+        return self._invoke(request, handler)
+
+    def is_none(self):
+        """Checks if the stored reference is ``None``.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True` if the stored reference is ``None``,
+                ``False`` otherwise.
+        """
+        return self.contains(None)
+
+    def clear(self):
+        """Clears the current stored reference, so it becomes ``None``.
+
+        Returns:
+            hazelcast.future.Future[None]:
+        """
+        return self.set(None)
+
+    def contains(self, value):
+        """Checks if the reference contains the value.
+
+        Args:
+            value: The value to check (is allowed to be ``None``).
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if the value is found, ``false`` otherwise.
+        """
+        value_data = self._to_data(value)
+        codec = atomic_ref_contains_codec
+        request = codec.encode_request(self._group_id, self._object_name, value_data)
+        return self._invoke(request, codec.decode_response)
+
+    def alter(self, function):
+        """Alters the currently stored reference by applying a function on it.
+
+        Notes:
+            ``function`` must be an instance of ``IdentifiedDataSerializable`` or
+            ``Portable`` that has a counterpart that implements the
+            `com.hazelcast.core.IFunction` interface registered on the server-side with
+            the actual implementation of the function to be applied.
+
+        Args:
+            function (hazelcast.serialization.api.Portable or hazelcast.serialization.api.IdentifiedDataSerializable):
+                The function that alters the currently stored reference.
+
+        Returns:
+            hazelcast.future.Future[None]:
+        """
+        check_not_none(function, "Function cannot be None")
+        function_data = self._to_data(function)
+        codec = atomic_ref_apply_codec
+        # 0 means don't return the value
+        request = codec.encode_request(self._group_id, self._object_name, function_data, 0, True)
+        return self._invoke(request)
+
+    def alter_and_get(self, function):
+        """Alters the currently stored reference by applying a function on it and
+        gets the result.
+
+        Notes:
+            ``function`` must be an instance of ``IdentifiedDataSerializable`` or
+            ``Portable`` that has a counterpart that implements the
+            `com.hazelcast.core.IFunction` interface registered on the server-side with
+            the actual implementation of the function to be applied.
+
+        Args:
+            function (hazelcast.serialization.api.Portable or hazelcast.serialization.api.IdentifiedDataSerializable):
+                The function that alters the currently stored reference.
+
+        Returns:
+            hazelcast.future.Future[any]: The new value, the result of the applied function.
+        """
+        check_not_none(function, "Function cannot be None")
+        function_data = self._to_data(function)
+        codec = atomic_ref_apply_codec
+        # 2 means return the new value
+        request = codec.encode_request(self._group_id, self._object_name, function_data, 2, True)
+
+        def handler(response):
+            return self._to_object(codec.decode_response(response))
+
+        return self._invoke(request, handler)
+
+    def get_and_alter(self, function):
+        """Alters the currently stored reference by applying a function on it on
+        and gets the old value.
+
+        Notes:
+            ``function`` must be an instance of ``IdentifiedDataSerializable`` or
+            ``Portable`` that has a counterpart that implements the
+            `com.hazelcast.core.IFunction` interface registered on the server-side with
+            the actual implementation of the function to be applied.
+
+        Args:
+            function (hazelcast.serialization.api.Portable or hazelcast.serialization.api.IdentifiedDataSerializable):
+                The function that alters the currently stored reference.
+
+        Returns:
+            hazelcast.future.Future[any]: The old value, the value before the function is applied.
+        """
+        check_not_none(function, "Function cannot be None")
+        function_data = self._to_data(function)
+        codec = atomic_ref_apply_codec
+        # 1 means return the old value
+        request = codec.encode_request(self._group_id, self._object_name, function_data, 1, True)
+
+        def handler(response):
+            return self._to_object(codec.decode_response(response))
+
+        return self._invoke(request, handler)
+
+    def apply(self, function):
+        """Applies a function on the value, the actual stored value will not
+        change.
+
+        Notes:
+            ``function`` must be an instance of ``IdentifiedDataSerializable`` or
+            ``Portable`` that has a counterpart that implements the
+            `com.hazelcast.core.IFunction` interface registered on the server-side with
+            the actual implementation of the function to be applied.
+
+        Args:
+            function (hazelcast.serialization.api.Portable or hazelcast.serialization.api.IdentifiedDataSerializable):
+                The function applied on the currently stored reference.
+
+        Returns:
+            hazelcast.future.Future[any]: The result of the function application.
+        """
+        check_not_none(function, "Function cannot be None")
+        function_data = self._to_data(function)
+        codec = atomic_ref_apply_codec
+        # 2 means return the new value
+        request = codec.encode_request(self._group_id, self._object_name, function_data, 2, False)
+
+        def handler(response):
+            return self._to_object(codec.decode_response(response))
+
+        return self._invoke(request, handler)

--- a/hazelcast/proxy/map.py
+++ b/hazelcast/proxy/map.py
@@ -944,11 +944,12 @@ class Map(Proxy):
         """Tries to acquire the lock for the specified key. 
         
         When the lock is not available:
-            - If timeout is not provided, the current thread doesn't wait and returns ``false`` immediately.
-            - If a timeout is provided, the current thread becomes disabled for thread scheduling purposes and lies
-                dormant until one of the followings happens:
-                - the lock is acquired by the current thread, or
-                - the specified waiting time elapses.
+
+        - If timeout is not provided, the current thread doesn't wait and returns ``false`` immediately.
+        - If a timeout is provided, the current thread becomes disabled for thread scheduling purposes and lies
+          dormant until one of the followings happens:
+            - the lock is acquired by the current thread, or
+            - the specified waiting time elapses.
         
         If ttl is provided, lock will be released after this time elapses.
 

--- a/hazelcast/proxy/multi_map.py
+++ b/hazelcast/proxy/multi_map.py
@@ -369,11 +369,12 @@ class MultiMap(Proxy):
         """Tries to acquire the lock for the specified key. 
         
         When the lock is not available:
-            - If timeout is not provided, the current thread doesn't wait and returns ``false`` immediately.
-            - If a timeout is provided, the current thread becomes disabled for thread scheduling purposes and lies
-                dormant until one of the followings happens:
-                    - the lock is acquired by the current thread, or
-                    - the specified waiting time elapses.
+
+        - If timeout is not provided, the current thread doesn't wait and returns ``false`` immediately.
+        - If a timeout is provided, the current thread becomes disabled for thread scheduling purposes and lies
+          dormant until one of the followings happens:
+            - the lock is acquired by the current thread, or
+            - the specified waiting time elapses.
         
         If lease_time is provided, lock will be released after this time elapses.
 

--- a/hazelcast/proxy/queue.py
+++ b/hazelcast/proxy/queue.py
@@ -191,8 +191,9 @@ class Queue(PartitionSpecificProxy):
         without violating capacity restrictions. 
         
         If there is no space currently available:
-            - If a timeout is provided, it waits until this timeout elapses and returns the result.
-            - If a timeout is not provided, returns ``False`` immediately.
+
+        - If a timeout is provided, it waits until this timeout elapses and returns the result.
+        - If a timeout is not provided, returns ``False`` immediately.
 
         Args:
             item: The item to be added.
@@ -222,8 +223,9 @@ class Queue(PartitionSpecificProxy):
         """Retrieves and removes the head of this queue.
         
         If this queue is empty:
-            - If a timeout is provided, it waits until this timeout elapses and returns the result.
-            - If a timeout is not provided, returns ``None``.
+
+        - If a timeout is provided, it waits until this timeout elapses and returns the result.
+        - If a timeout is not provided, returns ``None``.
 
         Args:
             timeout (int): Maximum time in seconds to wait for addition.

--- a/hazelcast/serialization/data.py
+++ b/hazelcast/serialization/data.py
@@ -56,8 +56,9 @@ class Data(object):
         """Returns partition hash calculated for serialized object.
 
         Partition hash is used to determine partition of a Data and is calculated using:
-            - PartitioningStrategy during serialization.
-            - If partition hash is not set then hash_code() is used.
+
+        - PartitioningStrategy during serialization.
+        - If partition hash is not set then hash_code() is used.
         
         Returns:
             int: Partition hash.

--- a/hazelcast/util.py
+++ b/hazelcast/util.py
@@ -34,6 +34,11 @@ def check_not_empty(collection, message):
         raise AssertionError(message)
 
 
+def check_is_int(val):
+    if not isinstance(val, six.integer_types):
+        raise AssertionError("Int value expected")
+
+
 def current_time():
     return time.time()
 

--- a/tests/proxy/cp/atomic_long_test.py
+++ b/tests/proxy/cp/atomic_long_test.py
@@ -5,14 +5,14 @@ from tests.util import set_attr
 
 
 class Multiplication(IdentifiedDataSerializable):
-    def __init__(self, multiplier=None):
+    def __init__(self, multiplier):
         self.multiplier = multiplier
 
     def write_data(self, object_data_output):
         object_data_output.write_long(self.multiplier)
 
     def read_data(self, object_data_input):
-        self.multiplier = object_data_input.read_long()
+        pass
 
     def get_factory_id(self):
         return 66

--- a/tests/proxy/cp/atomic_long_test.py
+++ b/tests/proxy/cp/atomic_long_test.py
@@ -1,4 +1,9 @@
+import unittest
+
+from mock import MagicMock
+
 from hazelcast.errors import DistributedObjectDestroyedError
+from hazelcast.proxy.cp.atomic_long import AtomicLong
 from hazelcast.serialization.api import IdentifiedDataSerializable
 from tests.proxy.cp import CPTestCase
 from tests.util import set_attr
@@ -133,3 +138,43 @@ class AtomicLongTest(CPTestCase):
         self.atomic_long.set(42)
         self.assertEqual(84, self.atomic_long.apply(Multiplication(2)))
         self.assertEqual(42, self.atomic_long.get())
+
+
+class AtomicLongInvalidInputTest(unittest.TestCase):
+    def setUp(self):
+        self.atomic_long = AtomicLong(MagicMock(), None, None, None, None)
+
+    def test_add_and_get(self):
+        self._check_error("add_and_get", "1")
+
+    def test_compare_and_set(self):
+        invalid_inputs = [("a", 1), (1, "b"), ("c", "d")]
+        for e, u in invalid_inputs:
+            self._check_error("compare_and_set", e, u)
+
+    def test_get_and_add(self):
+        self._check_error("get_and_add", None)
+
+    def test_get_and_set(self):
+        self._check_error("get_and_set", 1.1)
+
+    def test_set(self):
+        self._check_error("set", "a")
+
+    def test_alter(self):
+        self._check_error("alter", None)
+
+    def test_alter_and_get(self):
+        self._check_error("alter_and_get", None)
+
+    def test_get_and_alter(self):
+        self._check_error("get_and_alter", None)
+
+    def test_apply(self):
+        self._check_error("apply", None)
+
+    def _check_error(self, method_name, *args):
+        fn = getattr(self.atomic_long, method_name)
+        self.assertTrue(callable(fn))
+        with self.assertRaises(AssertionError):
+            fn(*args)

--- a/tests/proxy/cp/atomic_reference_test.py
+++ b/tests/proxy/cp/atomic_reference_test.py
@@ -1,0 +1,142 @@
+from hazelcast.errors import DistributedObjectDestroyedError, ClassCastError
+from hazelcast.serialization.api import IdentifiedDataSerializable
+from tests.proxy.cp import CPTestCase
+from tests.util import set_attr
+
+
+class AppendString(IdentifiedDataSerializable):
+    def __init__(self, suffix):
+        self.suffix = suffix
+
+    def write_data(self, object_data_output):
+        object_data_output.write_utf(self.suffix)
+
+    def read_data(self, object_data_input):
+        pass
+
+    def get_factory_id(self):
+        return 66
+
+    def get_class_id(self):
+        return 17
+
+
+class AtomicReferenceTest(CPTestCase):
+    def setUp(self):
+        self.ref = self.client.cp_subsystem.get_atomic_reference("ref").blocking()
+
+    def tearDown(self):
+        self.ref.clear()
+
+    def test_ref_in_another_group(self):
+        another_ref = self.client.cp_subsystem.get_atomic_reference("ref@mygroup").blocking()
+        another_ref.set("hey")
+        self.assertEqual("hey", another_ref.get())
+        # the following value has to be None,
+        # as `ref` belongs to the default CP group
+        self.assertIsNone(self.ref.get())
+
+    def test_use_after_destroy(self):
+        another_ref = self.client.cp_subsystem.get_atomic_reference("another-ref").blocking()
+        another_ref.destroy()
+        # the next destroy call should be ignored
+        another_ref.destroy()
+
+        with self.assertRaises(DistributedObjectDestroyedError):
+            another_ref.get()
+
+        another_ref2 = self.client.cp_subsystem.get_atomic_reference("another-ref").blocking()
+        with self.assertRaises(DistributedObjectDestroyedError):
+            another_ref2.get()
+
+    def test_initial_value(self):
+        self.assertIsNone(self.ref.get())
+
+    def test_compare_and_set_when_condition_is_met(self):
+        self.assertTrue(self.ref.compare_and_set(None, 42))
+        self.assertEqual(42, self.ref.get())
+        self.assertTrue(self.ref.compare_and_set(42, "hey"))
+        self.assertEqual("hey", self.ref.get())
+
+    def test_compare_and_set_when_condition_is_not_met(self):
+        self.assertFalse(self.ref.compare_and_set(42, 23))
+        self.assertIsNone(self.ref.get())
+        self.ref.set("a")
+        self.assertFalse(self.ref.compare_and_set("b", "c"))
+        self.assertEqual("a", self.ref.get())
+
+    def test_get(self):
+        self.ref.set([1, 2, 3])
+        self.assertEqual([1, 2, 3], self.ref.get())
+
+    def test_set(self):
+        self.assertIsNone(self.ref.set("abc"))
+        self.assertEqual("abc", self.ref.get())
+        self.assertIsNone(self.ref.set(["another_type", 1]))
+        self.assertEqual(["another_type", 1], self.ref.get())
+
+    def test_get_and_set(self):
+        self.assertIsNone(self.ref.get_and_set("42"))
+        self.assertEqual("42", self.ref.get())
+        self.assertEqual("42", self.ref.get_and_set(42))
+        self.assertEqual(42, self.ref.get())
+
+    def test_is_none(self):
+        self.assertTrue(self.ref.is_none())
+        self.ref.set(11)
+        self.assertFalse(self.ref.is_none())
+        self.ref.set(None)
+        self.assertTrue(self.ref.is_none())
+
+    def test_clear(self):
+        self.assertIsNone(self.ref.clear())
+        self.assertIsNone(self.ref.get())
+        self.ref.set("str")
+        self.assertEqual("str", self.ref.get())
+        self.assertIsNone(self.ref.clear())
+        self.assertIsNone(self.ref.get())
+
+    def test_contains(self):
+        self.assertTrue(self.ref.contains(None))
+        self.ref.set("42")
+        self.assertTrue(self.ref.contains("42"))
+        self.assertFalse(self.ref.contains(42))
+        self.assertFalse(self.ref.contains(None))
+        self.ref.clear()
+        self.assertFalse(self.ref.contains("42"))
+        self.assertTrue(self.ref.contains(None))
+
+    @set_attr(category=4.01)
+    def test_alter(self):
+        # the class is defined in the 4.1 JAR
+        self.ref.set("hey")
+        self.assertIsNone(self.ref.alter(AppendString("123")))
+        self.assertEqual("hey123", self.ref.get())
+
+    @set_attr(category=4.01)
+    def test_alter_with_incompatible_types(self):
+        # the class is defined in the 4.1 JAR
+        self.ref.set(42)
+        with self.assertRaises(ClassCastError):
+            self.ref.alter(AppendString("."))
+
+    @set_attr(category=4.01)
+    def test_alter_and_get(self):
+        # the class is defined in the 4.1 JAR
+        self.ref.set("123")
+        self.assertEqual("123...", self.ref.alter_and_get(AppendString("...")))
+        self.assertEqual("123...", self.ref.get())
+
+    @set_attr(category=4.01)
+    def test_get_and_alter(self):
+        # the class is defined in the 4.1 JAR
+        self.ref.set("hell")
+        self.assertEqual("hell", self.ref.get_and_alter(AppendString("o")))
+        self.assertEqual("hello", self.ref.get())
+
+    @set_attr(category=4.01)
+    def test_apply(self):
+        # the class is defined in the 4.1 JAR
+        self.ref.set("hell")
+        self.assertEqual("hello", self.ref.apply(AppendString("o")))
+        self.assertEqual("hell", self.ref.get())

--- a/tests/proxy/cp/atomic_reference_test.py
+++ b/tests/proxy/cp/atomic_reference_test.py
@@ -1,4 +1,9 @@
+import unittest
+
+from mock import MagicMock
+
 from hazelcast.errors import DistributedObjectDestroyedError, ClassCastError
+from hazelcast.proxy.cp.atomic_reference import AtomicReference
 from hazelcast.serialization.api import IdentifiedDataSerializable
 from tests.proxy.cp import CPTestCase
 from tests.util import set_attr
@@ -140,3 +145,26 @@ class AtomicReferenceTest(CPTestCase):
         self.ref.set("hell")
         self.assertEqual("hello", self.ref.apply(AppendString("o")))
         self.assertEqual("hell", self.ref.get())
+
+
+class AtomicReferenceInvalidInputTest(unittest.TestCase):
+    def setUp(self):
+        self.atomic_ref = AtomicReference(MagicMock(), None, None, None, None)
+
+    def test_alter(self):
+        self._check_error("alter", None)
+
+    def test_alter_and_get(self):
+        self._check_error("alter_and_get", None)
+
+    def test_get_and_alter(self):
+        self._check_error("get_and_alter", None)
+
+    def test_apply(self):
+        self._check_error("apply", None)
+
+    def _check_error(self, method_name, *args):
+        fn = getattr(self.atomic_ref, method_name)
+        self.assertTrue(callable(fn))
+        with self.assertRaises(AssertionError):
+            fn(*args)


### PR DESCRIPTION
For the AtomicReference, implementation, code samples, documentation and
tests are added. It also includes some minor docstring fixes regarding
the lists in some places and some missing checks and documentation fixes
for the AtomicLong.

depends on #223 