### PR TITLE
Fix class definition registrations with the same class id

### DIFF
--- a/hazelcast/serialization/portable/classdef.py
+++ b/hazelcast/serialization/portable/classdef.py
@@ -225,7 +225,8 @@ class ClassDefinitionBuilder(object):
 
     def _add_field_by_type(self, field_name, field_type, version, factory_id=0, class_id=0):
         self._check()
-        self._field_defs.append(FieldDefinition(self._index, field_name, field_type, version, factory_id, class_id))
+        fd = FieldDefinition(self._index, field_name, field_type, version, factory_id, class_id)
+        self._field_defs.append(fd)
         self._index += 1
 
     def _check(self):

--- a/hazelcast/serialization/service.py
+++ b/hazelcast/serialization/service.py
@@ -78,24 +78,40 @@ class SerializationServiceV1(BaseSerializationService):
         self._registry.safe_register_serializer(self._registry._python_serializer)
 
     def register_class_definitions(self, class_definitions, check_error):
-        class_defs = dict()
+        factories = dict()
         for cd in class_definitions:
-            if cd in class_defs:
-                raise HazelcastSerializationError("Duplicate registration found for class-id: %s" % cd.class_id)
-            class_defs[cd.class_id] = cd
-        for cd in class_definitions:
-            self.register_class_definition(cd, class_defs, check_error)
+            factory_id = cd.factory_id
+            class_defs = factories.get(factory_id, None)
+            if class_defs is None:
+                class_defs = dict()
+                factories[factory_id] = class_defs
 
-    def register_class_definition(self, cd, class_defs, check_error):
+            class_id = cd.class_id
+            if class_id in class_defs:
+                raise HazelcastSerializationError("Duplicate registration found for class-id: %s" % class_id)
+            class_defs[class_id] = cd
+
+        for cd in class_definitions:
+            self.register_class_definition(cd, factories, check_error)
+
+    def register_class_definition(self, cd, factories, check_error):
         field_names = cd.get_field_names()
         for field_name in field_names:
             fd = cd.get_field(field_name)
             if fd.field_type == FieldType.PORTABLE or fd.field_type == FieldType.PORTABLE_ARRAY:
-                nested_cd = class_defs.get(fd.class_id, None)
-                if nested_cd is not None:
-                    self.register_class_definition(nested_cd, class_defs, check_error)
-                    self._portable_context.register_class_definition(nested_cd)
-                elif check_error:
+                factory_id = fd.factory_id
+                class_id = fd.class_id
+                class_defs = factories.get(factory_id, None)
+                if class_defs is not None:
+                    nested_cd = class_defs.get(class_id, None)
+                    if nested_cd is not None:
+                        self.register_class_definition(nested_cd, factories, check_error)
+                        self._portable_context.register_class_definition(nested_cd)
+                        continue
+
+                if check_error:
                     raise HazelcastSerializationError(
-                            "Could not find registered ClassDefinition for class-id: %s" % fd.class_id)
+                        "Could not find registered ClassDefinition for factory-id: %s, class-id: %s"
+                        % (factory_id, class_id))
+
         self._portable_context.register_class_definition(cd)

--- a/hazelcast/serialization/service.py
+++ b/hazelcast/serialization/service.py
@@ -94,10 +94,10 @@ class SerializationServiceV1(BaseSerializationService):
         for cd in class_definitions:
             self.register_class_definition(cd, factories, check_error)
 
-    def register_class_definition(self, cd, factories, check_error):
-        field_names = cd.get_field_names()
+    def register_class_definition(self, class_definition, factories, check_error):
+        field_names = class_definition.get_field_names()
         for field_name in field_names:
-            fd = cd.get_field(field_name)
+            fd = class_definition.get_field(field_name)
             if fd.field_type == FieldType.PORTABLE or fd.field_type == FieldType.PORTABLE_ARRAY:
                 factory_id = fd.factory_id
                 class_id = fd.class_id
@@ -114,4 +114,4 @@ class SerializationServiceV1(BaseSerializationService):
                         "Could not find registered ClassDefinition for factory-id: %s, class-id: %s"
                         % (factory_id, class_id))
 
-        self._portable_context.register_class_definition(cd)
+        self._portable_context.register_class_definition(class_definition)


### PR DESCRIPTION
When class definitions for two different classes with the same class id
but different factory ids are registered, we were throwing an error
indicating that there are duplicate registrations. However, we should
allow such cases.

Apart from the fix for that, the PR also includes a test case for
null portable serialization.

Closes #199