### PR TITLE
Remove logging on sending each client message

### DIFF
--- a/hazelcast/invocation.py
+++ b/hazelcast/invocation.py
@@ -206,7 +206,7 @@ class InvocationService(object):
         if invocation.event_handler:
             self._listener_service.add_event_handler(correlation_id, invocation.event_handler)
 
-        _logger.debug("Sending %s to %s", message, connection)
+        # _logger.debug("Sending %s to %s", message, connection)
 
         if not connection.send_message(message):
             if invocation.event_handler:

--- a/hazelcast/invocation.py
+++ b/hazelcast/invocation.py
@@ -206,8 +206,6 @@ class InvocationService(object):
         if invocation.event_handler:
             self._listener_service.add_event_handler(correlation_id, invocation.event_handler)
 
-        # _logger.debug("Sending %s to %s", message, connection)
-
         if not connection.send_message(message):
             if invocation.event_handler:
                 self._listener_service.remove_event_handler(correlation_id)


### PR DESCRIPTION
It is not really useful for the end user to see the each message
that clients send. It might be useful for us on some occasions,
so I left it as a commented line. Commenting it resulted in
approx. %1-2 throughput increase.