### PR TITLE
Optimize murmur hash calculation

### DIFF
--- a/hazelcast/hash.py
+++ b/hazelcast/hash.py
@@ -11,8 +11,8 @@ def murmur_hash3_x86_32(data):
     Returns:
         int: Calculated hash value.
     """
-    length = len(data) - 8  # Heap data overhead
-    nblocks = int(length / 4)
+    length = max(len(data) - 8, 0)  # Heap data overhead
+    nblocks = length // 4
 
     h1 = 0x01000193
 
@@ -37,7 +37,7 @@ def murmur_hash3_x86_32(data):
     k1 = 0
     tail_size = length & 3
 
-    # offsets below are shifted according to Heap data offset
+    # Offsets below are shifted according to heap data overhead
     if tail_size >= 3:
         k1 ^= data[tail_index + 10] << 16
     if tail_size >= 2:

--- a/hazelcast/hash.py
+++ b/hazelcast/hash.py
@@ -1,33 +1,20 @@
-import math
+from hazelcast.serialization import LE_UINT
 from hazelcast.six.moves import range
 
 
-def _fmix(h):
-    h ^= h >> 16
-    h = (h * 0x85ebca6b) & 0xFFFFFFFF
-    h ^= h >> 13
-    h = (h * 0xc2b2ae35) & 0xFFFFFFFF
-    h ^= h >> 16
-    return h
-
-
-def murmur_hash3_x86_32(data, offset, size, seed=0x01000193):
+def murmur_hash3_x86_32(data):
     """murmur3 hash function to determine partition
 
     Args:
-        data (bytearray): Input byte array
-        offset (int): Offset.
-        size (int): Byte length.
-        seed (int): Murmur hash seed hazelcast uses 0x01000193.
+        data (bytearray or bytes): Input byte array
 
     Returns:
         int: Calculated hash value.
     """
-    key = bytearray(data[offset: offset + size])
-    length = len(key)
+    length = len(data) - 8  # Heap data overhead
     nblocks = int(length / 4)
 
-    h1 = seed
+    h1 = 0x01000193
 
     c1 = 0xcc9e2d51
     c2 = 0x1b873593
@@ -35,10 +22,7 @@ def murmur_hash3_x86_32(data, offset, size, seed=0x01000193):
     # body
     for block_start in range(0, nblocks * 4, 4):
         # ??? big endian?
-        k1 = key[block_start + 3] << 24 | \
-             key[block_start + 2] << 16 | \
-             key[block_start + 1] << 8 | \
-             key[block_start + 0]
+        k1 = LE_UINT.unpack_from(data, block_start + 8)[0]
 
         k1 = c1 * k1 & 0xFFFFFFFF
         k1 = (k1 << 15 | k1 >> 17) & 0xFFFFFFFF  # inlined ROTL32
@@ -53,12 +37,13 @@ def murmur_hash3_x86_32(data, offset, size, seed=0x01000193):
     k1 = 0
     tail_size = length & 3
 
+    # offsets below are shifted according to Heap data offset
     if tail_size >= 3:
-        k1 ^= key[tail_index + 2] << 16
+        k1 ^= data[tail_index + 10] << 16
     if tail_size >= 2:
-        k1 ^= key[tail_index + 1] << 8
+        k1 ^= data[tail_index + 9] << 8
     if tail_size >= 1:
-        k1 ^= key[tail_index + 0]
+        k1 ^= data[tail_index + 8]
 
     if tail_size != 0:
         k1 = (k1 * c1) & 0xFFFFFFFF
@@ -66,12 +51,17 @@ def murmur_hash3_x86_32(data, offset, size, seed=0x01000193):
         k1 = (k1 * c2) & 0xFFFFFFFF
         h1 ^= k1
 
-    result = _fmix(h1 ^ length)
-    return -(result & 0x80000000) | (result & 0x7FFFFFFF)
+    h1 ^= length
+    h1 ^= h1 >> 16
+    h1 = (h1 * 0x85ebca6b) & 0xFFFFFFFF
+    h1 ^= h1 >> 13
+    h1 = (h1 * 0xc2b2ae35) & 0xFFFFFFFF
+    h1 ^= h1 >> 16
+    return -(h1 & 0x80000000) | (h1 & 0x7FFFFFFF)
 
 
-def hash_to_index(hash, length):
-    if hash == 0x80000000:
+def hash_to_index(mm_hash, length):
+    if mm_hash == 0x80000000:
         return 0
     else:
-        return int(abs(math.fmod(hash, length)))
+        return abs(mm_hash) % length

--- a/hazelcast/serialization/data.py
+++ b/hazelcast/serialization/data.py
@@ -92,7 +92,7 @@ class Data(object):
         Returns:
             int: The murmur hash of the internal data.
         """
-        return murmur_hash3_x86_32(self._buffer, DATA_OFFSET, self.data_size())
+        return murmur_hash3_x86_32(self._buffer)
 
     def __hash__(self):
         return self.hash_code()

--- a/tests/murmur_hash_test.py
+++ b/tests/murmur_hash_test.py
@@ -6,19 +6,19 @@ from hazelcast.hash import murmur_hash3_x86_32, hash_to_index
 class HashTest(unittest.TestCase):
     def test_hash(self):
         expected = [
-            (b"key-1", 1228513025, 107),
-            (b"key-2", 1503416236, 105),
-            (b"key-3", 1876349747, 218),
-            (b"key-4", -914632498, 181),
-            (b"key-5", -803210507, 111),
-            (b"key-6", -847942313, 115),
-            (b"key-7", 1196747334, 223),
-            (b"key-8", -1444149994, 208),
-            (b"key-9", 1182720020, 140),
+            (b"00000000key-1", 1228513025, 107),
+            (b"00000000key-2", 1503416236, 105),
+            (b"00000000key-3", 1876349747, 218),
+            (b"00000000key-4", -914632498, 181),
+            (b"00000000key-5", -803210507, 111),
+            (b"00000000key-6", -847942313, 115),
+            (b"00000000key-7", 1196747334, 223),
+            (b"00000000key-8", -1444149994, 208),
+            (b"00000000key-9", 1182720020, 140),
         ]
 
-        for key, hash, partition_id in expected:
-            h = murmur_hash3_x86_32(key, 0, len(key))
+        for key, mm_hash, partition_id in expected:
+            h = murmur_hash3_x86_32(key)
             p = hash_to_index(h, 271)
-            self.assertEqual(h, hash)
+            self.assertEqual(h, mm_hash)
             self.assertEqual(p, partition_id)

--- a/tests/murmur_hash_test.py
+++ b/tests/murmur_hash_test.py
@@ -5,8 +5,10 @@ from hazelcast.hash import murmur_hash3_x86_32, hash_to_index
 
 class HashTest(unittest.TestCase):
     def test_hash(self):
-        expected = [
+        expected = [  # Expected values are from the Java implementation
+            #  00000000 -> HEAP_DATA_OVERHEAD
             (b"00000000key-1", 1228513025, 107),
+            (b"12345678key-1", 1228513025, 107),  # Heap data overhead should not matter
             (b"00000000key-2", 1503416236, 105),
             (b"00000000key-3", 1876349747, 218),
             (b"00000000key-4", -914632498, 181),
@@ -15,10 +17,17 @@ class HashTest(unittest.TestCase):
             (b"00000000key-7", 1196747334, 223),
             (b"00000000key-8", -1444149994, 208),
             (b"00000000key-9", 1182720020, 140),
+            # Test with different lengths
+            (b"00000000", -1585187909, 238),
+            (b"00000000a", -1686100800, 46),
+            (b"00000000ab", 312914265, 50),
+            (b"00000000abc", -2068121803, 208),
+            (b"00000000abcd", -973615161, 236),
+            (b"", -1585187909, 238),
         ]
 
         for key, mm_hash, partition_id in expected:
-            h = murmur_hash3_x86_32(key)
+            h = murmur_hash3_x86_32(bytearray(key))
             p = hash_to_index(h, 271)
             self.assertEqual(h, mm_hash)
             self.assertEqual(p, partition_id)


### PR DESCRIPTION
We were always passing a bytes-like object to the murmur hash function
but, we were copying it from the HEAP_DATA_OVERHEAD(8) offset, which
can be huge. I removed that copy and tuned the offsets according to our
HEAP_DATA_OVERHEAD.

Another parameter of the function was the data size. For valid Data
objects, this is always equal to the `len(buffer) - HEAP_DATA_OVERHEAD`.
This parameter is removed and this length is calculated inside the
murmur hash function now.

Also, inlined the _fmix function call and removed the unnecessary
method calls on hash_to_index function.