### PR TITLE
Update SSL protocol used in tests

### DIFF
--- a/tests/ssl/hazelcast-default-ca.xml
+++ b/tests/ssl/hazelcast-default-ca.xml
@@ -11,7 +11,7 @@
                 <property name="keyStore">com/hazelcast/nio/ssl/letsencrypt.jks</property>
                 <property name="keyStorePassword">123456</property>
                 <property name="keyManagerAlgorithm">SunX509</property>
-                <property name="protocol">TLSv1</property>
+                <property name="protocol">TLSv1.2</property>
             </properties>
         </ssl>
     </network>

--- a/tests/ssl/hazelcast-ma-optional.xml
+++ b/tests/ssl/hazelcast-ma-optional.xml
@@ -16,7 +16,7 @@
                 <property name="trustManagerAlgorithm">SunX509</property>
                 <property name="javax.net.ssl.mutualAuthentication">OPTIONAL</property>
                 <property name="keyManagerAlgorithm">SunX509</property>
-                <property name="protocol">TLSv1</property>
+                <property name="protocol">TLSv1.2</property>
             </properties>
         </ssl>
     </network>

--- a/tests/ssl/hazelcast-ma-required.xml
+++ b/tests/ssl/hazelcast-ma-required.xml
@@ -16,7 +16,7 @@
                 <property name="trustManagerAlgorithm">SunX509</property>
                 <property name="javax.net.ssl.mutualAuthentication">REQUIRED</property>
                 <property name="keyManagerAlgorithm">SunX509</property>
-                <property name="protocol">TLSv1</property>
+                <property name="protocol">TLSv1.2</property>
             </properties>
         </ssl>
     </network>

--- a/tests/ssl/hazelcast-ssl.xml
+++ b/tests/ssl/hazelcast-ssl.xml
@@ -11,7 +11,7 @@
                 <property name="keyStore">com/hazelcast/nio/ssl-mutual-auth/server1.keystore</property>
                 <property name="keyStorePassword">password</property>
                 <property name="keyManagerAlgorithm">SunX509</property>
-                <property name="protocol">TLSv1</property>
+                <property name="protocol">TLSv1.2</property>
             </properties>
         </ssl>
     </network>

--- a/tests/ssl/mutual_authentication_test.py
+++ b/tests/ssl/mutual_authentication_test.py
@@ -2,7 +2,6 @@ import os
 
 from tests.base import HazelcastTestCase
 from hazelcast.client import HazelcastClient
-from hazelcast.config import SSLProtocol
 from hazelcast.errors import HazelcastError
 from tests.util import get_ssl_config, get_abs_path, set_attr
 
@@ -27,8 +26,7 @@ class MutualAuthenticationTest(HazelcastTestCase):
         client = HazelcastClient(**get_ssl_config(cluster.id, True,
                                                   get_abs_path(self.current_directory, "server1-cert.pem"),
                                                   get_abs_path(self.current_directory, "client1-cert.pem"),
-                                                  get_abs_path(self.current_directory, "client1-key.pem"),
-                                                  protocol=SSLProtocol.TLSv1))
+                                                  get_abs_path(self.current_directory, "client1-key.pem")))
         self.assertTrue(client.lifecycle_service.is_running())
         client.shutdown()
 
@@ -40,8 +38,7 @@ class MutualAuthenticationTest(HazelcastTestCase):
             HazelcastClient(**get_ssl_config(cluster.id, True,
                                              get_abs_path(self.current_directory, "server2-cert.pem"),
                                              get_abs_path(self.current_directory, "client1-cert.pem"),
-                                             get_abs_path(self.current_directory, "client1-key.pem"),
-                                             protocol=SSLProtocol.TLSv1))
+                                             get_abs_path(self.current_directory, "client1-key.pem")))
 
     def test_ma_required_client_not_authenticated(self):
         cluster = self.create_cluster(self.rc, self.configure_cluster(True))
@@ -51,8 +48,7 @@ class MutualAuthenticationTest(HazelcastTestCase):
             HazelcastClient(**get_ssl_config(cluster.id, True,
                                              get_abs_path(self.current_directory, "server1-cert.pem"),
                                              get_abs_path(self.current_directory, "client2-cert.pem"),
-                                             get_abs_path(self.current_directory, "client2-key.pem"),
-                                             protocol=SSLProtocol.TLSv1))
+                                             get_abs_path(self.current_directory, "client2-key.pem")))
 
     def test_ma_required_client_and_server_not_authenticated(self):
         cluster = self.create_cluster(self.rc, self.configure_cluster(True))
@@ -62,8 +58,7 @@ class MutualAuthenticationTest(HazelcastTestCase):
             HazelcastClient(**get_ssl_config(cluster.id, True,
                                              get_abs_path(self.current_directory, "server2-cert.pem"),
                                              get_abs_path(self.current_directory, "client2-cert.pem"),
-                                             get_abs_path(self.current_directory, "client2-key.pem"),
-                                             protocol=SSLProtocol.TLSv1))
+                                             get_abs_path(self.current_directory, "client2-key.pem")))
 
     def test_ma_optional_client_and_server_authenticated(self):
         cluster = self.create_cluster(self.rc, self.configure_cluster(False))
@@ -71,8 +66,7 @@ class MutualAuthenticationTest(HazelcastTestCase):
         client = HazelcastClient(**get_ssl_config(cluster.id, True,
                                                   get_abs_path(self.current_directory, "server1-cert.pem"),
                                                   get_abs_path(self.current_directory, "client1-cert.pem"),
-                                                  get_abs_path(self.current_directory, "client1-key.pem"),
-                                                  protocol=SSLProtocol.TLSv1))
+                                                  get_abs_path(self.current_directory, "client1-key.pem")))
         self.assertTrue(client.lifecycle_service.is_running())
         client.shutdown()
 
@@ -84,8 +78,7 @@ class MutualAuthenticationTest(HazelcastTestCase):
             HazelcastClient(**get_ssl_config(cluster.id, True,
                                              get_abs_path(self.current_directory, "server2-cert.pem"),
                                              get_abs_path(self.current_directory, "client1-cert.pem"),
-                                             get_abs_path(self.current_directory, "client1-key.pem"),
-                                             protocol=SSLProtocol.TLSv1))
+                                             get_abs_path(self.current_directory, "client1-key.pem")))
 
     def test_ma_optional_client_not_authenticated(self):
         cluster = self.create_cluster(self.rc, self.configure_cluster(False))
@@ -95,8 +88,7 @@ class MutualAuthenticationTest(HazelcastTestCase):
             HazelcastClient(**get_ssl_config(cluster.id, True,
                                              get_abs_path(self.current_directory, "server1-cert.pem"),
                                              get_abs_path(self.current_directory, "client2-cert.pem"),
-                                             get_abs_path(self.current_directory, "client2-key.pem"),
-                                             protocol=SSLProtocol.TLSv1))
+                                             get_abs_path(self.current_directory, "client2-key.pem")))
 
     def test_ma_optional_client_and_server_not_authenticated(self):
         cluster = self.create_cluster(self.rc, self.configure_cluster(False))
@@ -106,8 +98,7 @@ class MutualAuthenticationTest(HazelcastTestCase):
             HazelcastClient(**get_ssl_config(cluster.id, True,
                                              get_abs_path(self.current_directory, "server2-cert.pem"),
                                              get_abs_path(self.current_directory, "client2-cert.pem"),
-                                             get_abs_path(self.current_directory, "client2-key.pem"),
-                                             protocol=SSLProtocol.TLSv1))
+                                             get_abs_path(self.current_directory, "client2-key.pem")))
 
     def test_ma_required_with_no_cert_file(self):
         cluster = self.create_cluster(self.rc, self.configure_cluster(True))
@@ -115,15 +106,13 @@ class MutualAuthenticationTest(HazelcastTestCase):
 
         with self.assertRaises(HazelcastError):
             HazelcastClient(**get_ssl_config(cluster.id, True,
-                                             get_abs_path(self.current_directory, "server1-cert.pem"),
-                                             protocol=SSLProtocol.TLSv1))
+                                             get_abs_path(self.current_directory, "server1-cert.pem")))
 
     def test_ma_optional_with_no_cert_file(self):
         cluster = self.create_cluster(self.rc, self.configure_cluster(False))
         cluster.start_member()
         client = HazelcastClient(**get_ssl_config(cluster.id, True,
-                                                  get_abs_path(self.current_directory, "server1-cert.pem"),
-                                                  protocol=SSLProtocol.TLSv1))
+                                                  get_abs_path(self.current_directory, "server1-cert.pem")))
         self.assertTrue(client.lifecycle_service.is_running())
         client.shutdown()
 

--- a/tests/ssl/ssl_test.py
+++ b/tests/ssl/ssl_test.py
@@ -32,8 +32,7 @@ class SSLTest(HazelcastTestCase):
         cluster.start_member()
 
         client = HazelcastClient(**get_ssl_config(cluster.id, True,
-                                                  get_abs_path(self.current_directory, "server1-cert.pem"),
-                                                  protocol=SSLProtocol.TLSv1))
+                                                  get_abs_path(self.current_directory, "server1-cert.pem")))
         self.assertTrue(client.lifecycle_service.is_running())
         client.shutdown()
 
@@ -42,8 +41,7 @@ class SSLTest(HazelcastTestCase):
         cluster = self.create_cluster(self.rc, self.configure_cluster(self.default_ca_xml))
         cluster.start_member()
 
-        client = HazelcastClient(**get_ssl_config(cluster.id, True,
-                                                  protocol=SSLProtocol.TLSv1))
+        client = HazelcastClient(**get_ssl_config(cluster.id, True))
         self.assertTrue(client.lifecycle_service.is_running())
         client.shutdown()
 
@@ -53,16 +51,14 @@ class SSLTest(HazelcastTestCase):
         cluster.start_member()
 
         with self.assertRaises(HazelcastError):
-            HazelcastClient(**get_ssl_config(cluster.id, True,
-                                             protocol=SSLProtocol.TLSv1))
+            HazelcastClient(**get_ssl_config(cluster.id, True))
 
     def test_ssl_enabled_map_size(self):
         cluster = self.create_cluster(self.rc, self.configure_cluster(self.hazelcast_ssl_xml))
         cluster.start_member()
 
         client = HazelcastClient(**get_ssl_config(cluster.id, True,
-                                                  get_abs_path(self.current_directory, "server1-cert.pem"),
-                                                  protocol=SSLProtocol.TLSv1))
+                                                  get_abs_path(self.current_directory, "server1-cert.pem")))
         test_map = client.get_map("test_map")
         fill_map(test_map, 10)
         self.assertEqual(test_map.size().result(), 10)
@@ -74,7 +70,6 @@ class SSLTest(HazelcastTestCase):
 
         client = HazelcastClient(**get_ssl_config(cluster.id, True,
                                                   get_abs_path(self.current_directory, "server1-cert.pem"),
-                                                  protocol=SSLProtocol.TLSv1,
                                                   ciphers="DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA:DHE-RSA-DES-"
                                                           "CBC3-SHA:DHE-RSA-DES-CBC3-SHA:DHE-DSS-DES-CBC3-SHA"))
         self.assertTrue(client.lifecycle_service.is_running())
@@ -87,7 +82,6 @@ class SSLTest(HazelcastTestCase):
         with self.assertRaises(HazelcastError):
             HazelcastClient(**get_ssl_config(cluster.id, True,
                                              get_abs_path(self.current_directory, "server1-cert.pem"),
-                                             protocol=SSLProtocol.TLSv1,
                                              ciphers="INVALID-CIPHER1:INVALID_CIPHER2"))
 
     def test_ssl_enabled_with_protocol_mismatch(self):

--- a/tests/ssl/ssl_test.py
+++ b/tests/ssl/ssl_test.py
@@ -70,8 +70,7 @@ class SSLTest(HazelcastTestCase):
 
         client = HazelcastClient(**get_ssl_config(cluster.id, True,
                                                   get_abs_path(self.current_directory, "server1-cert.pem"),
-                                                  ciphers="DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA:DHE-RSA-DES-"
-                                                          "CBC3-SHA:DHE-RSA-DES-CBC3-SHA:DHE-DSS-DES-CBC3-SHA"))
+                                                  ciphers="ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-GCM-SHA384"))
         self.assertTrue(client.lifecycle_service.is_running())
         client.shutdown()
 


### PR DESCRIPTION
OpenSSL 1.1.1 disables TLSv1 by default. We will be using it
on our new docker images. So, SSL tests are updated to use TLSv1.2 instead.