### PR TITLE
Implement PagingPredicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -2442,9 +2442,9 @@ In the example code below:
 This predicate has a filter to retrieve the objects with an `age` greater than or equal to `18`.
 
 - Then a `PagingPredicate` is constructed in which the page size is `5`, so that there are five objects in each page. 
-The first time the values are called creates the first page.
+The first time the ``values()`` method is called, the first page is fetched.
 
-- It gets subsequent pages with the `next_page()` method of `PagingPredicate` and querying the map again with the updated `PagingPredicate`.
+- Finally, the subsequent page is fetched by calling `next_page()` method of `PagingPredicate` and querying the map again with the updated `PagingPredicate`.
 
 ```python
 from hazelcast.serialization.predicate import paging, is_greater_than_or_equal_to
@@ -2467,7 +2467,7 @@ values = m.values(predicate)
 ```
 
 If a comparator is not specified for `PagingPredicate`, but you want to get a collection of keys or values page by page, 
-this collection must be an instance of `Comparable` (i.e., it must implement `java.lang.Comparable` on the member side). 
+keys or values of the collection must implement the `java.lang.Comparable` interface on the member side. 
 Otherwise, paging fails with an exception from the server. Luckily, a lot of types implement the `Comparable`
 interface by [default](https://docs.oracle.com/javase/8/docs/api/java/lang/Comparable.html), including the primitive types,
 so, you may use values of types `int`, `float`, `str` etc. in paging without specifying a comparator on the Python client.
@@ -2475,7 +2475,7 @@ so, you may use values of types `int`, `float`, `str` etc. in paging without spe
 You can also access a specific page more easily by setting the `predicate.page` attribute before making the remote call.
 This way, if you make a query for the hundredth page, for example, it gets all `100` pages at once instead of reaching the hundredth page one by one using the `next_page()` method. 
 
-`PagingPredicate`, also known as Order & Limit, is not supported in Transactional Context.
+> **NOTE: `PagingPredicate`, also known as Order & Limit, is not supported in Transactional Context.**
 
 ## 7.8. Performance
 

--- a/examples/map/map_paging_predicate_example.py
+++ b/examples/map/map_paging_predicate_example.py
@@ -1,0 +1,105 @@
+import hazelcast
+from hazelcast.serialization.api import IdentifiedDataSerializable
+from hazelcast.serialization.predicate import paging, true
+
+client = hazelcast.HazelcastClient()
+
+m1 = client.get_map("m1").blocking()
+
+m1.put_all({
+    "a": 1,
+    "b": 2,
+    "c": 3,
+    "d": 4,
+    "e": 5,
+    "f": 6,
+    "g": 7,
+})
+
+size = m1.size()
+print("Added %s elements" % size)
+
+# When using paging predicate without a comparator,
+# server sorts the entries according to their default
+# orderings. In this particular case, values will be
+# sorted in ascending order.
+predicate = paging(true(), 2)  # Get all values with page size of 2
+
+# Prints pages of size 2 in the [1, 2], [3, 4], [5, 6], [7] order
+for i in range(4):
+    values = m1.values(predicate)
+    print("Page %s:%s" % (i, values))
+    predicate.next_page()  # Call next_page on predicate to get the next page on the next iteration
+
+
+# If you want to sort results differently, you have to use
+# a comparator. Comparator will be serialized and sent
+# to server. Server will do the sorting accordingly. Hence,
+# the implementation of the comparator must be defined on the
+# server side and registered as a Portable or IdentifiedDataSerializable
+# before the server starts.
+
+class ReversedKeyComparator(IdentifiedDataSerializable):
+    """
+    This class is simply a marker implementation
+    to tell server which comparator to use.
+    Its implementation must be defined on the
+    server side. A sample server side implementation
+    is provided at the end of file.
+    """
+    def get_class_id(self):
+        return 1
+
+    def get_factory_id(self):
+        return 1
+
+    def write_data(self, object_data_output):
+        pass
+
+    def read_data(self, object_data_input):
+        pass
+
+
+predicate = paging(true(), 2, ReversedKeyComparator())
+
+# Prints pages of size 2 in the [7, 6], [5, 4], [3, 2], [1] order
+for i in range(4):
+    values = m1.values(predicate)
+    print("Page %s:%s" % (i, values))
+    predicate.next_page()  # Call next_page on predicate to get the next page on the next iteration
+
+client.shutdown()
+
+# A sample implementation of the comparator that
+# sorts the values according the reverse of
+# the alphabetical order of keys.
+
+# class ReversedKeyComparator implements Comparator<Map.Entry<String, Integer>>, IdentifiedDataSerializable {
+#
+#     @Override
+#     public int compare(Map.Entry<String, Integer> entry1, Map.Entry<String, Integer> entry2) {
+#         // Reverse the order. The main comparator logic
+#         // goes to here.
+#         return entry2.getValue().compareTo(entry1.getValue());
+#     }
+#
+#     @Override
+#     public int getFactoryId() {
+#         return 1;
+#     }
+#
+#     @Override
+#     public int getClassId() {
+#         return 1;
+#     }
+#
+#     @Override
+#     public void writeData(ObjectDataOutput out) {
+#
+#     }
+#
+#     @Override
+#     public void readData(ObjectDataInput in) {
+#
+#     }
+# }

--- a/hazelcast/core.py
+++ b/hazelcast/core.py
@@ -2,6 +2,7 @@
 import json
 
 from hazelcast import six
+from hazelcast.six.moves import range
 from hazelcast import util
 
 CLIENT_TYPE = "PYH"

--- a/hazelcast/hash.py
+++ b/hazelcast/hash.py
@@ -1,6 +1,7 @@
 import math
 from hazelcast.six.moves import range
 
+
 def _fmix(h):
     h ^= h >> 16
     h = (h * 0x85ebca6b) & 0xFFFFFFFF

--- a/hazelcast/protocol/builtin.py
+++ b/hazelcast/protocol/builtin.py
@@ -1,6 +1,7 @@
 import uuid
 
 from hazelcast import six
+from hazelcast.six.moves import range
 from hazelcast.protocol.client_message import NULL_FRAME_BUF, BEGIN_FRAME_BUF, END_FRAME_BUF, \
     SIZE_OF_FRAME_LENGTH_AND_FLAGS, _IS_FINAL_FLAG, NULL_FINAL_FRAME_BUF, END_FINAL_FRAME_BUF
 from hazelcast.serialization import LONG_SIZE_IN_BYTES, UUID_SIZE_IN_BYTES, LE_INT, LE_LONG, BOOLEAN_SIZE_IN_BYTES, \

--- a/hazelcast/protocol/codec/custom/anchor_data_list_holder_codec.py
+++ b/hazelcast/protocol/codec/custom/anchor_data_list_holder_codec.py
@@ -1,0 +1,26 @@
+from hazelcast.protocol.builtin import CodecUtil
+from hazelcast.protocol.client_message import END_FRAME_BUF, END_FINAL_FRAME_BUF, BEGIN_FRAME_BUF
+from hazelcast.protocol.builtin import ListIntegerCodec
+from hazelcast.protocol import AnchorDataListHolder
+from hazelcast.protocol.builtin import EntryListCodec
+from hazelcast.protocol.builtin import DataCodec
+
+
+class AnchorDataListHolderCodec(object):
+    @staticmethod
+    def encode(buf, anchor_data_list_holder, is_final=False):
+        buf.extend(BEGIN_FRAME_BUF)
+        ListIntegerCodec.encode(buf, anchor_data_list_holder.anchor_page_list)
+        EntryListCodec.encode(buf, anchor_data_list_holder.anchor_data_list, DataCodec.encode, DataCodec.encode)
+        if is_final:
+            buf.extend(END_FINAL_FRAME_BUF)
+        else:
+            buf.extend(END_FRAME_BUF)
+
+    @staticmethod
+    def decode(msg):
+        msg.next_frame()
+        anchor_page_list = ListIntegerCodec.decode(msg)
+        anchor_data_list = EntryListCodec.decode(msg, DataCodec.decode, DataCodec.decode)
+        CodecUtil.fast_forward_to_end_frame(msg)
+        return AnchorDataListHolder(anchor_page_list, anchor_data_list)

--- a/hazelcast/protocol/codec/custom/paging_predicate_holder_codec.py
+++ b/hazelcast/protocol/codec/custom/paging_predicate_holder_codec.py
@@ -1,0 +1,46 @@
+from hazelcast.protocol.builtin import FixSizedTypesCodec, CodecUtil
+from hazelcast.serialization.bits import *
+from hazelcast.protocol.client_message import END_FRAME_BUF, END_FINAL_FRAME_BUF, SIZE_OF_FRAME_LENGTH_AND_FLAGS, create_initial_buffer_custom
+from hazelcast.protocol import PagingPredicateHolder
+from hazelcast.protocol.codec.custom.anchor_data_list_holder_codec import AnchorDataListHolderCodec
+from hazelcast.protocol.builtin import DataCodec
+
+_PAGE_SIZE_ENCODE_OFFSET = 2 * SIZE_OF_FRAME_LENGTH_AND_FLAGS
+_PAGE_SIZE_DECODE_OFFSET = 0
+_PAGE_ENCODE_OFFSET = _PAGE_SIZE_ENCODE_OFFSET + INT_SIZE_IN_BYTES
+_PAGE_DECODE_OFFSET = _PAGE_SIZE_DECODE_OFFSET + INT_SIZE_IN_BYTES
+_ITERATION_TYPE_ID_ENCODE_OFFSET = _PAGE_ENCODE_OFFSET + INT_SIZE_IN_BYTES
+_ITERATION_TYPE_ID_DECODE_OFFSET = _PAGE_DECODE_OFFSET + INT_SIZE_IN_BYTES
+_INITIAL_FRAME_SIZE = _ITERATION_TYPE_ID_ENCODE_OFFSET + BYTE_SIZE_IN_BYTES - 2 * SIZE_OF_FRAME_LENGTH_AND_FLAGS
+
+
+class PagingPredicateHolderCodec(object):
+    @staticmethod
+    def encode(buf, paging_predicate_holder, is_final=False):
+        initial_frame_buf = create_initial_buffer_custom(_INITIAL_FRAME_SIZE)
+        FixSizedTypesCodec.encode_int(initial_frame_buf, _PAGE_SIZE_ENCODE_OFFSET, paging_predicate_holder.page_size)
+        FixSizedTypesCodec.encode_int(initial_frame_buf, _PAGE_ENCODE_OFFSET, paging_predicate_holder.page)
+        FixSizedTypesCodec.encode_byte(initial_frame_buf, _ITERATION_TYPE_ID_ENCODE_OFFSET, paging_predicate_holder.iteration_type_id)
+        buf.extend(initial_frame_buf)
+        AnchorDataListHolderCodec.encode(buf, paging_predicate_holder.anchor_data_list_holder)
+        CodecUtil.encode_nullable(buf, paging_predicate_holder.predicate_data, DataCodec.encode)
+        CodecUtil.encode_nullable(buf, paging_predicate_holder.comparator_data, DataCodec.encode)
+        CodecUtil.encode_nullable(buf, paging_predicate_holder.partition_key_data, DataCodec.encode)
+        if is_final:
+            buf.extend(END_FINAL_FRAME_BUF)
+        else:
+            buf.extend(END_FRAME_BUF)
+
+    @staticmethod
+    def decode(msg):
+        msg.next_frame()
+        initial_frame = msg.next_frame()
+        page_size = FixSizedTypesCodec.decode_int(initial_frame.buf, _PAGE_SIZE_DECODE_OFFSET)
+        page = FixSizedTypesCodec.decode_int(initial_frame.buf, _PAGE_DECODE_OFFSET)
+        iteration_type_id = FixSizedTypesCodec.decode_byte(initial_frame.buf, _ITERATION_TYPE_ID_DECODE_OFFSET)
+        anchor_data_list_holder = AnchorDataListHolderCodec.decode(msg)
+        predicate_data = CodecUtil.decode_nullable(msg, DataCodec.decode)
+        comparator_data = CodecUtil.decode_nullable(msg, DataCodec.decode)
+        partition_key_data = CodecUtil.decode_nullable(msg, DataCodec.decode)
+        CodecUtil.fast_forward_to_end_frame(msg)
+        return PagingPredicateHolder(anchor_data_list_holder, predicate_data, comparator_data, page_size, page, iteration_type_id, partition_key_data)

--- a/hazelcast/protocol/codec/map_entries_with_paging_predicate_codec.py
+++ b/hazelcast/protocol/codec/map_entries_with_paging_predicate_codec.py
@@ -1,0 +1,28 @@
+from hazelcast.protocol.client_message import OutboundMessage, REQUEST_HEADER_SIZE, create_initial_buffer
+from hazelcast.protocol.builtin import StringCodec
+from hazelcast.protocol.codec.custom.paging_predicate_holder_codec import PagingPredicateHolderCodec
+from hazelcast.protocol.builtin import EntryListCodec
+from hazelcast.protocol.builtin import DataCodec
+from hazelcast.protocol.codec.custom.anchor_data_list_holder_codec import AnchorDataListHolderCodec
+
+# hex: 0x013600
+_REQUEST_MESSAGE_TYPE = 79360
+# hex: 0x013601
+_RESPONSE_MESSAGE_TYPE = 79361
+
+_REQUEST_INITIAL_FRAME_SIZE = REQUEST_HEADER_SIZE
+
+
+def encode_request(name, predicate):
+    buf = create_initial_buffer(_REQUEST_INITIAL_FRAME_SIZE, _REQUEST_MESSAGE_TYPE)
+    StringCodec.encode(buf, name)
+    PagingPredicateHolderCodec.encode(buf, predicate, True)
+    return OutboundMessage(buf, True)
+
+
+def decode_response(msg):
+    msg.next_frame()
+    response = dict()
+    response["response"] = EntryListCodec.decode(msg, DataCodec.decode, DataCodec.decode)
+    response["anchor_data_list"] = AnchorDataListHolderCodec.decode(msg)
+    return response

--- a/hazelcast/protocol/codec/map_key_set_with_paging_predicate_codec.py
+++ b/hazelcast/protocol/codec/map_key_set_with_paging_predicate_codec.py
@@ -1,0 +1,28 @@
+from hazelcast.protocol.client_message import OutboundMessage, REQUEST_HEADER_SIZE, create_initial_buffer
+from hazelcast.protocol.builtin import StringCodec
+from hazelcast.protocol.codec.custom.paging_predicate_holder_codec import PagingPredicateHolderCodec
+from hazelcast.protocol.builtin import ListMultiFrameCodec
+from hazelcast.protocol.builtin import DataCodec
+from hazelcast.protocol.codec.custom.anchor_data_list_holder_codec import AnchorDataListHolderCodec
+
+# hex: 0x013400
+_REQUEST_MESSAGE_TYPE = 78848
+# hex: 0x013401
+_RESPONSE_MESSAGE_TYPE = 78849
+
+_REQUEST_INITIAL_FRAME_SIZE = REQUEST_HEADER_SIZE
+
+
+def encode_request(name, predicate):
+    buf = create_initial_buffer(_REQUEST_INITIAL_FRAME_SIZE, _REQUEST_MESSAGE_TYPE)
+    StringCodec.encode(buf, name)
+    PagingPredicateHolderCodec.encode(buf, predicate, True)
+    return OutboundMessage(buf, True)
+
+
+def decode_response(msg):
+    msg.next_frame()
+    response = dict()
+    response["response"] = ListMultiFrameCodec.decode(msg, DataCodec.decode)
+    response["anchor_data_list"] = AnchorDataListHolderCodec.decode(msg)
+    return response

--- a/hazelcast/protocol/codec/map_values_with_paging_predicate_codec.py
+++ b/hazelcast/protocol/codec/map_values_with_paging_predicate_codec.py
@@ -1,0 +1,28 @@
+from hazelcast.protocol.client_message import OutboundMessage, REQUEST_HEADER_SIZE, create_initial_buffer
+from hazelcast.protocol.builtin import StringCodec
+from hazelcast.protocol.codec.custom.paging_predicate_holder_codec import PagingPredicateHolderCodec
+from hazelcast.protocol.builtin import ListMultiFrameCodec
+from hazelcast.protocol.builtin import DataCodec
+from hazelcast.protocol.codec.custom.anchor_data_list_holder_codec import AnchorDataListHolderCodec
+
+# hex: 0x013500
+_REQUEST_MESSAGE_TYPE = 79104
+# hex: 0x013501
+_RESPONSE_MESSAGE_TYPE = 79105
+
+_REQUEST_INITIAL_FRAME_SIZE = REQUEST_HEADER_SIZE
+
+
+def encode_request(name, predicate):
+    buf = create_initial_buffer(_REQUEST_INITIAL_FRAME_SIZE, _REQUEST_MESSAGE_TYPE)
+    StringCodec.encode(buf, name)
+    PagingPredicateHolderCodec.encode(buf, predicate, True)
+    return OutboundMessage(buf, True)
+
+
+def decode_response(msg):
+    msg.next_frame()
+    response = dict()
+    response["response"] = ListMultiFrameCodec.decode(msg, DataCodec.decode)
+    response["anchor_data_list"] = AnchorDataListHolderCodec.decode(msg)
+    return response

--- a/hazelcast/serialization/predicate.py
+++ b/hazelcast/serialization/predicate.py
@@ -1,9 +1,13 @@
 from hazelcast.serialization.api import IdentifiedDataSerializable
+from hazelcast.util import IterationType, get_attr_name
 
 PREDICATE_FACTORY_ID = -20
 
 
 class Predicate(IdentifiedDataSerializable):
+    def read_data(self, object_data_input):
+        pass
+
     def get_factory_id(self):
         return PREDICATE_FACTORY_ID
 
@@ -205,6 +209,105 @@ class TruePredicate(Predicate):
         return "TruePredicate()"
 
 
+class PagingPredicate(Predicate):
+    CLASS_ID = 15
+
+    def __init__(self, predicate, page_size, comparator=None):
+        """
+        Creates a Paging predicate with provided arguments.
+
+        Args:
+            predicate (hazelcast.serialization.predicate.Predicate):
+                Predicate to filter the results
+            page_size (int): The page size of each result set.
+            comparator (hazelcast.serialization.api.Portable or hazelcast.serialization.api.IdentifiedDataSerializable):
+                An optional comparator object to be used on the server side
+                to sort the results. It must be registered on the server side
+                and implement the ``java.util.Comparator`` interface.
+        """
+        if isinstance(predicate, PagingPredicate):
+            raise TypeError("Nested paging predicate not supported.")
+
+        if page_size <= 0:
+            raise ValueError('page_size should be greater than 0.')
+
+        self._internal_predicate = predicate
+        self._page_size = page_size
+        self._page = 0  # initialized to be on first page
+        self.comparator = comparator
+        self.iteration_type = IterationType.ENTRY
+        self.anchor_list = []  # List of pairs: (nearest page, (anchor key, anchor value))
+
+    def __repr__(self):
+        return "PagingPredicate(predicate=%s, page_size=%s, comparator=%s)" % (self._internal_predicate,
+                                                                               self.page_size, self.comparator)
+
+    def write_data(self, output):
+        output.write_object(self._internal_predicate)
+        output.write_object(self.comparator)
+        output.write_int(self.page)
+        output.write_int(self._page_size)
+        output.write_utf(get_attr_name(IterationType, self.iteration_type))
+        output.write_int(len(self.anchor_list))
+        for nearest_page, (anchor_key, anchor_value) in self.anchor_list:
+            output.write_int(nearest_page)
+            output.write_object(anchor_key)
+            output.write_object(anchor_value)
+
+    def next_page(self):
+        """Sets page index to next page.
+
+        If new index is out of range, the query results that this
+        paging predicate will retrieve will be an empty list.
+
+        Returns:
+            int: Updated page index
+        """
+        self.page += 1
+        return self.page
+
+    def previous_page(self):
+        """sets page index to previous page.
+
+        If current page index is 0, this method does nothing.
+
+        Returns:
+            int: Updated page index.
+        """
+        if self.page != 0:
+            self.page -= 1
+        return self.page
+
+    def reset(self):
+        """Resets the predicate for reuse."""
+        self.iteration_type = IterationType.ENTRY
+        del self.anchor_list[:]
+        self.page = 0
+
+    @property
+    def page(self):
+        return self._page
+
+    @page.setter
+    def page(self, page_no):
+        """Sets page index to specified page_no.
+
+        If page_no is out of range, the query results that this paging predicate
+        will retrieve will be an empty list.
+
+        Args:
+            page_no (int): New page index. Must be greater than or equal to ``0``.
+        """
+        if page_no < 0:
+            raise ValueError("page_no should be positive or 0.")
+
+        self._page = page_no
+
+    @property
+    def page_size(self):
+        return self._page_size
+
+
 sql = SqlPredicate
 is_equal_to = EqualPredicate
 is_not_equal_to = NotEqualPredicate
@@ -220,6 +323,7 @@ is_instance_of = InstanceOfPredicate
 is_not = NotPredicate
 false = FalsePredicate
 true = TruePredicate
+paging = PagingPredicate
 
 
 def is_greater_than(attribute, x):

--- a/hazelcast/util.py
+++ b/hazelcast/util.py
@@ -285,7 +285,7 @@ class RandomLB(_AbstractLoadBalancer):
 
 class IterationType:
     """To differentiate users selection on result collection on map-wide
-    operations like values, keySet, query etc.
+    operations like ``entry_set``, ``key_set``, ``values`` etc.
     """
 
     KEY = 0

--- a/hazelcast/util.py
+++ b/hazelcast/util.py
@@ -281,3 +281,18 @@ class RandomLB(_AbstractLoadBalancer):
             return None
         idx = random.randrange(0, len(members))
         return members[idx]
+
+
+class IterationType:
+    """To differentiate users selection on result collection on map-wide
+    operations like values, keySet, query etc.
+    """
+
+    KEY = 0
+    """Iterate over keys"""
+
+    VALUE = 1
+    """Iterate over values"""
+
+    ENTRY = 2
+    """Iterate over entries"""


### PR DESCRIPTION
This is the port of #212
to the 4.0 branch. However, there are some differences from that PR.

- Documentation of the feature is a little bit different since the client
side sorting is removed.
- Tests are more-or-less ported directly with a few additions for
input validations. However, the above PR was using `six.assertCounEqual`
for assertions which checks equality but not order. For paging predicate
tests, it makes more sense to check ordering.
- Client side codecs and holder classes for PagingPredicates and AnchorDataLists
are added.
- Some public methods, like `get_anchor`, `set_anchor`, `get_nearest_anchor_entry`
is removed. `get_anchor` is defined on the public API on the Java side but I think
it does not provide any functionality to the user.

Also, some missing `six.moves.range` imports are added.

Protocol PR: https://github.com/hazelcast/hazelcast-client-protocol/pull/355