### PR TITLE
CP Subsystem - CountDownLatch

### DIFF
--- a/docs/hazelcast.proxy.cp.atomic_reference.rst
+++ b/docs/hazelcast.proxy.cp.atomic_reference.rst
@@ -1,0 +1,4 @@
+AtomicReference
+===============
+
+.. automodule:: hazelcast.proxy.cp.atomic_reference

--- a/docs/hazelcast.proxy.cp.count_down_latch.rst
+++ b/docs/hazelcast.proxy.cp.count_down_latch.rst
@@ -1,0 +1,4 @@
+CountDownLatch
+==============
+
+.. automodule:: hazelcast.proxy.cp.count_down_latch

--- a/docs/hazelcast.proxy.cp.rst
+++ b/docs/hazelcast.proxy.cp.rst
@@ -3,3 +3,5 @@ CP Proxies
 
 .. toctree::
     hazelcast.proxy.cp.atomic_long
+    hazelcast.proxy.cp.atomic_reference
+    hazelcast.proxy.cp.count_down_latch

--- a/examples/cp/count_down_latch_example.py
+++ b/examples/cp/count_down_latch_example.py
@@ -1,0 +1,18 @@
+import hazelcast
+
+client = hazelcast.HazelcastClient()
+
+latch = client.cp_subsystem.get_count_down_latch("my-latch")
+initialized = latch.try_set_count(3).result()
+print("Initialized:", initialized)
+count = latch.get_count().result()
+print("Count:", count)
+
+latch.await_latch(10).add_done_callback(lambda f: print("Result of await:", f.result()))
+
+for _ in range(3):
+    latch.count_down().result()
+    count = latch.get_count().result()
+    print("Current count:", count)
+
+client.shutdown()

--- a/hazelcast/cp.py
+++ b/hazelcast/cp.py
@@ -2,6 +2,7 @@ from hazelcast.invocation import Invocation
 from hazelcast.protocol.codec import cp_group_create_cp_group_codec
 from hazelcast.proxy.cp.atomic_long import AtomicLong
 from hazelcast.proxy.cp.atomic_reference import AtomicReference
+from hazelcast.proxy.cp.count_down_latch import CountDownLatch
 from hazelcast.util import check_true
 
 
@@ -74,6 +75,26 @@ class CPSubsystem(object):
         """
         return self._proxy_manager.get_or_create(ATOMIC_REFERENCE_SERVICE, name)
 
+    def get_count_down_latch(self, name):
+        """Returns the distributed CountDownLatch instance with given name.
+
+        The instance is created on CP Subsystem.
+
+        If no group name is given within the ``name`` argument, then the
+        CountDownLatch instance will be created on the DEFAULT CP group.
+        If a group name is given, like ``.get_count_down_latch("myLatch@group1")``,
+        the given group will be initialized first, if not initialized
+        already, and then the instance will be created on this group.
+
+        Args:
+            name (str): Name of the CountDownLatch.
+
+        Returns:
+            hazelcast.proxy.cp.count_down_latch.CountDownLatch: The CountDownLatch
+                proxy for the given name.
+        """
+        return self._proxy_manager.get_or_create(COUNT_DOWN_LATCH_SERVICE, name)
+
 
 _DEFAULT_GROUP_NAME = "default"
 
@@ -105,6 +126,7 @@ def _get_object_name_for_proxy(name):
 
 ATOMIC_LONG_SERVICE = "hz:raft:atomicLongService"
 ATOMIC_REFERENCE_SERVICE = "hz:raft:atomicRefService"
+COUNT_DOWN_LATCH_SERVICE = "hz:raft:countDownLatchService"
 
 
 class CPProxyManager(object):
@@ -120,6 +142,8 @@ class CPProxyManager(object):
             return AtomicLong(self._context, group_id, service_name, proxy_name, object_name)
         elif service_name == ATOMIC_REFERENCE_SERVICE:
             return AtomicReference(self._context, group_id, service_name, proxy_name, object_name)
+        elif service_name == COUNT_DOWN_LATCH_SERVICE:
+            return CountDownLatch(self._context, group_id, service_name, proxy_name, object_name)
 
     def _get_group_id(self, proxy_name):
         codec = cp_group_create_cp_group_codec

--- a/hazelcast/invocation.py
+++ b/hazelcast/invocation.py
@@ -3,8 +3,8 @@ import time
 import functools
 
 from hazelcast.errors import create_error_from_message, HazelcastInstanceNotActiveError, is_retryable_error, \
-    HazelcastTimeoutError, TargetDisconnectedError, HazelcastClientNotActiveError, TargetNotMemberError, \
-    EXCEPTION_MESSAGE_TYPE, IndeterminateOperationStateError
+    TargetDisconnectedError, HazelcastClientNotActiveError, TargetNotMemberError, \
+    EXCEPTION_MESSAGE_TYPE, IndeterminateOperationStateError, OperationTimeoutError
 from hazelcast.future import Future
 from hazelcast.protocol.codec import client_local_backup_listener_codec
 from hazelcast.util import AtomicInteger
@@ -231,7 +231,7 @@ class InvocationService(object):
         if invocation.timeout < time.time():
             self.logger.debug("Error will not be retried because invocation timed out: %s", error,
                               extra=self._logger_extras)
-            error = HazelcastTimeoutError("Request timed out because an error occurred "
+            error = OperationTimeoutError("Request timed out because an error occurred "
                                           "after invocation timeout: %s" % error)
             self._complete_with_error(invocation, error)
             return

--- a/hazelcast/proxy/cp/count_down_latch.py
+++ b/hazelcast/proxy/cp/count_down_latch.py
@@ -1,0 +1,138 @@
+import uuid
+
+from hazelcast.errors import OperationTimeoutError
+from hazelcast.protocol.codec import count_down_latch_await_codec, count_down_latch_get_round_codec, \
+    count_down_latch_count_down_codec, count_down_latch_get_count_codec, count_down_latch_try_set_count_codec
+from hazelcast.proxy.cp import BaseCPProxy
+from hazelcast.util import to_millis, check_true
+
+
+class CountDownLatch(BaseCPProxy):
+    """A distributed, concurrent countdown latch data structure.
+
+    CountDownLatch is a cluster-wide synchronization aid
+    that allows one or more callers to wait until a set of operations being
+    performed in other callers completes.
+
+    CountDownLatch count can be reset using ``try_set_count()`` method after
+    a countdown has finished but not during an active count. This allows
+    the same latch instance to be reused.
+
+    There is no ``await_latch()`` method to do an unbound wait since this is undesirable
+    in a distributed application: for example, a cluster can split or the master
+    and replicas could all die. In most cases, it is best to configure
+    an explicit timeout so you have the ability to deal with these situations.
+
+    All of the API methods in the CountDownLatch offer the exactly-once
+    execution semantics. For instance, even if a ``count_down()`` call is
+    internally retried because of crashed Hazelcast member, the counter
+    value is decremented only once.
+    """
+
+    def await_latch(self, timeout):
+        """Causes the current thread to wait until the latch has counted down to
+        zero, or an exception is thrown, or the specified waiting time elapses.
+
+        If the current count is zero then this method returns ``True``.
+
+        If the current count is greater than zero, then the current
+        thread becomes disabled for thread scheduling purposes and lies
+        dormant until one of the following things happen:
+
+        - The count reaches zero due to invocations of the ``count_down()`` method
+        - This CountDownLatch instance is destroyed
+        - The countdown owner becomes disconnected
+        - The specified waiting time elapses
+
+        If the count reaches zero, then the method returns with the
+        value ``True``.
+
+        If the specified waiting time elapses then the value ``False``
+        is returned.  If the time is less than or equal to zero, the method
+        will not wait at all.
+
+        Args:
+            timeout (int): The maximum time to wait in seconds
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if the count reached zero,
+                ``False`` if the waiting time elapsed before the count reached zero
+        Raises:
+            IllegalStateError: If the Hazelcast instance was shut down while waiting.
+        """
+        timeout = max(0, timeout)
+        invocation_uuid = uuid.uuid4()
+        codec = count_down_latch_await_codec
+        request = codec.encode_request(self._group_id, self._object_name, invocation_uuid, to_millis(timeout))
+        return self._invoke(request, codec.decode_response)
+
+    def count_down(self):
+        """Decrements the count of the latch, releasing all waiting threads if
+        the count reaches zero.
+
+        If the current count is greater than zero, then it is decremented.
+        If the new count is zero:
+
+        - All waiting threads are re-enabled for thread scheduling purposes
+        - Countdown owner is set to ``None``.
+
+        If the current count equals zero, then nothing happens.
+
+        Returns:
+            hazelcast.future.Future[None]:
+        """
+        invocation_uuid = uuid.uuid4()
+
+        def handler(f):
+            return self._do_count_down(f.result(), invocation_uuid)
+
+        return self._get_round().continue_with(handler)
+
+    def get_count(self):
+        """Returns the current count.
+
+        Returns:
+            hazelcast.future.Future[int]: The current count.
+        """
+        codec = count_down_latch_get_count_codec
+        request = codec.encode_request(self._group_id, self._object_name)
+        return self._invoke(request, codec.decode_response)
+
+    def try_set_count(self, count):
+        """Sets the count to the given value if the current count is zero.
+
+        If count is not zero, then this method does nothing and returns
+        ``False``.
+
+        Args:
+            count (int): The number of times ``count_down()`` must be invoked
+                before callers can pass through ``await_latch()``.
+
+        Returns:
+            hazelcast.future.Future[bool]: ``True`` if the new count was set,
+                ``False`` if the current count is not zero.
+        """
+        check_true(count > 0, "Count must be positive")
+        codec = count_down_latch_try_set_count_codec
+        request = codec.encode_request(self._group_id, self._object_name, count)
+        return self._invoke(request, codec.decode_response)
+
+    def _do_count_down(self, expected_round, invocation_uuid):
+        def handler(f):
+            try:
+                f.result()
+            except OperationTimeoutError:
+                # we can retry safely because the retry is idempotent
+                return self._do_count_down(expected_round, invocation_uuid)
+
+        return self._request_count_down(expected_round, invocation_uuid).continue_with(handler)
+
+    def _get_round(self):
+        codec = count_down_latch_get_round_codec
+        request = codec.encode_request(self._group_id, self._object_name)
+        return self._invoke(request, codec.decode_response)
+
+    def _request_count_down(self, expected_round, invocation_uuid):
+        codec = count_down_latch_count_down_codec
+        request = codec.encode_request(self._group_id, self._object_name, invocation_uuid, expected_round)
+        return self._invoke(request)

--- a/hazelcast/proxy/cp/count_down_latch.py
+++ b/hazelcast/proxy/cp/count_down_latch.py
@@ -4,7 +4,7 @@ from hazelcast.errors import OperationTimeoutError
 from hazelcast.protocol.codec import count_down_latch_await_codec, count_down_latch_get_round_codec, \
     count_down_latch_count_down_codec, count_down_latch_get_count_codec, count_down_latch_try_set_count_codec
 from hazelcast.proxy.cp import BaseCPProxy
-from hazelcast.util import to_millis, check_true
+from hazelcast.util import to_millis, check_true, check_is_number, check_is_int
 
 
 class CountDownLatch(BaseCPProxy):
@@ -60,6 +60,7 @@ class CountDownLatch(BaseCPProxy):
         Raises:
             IllegalStateError: If the Hazelcast instance was shut down while waiting.
         """
+        check_is_number(timeout)
         timeout = max(0, timeout)
         invocation_uuid = uuid.uuid4()
         codec = count_down_latch_await_codec
@@ -112,6 +113,7 @@ class CountDownLatch(BaseCPProxy):
             hazelcast.future.Future[bool]: ``True`` if the new count was set,
                 ``False`` if the current count is not zero.
         """
+        check_is_int(count)
         check_true(count > 0, "Count must be positive")
         codec = count_down_latch_try_set_count_codec
         request = codec.encode_request(self._group_id, self._object_name, count)

--- a/hazelcast/util.py
+++ b/hazelcast/util.py
@@ -80,13 +80,21 @@ class AtomicInteger(object):
         """Returns the current value and increment it.
         
         Returns:
-            int: current value of AtomicInteger.
+            int: Current value of AtomicInteger.
         """
         with self._mux:
             res = self._counter
             self._counter += 1
             return res
 
+    def get(self):
+        """Returns the current value.
+
+        Returns:
+            int: The current value.
+        """
+        with self._mux:
+            return self._counter
 
 class ImmutableLazyDataList(Sequence):
     def __init__(self, list_data, to_object):

--- a/hazelcast/util.py
+++ b/hazelcast/util.py
@@ -34,6 +34,11 @@ def check_not_empty(collection, message):
         raise AssertionError(message)
 
 
+def check_is_number(val):
+    if not isinstance(val, number_types):
+        raise AssertionError("Number value expected")
+
+
 def check_is_int(val):
     if not isinstance(val, six.integer_types):
         raise AssertionError("Int value expected")

--- a/tests/invocation_test.py
+++ b/tests/invocation_test.py
@@ -5,7 +5,7 @@ from mock import MagicMock
 
 import hazelcast
 from hazelcast.config import _Config
-from hazelcast.errors import HazelcastTimeoutError, IndeterminateOperationStateError
+from hazelcast.errors import IndeterminateOperationStateError, OperationTimeoutError
 from hazelcast.invocation import Invocation, InvocationService
 from hazelcast.protocol.client_message import OutboundMessage
 from hazelcast.serialization import LE_INT
@@ -176,7 +176,7 @@ class InvocationTimeoutTest(HazelcastTestCase):
         invocation_service._invoke_on_random_connection = MagicMock(return_value=False)
 
         invocation_service.invoke(invocation)
-        with self.assertRaises(HazelcastTimeoutError):
+        with self.assertRaises(OperationTimeoutError):
             invocation.future.result()
 
     def test_invocation_not_timed_out_when_there_is_no_exception(self):

--- a/tests/proxy/cp/count_down_latch_test.py
+++ b/tests/proxy/cp/count_down_latch_test.py
@@ -1,0 +1,153 @@
+import time
+from threading import Thread
+
+from hazelcast.errors import DistributedObjectDestroyedError, OperationTimeoutError
+from hazelcast.future import ImmediateExceptionFuture
+from hazelcast.util import AtomicInteger
+from tests.proxy.cp import CPTestCase
+from tests.util import random_string
+
+inf = 2 ** 31 - 1
+
+
+class CountDownLatchTest(CPTestCase):
+    def test_latch_in_another_group(self):
+        latch = self._get_latch()
+        another_latch = self._get_latch()
+
+        another_latch.try_set_count(42)
+        self.assertEqual(42, another_latch.get_count())
+        self.assertNotEqual(42, latch.get_count())
+
+    def test_use_after_destroy(self):
+        latch = self._get_latch()
+        latch.destroy()
+        # the next destroy call should be ignored
+        latch.destroy()
+
+        with self.assertRaises(DistributedObjectDestroyedError):
+            latch.get_count()
+
+        latch2 = self.client.cp_subsystem.get_count_down_latch(latch._proxy_name).blocking()
+
+        with self.assertRaises(DistributedObjectDestroyedError):
+            latch2.get_count()
+
+    def test_await_latch_negative_timeout(self):
+        latch = self._get_latch(1)
+        self.assertFalse(latch.await_latch(-1))
+
+    def test_await_latch_zero_timeout(self):
+        latch = self._get_latch(1)
+        self.assertFalse(latch.await_latch(0))
+
+    def test_await_latch_with_timeout(self):
+        latch = self._get_latch(1)
+        start = time.time()
+        self.assertFalse(latch.await_latch(0.1))
+        time_passed = time.time() - start
+        self.assertTrue(time_passed > 0.1)
+
+    def test_await_latch_multiple_waiters(self):
+        latch = self._get_latch(1)
+
+        completed = AtomicInteger()
+
+        def run():
+            latch.await_latch(inf)
+            completed.get_and_increment()
+
+        count = 10
+        threads = []
+        for _ in range(count):
+            t = Thread(target=run)
+            threads.append(t)
+            t.start()
+
+        latch.count_down()
+
+        def assertion():
+            self.assertEqual(count, completed.get())
+
+        self.assertTrueEventually(assertion)
+
+        for i in range(count):
+            threads[i].join()
+
+    def test_await_latch_response_on_count_down(self):
+        latch = self._get_latch()
+        self.assertTrue(latch.await_latch(inf))
+        self.assertTrue(latch.try_set_count(1))
+
+        # make a non-blocking request
+        future = latch._wrapped.await_latch(inf)
+        t = Thread(target=lambda: latch.count_down())
+        t.start()
+        t.join()
+
+        def assertion():
+            self.assertTrue(future.done())
+            self.assertTrue(future.result())
+
+        self.assertTrueEventually(assertion)
+
+    def test_count_down(self):
+        latch = self._get_latch(10)
+
+        for i in range(9, -1, -1):
+            self.assertIsNone(latch.count_down())
+            self.assertEqual(i, latch.get_count())
+
+    def test_count_down_retry_on_timeout(self):
+        latch = self._get_latch(1)
+
+        original = latch._wrapped._request_count_down
+        called_count = AtomicInteger()
+
+        def mock(expected_round, invocation_uuid):
+            if called_count.get_and_increment() < 2:
+                return ImmediateExceptionFuture(OperationTimeoutError("xx"))
+            return original(expected_round, invocation_uuid)
+
+        latch._wrapped._request_count_down = mock
+
+        latch.count_down()
+        self.assertEqual(3, called_count.get())  # Will resolve on it's third call. First 2 throws timeout error
+        self.assertEqual(0, latch.get_count())
+
+    def test_get_count(self):
+        latch = self._get_latch(1)
+        self.assertEqual(1, latch.get_count())
+        latch.count_down()
+        self.assertEqual(0, latch.get_count())
+        latch.try_set_count(10)
+        self.assertEqual(10, latch.get_count())
+
+    def test_try_set_count_with_negative_count(self):
+        latch = self._get_latch()
+
+        with self.assertRaises(AssertionError):
+            latch.try_set_count(-1)
+
+    def test_try_set_count_with_zero(self):
+        latch = self._get_latch()
+
+        with self.assertRaises(AssertionError):
+            latch.try_set_count(0)
+
+    def test_try_set_count(self):
+        latch = self._get_latch()
+        self.assertTrue(latch.try_set_count(3))
+        self.assertEqual(3, latch.get_count())
+
+    def test_try_set_count_when_count_is_already_set(self):
+        latch = self._get_latch(1)
+        self.assertFalse(latch.try_set_count(10))
+        self.assertFalse(latch.try_set_count(20))
+        self.assertEqual(1, latch.get_count())
+
+    def _get_latch(self, initial_count=None):
+        latch = self.client.cp_subsystem.get_count_down_latch("latch@" + random_string()).blocking()
+        if initial_count is not None:
+            self.assertTrue(latch.try_set_count(initial_count))
+        return latch

--- a/tests/proxy/cp/count_down_latch_test.py
+++ b/tests/proxy/cp/count_down_latch_test.py
@@ -138,6 +138,13 @@ class CountDownLatchTest(CPTestCase):
         self.assertFalse(latch.try_set_count(20))
         self.assertEqual(1, latch.get_count())
 
+    def test_try_set_count_when_count_goes_to_zero(self):
+        latch = self._get_latch(1)
+        latch.count_down()
+        self.assertEqual(0, latch.get_count())
+        self.assertTrue(latch.try_set_count(3))
+        self.assertEqual(3, latch.get_count())
+
     def _get_latch(self, initial_count=None):
         latch = self.client.cp_subsystem.get_count_down_latch("latch-" + random_string()).blocking()
         if initial_count is not None:

--- a/tests/proxy/cp/count_down_latch_test.py
+++ b/tests/proxy/cp/count_down_latch_test.py
@@ -17,7 +17,7 @@ inf = 2 ** 31 - 1
 class CountDownLatchTest(CPTestCase):
     def test_latch_in_another_group(self):
         latch = self._get_latch()
-        another_latch = self._get_latch()
+        another_latch = self.client.cp_subsystem.get_count_down_latch(latch._proxy_name + "@another").blocking()
 
         another_latch.try_set_count(42)
         self.assertEqual(42, another_latch.get_count())
@@ -139,7 +139,7 @@ class CountDownLatchTest(CPTestCase):
         self.assertEqual(1, latch.get_count())
 
     def _get_latch(self, initial_count=None):
-        latch = self.client.cp_subsystem.get_count_down_latch("latch@" + random_string()).blocking()
+        latch = self.client.cp_subsystem.get_count_down_latch("latch-" + random_string()).blocking()
         if initial_count is not None:
             self.assertTrue(latch.try_set_count(initial_count))
         return latch


### PR DESCRIPTION
Adds the implementation, documentation, code samples, and test of
CP CountDownLatch.

Also, the invocation service is edited to return `OperationTimeoutError`
instead of `HazelcastTimeoutError` in case of invocation timeouts
as the Java client does.

depends on #224 