### PR TITLE
Fix the race on the timers

### DIFF
--- a/hazelcast/reactor.py
+++ b/hazelcast/reactor.py
@@ -78,8 +78,8 @@ class AsyncoreReactor(object):
                 if timer.check_timer(now):
                     heappop(timers)
                 else:
-                    # Timer in the root of the min heap is not expired
-                    # Therefore, there should not be any expired
+                    # Timer in the root of the min heap is not expired.
+                    # Therefore, there should be no expired
                     # timers in the heap.
                     return
 


### PR DESCRIPTION
Formerly, we were doing a logic like the following: Check the
timer in front of the priority queue of timers. If it is expired,
call the callback and pop it from the queue. However, this logic
is flawed because the timers queue was accessed from multiple threads.
So, it may be the case that, we check the timer in front of the queue,
run its callback, then, some other thread adds another timer to the
queue concurrently and it is put in front of the queue. Now, when the
reactor thread pops the item in front of the queue, it will be the newly
added timer, before its callback being executed.

To solve this, we use a double buffering approach. A thead-safe queue
is used to store newly added timers which can be efficiently modified
on both ends on multiple threads. Then, the reactor thread periodically
pops items from that queue in FIFO order and maintains a min heap
using a list with the help of heappush and heappop functions. Only if
the min heap has some elements, timers are popped from that and executed.

Also, the unneeded `timer_cancelled_cb` is field is removed. We were
removing the timer from the queue after canceling it. That was the
only usage of this field. We do the same with the new approach,
if it is canceled, it will return `True` on `check_timer` call without
executing its `timer_ended_cb` and will be removed from the heap.