### PR TITLE
Test member list after hot restart

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -42,6 +42,10 @@ class HazelcastTestCase(unittest.TestCase):
     def create_cluster(cls, rc, config=None):
         return _Cluster(rc, rc.createCluster(None, config))
 
+    @classmethod
+    def create_cluster_keep_cluster_name(cls, rc, config=None):
+        return _Cluster(rc, rc.createClusterKeepClusterName(None, config))
+
     def create_client(self, config=None):
         client = hazelcast.HazelcastClient(**config)
         self.clients.append(client)


### PR DESCRIPTION
Added a test that verifies when all members of the Hot Restart enabled
cluster is restarted, client's member list is not broken.

The implementation is fixed within the initial 4.0 PR, so adding
just the test to verify that the implementation is correct.

closes #164