### PR TITLE
Make ListenerService return Future

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1766,7 +1766,7 @@ A Topic usage example is shown below.
         print("Got message:", topic_message.message)
 
     # Get a Topic called "my-distributed-topic"
-    topic = client.get_topic("my-distributed-topic")
+    topic = client.get_topic("my-distributed-topic").blocking()
 
     # Add a Listener to the Topic
     topic.add_listener(print_on_message)
@@ -2342,7 +2342,7 @@ client.
 
     client.add_distributed_object_listener(
         listener_func=distributed_object_listener
-    )
+    ).result()
 
     map_name = "test_map"
 
@@ -2483,7 +2483,7 @@ See the following example.
 
 
     customer_map.add_entry_listener(include_value=True, clear_all_func=cleared)
-    customer_map.clear().result()
+    customer_map.clear()
 
 7.6. Distributed Computing
 --------------------------

--- a/README.rst
+++ b/README.rst
@@ -2347,10 +2347,10 @@ client.
     map_name = "test_map"
 
     # This call causes a CREATED event
-    test_map = client.get_map(map_name)
+    test_map = client.get_map(map_name).blocking()
 
     # This causes no event because map was already created
-    test_map2 = client.get_map(map_name)
+    test_map2 = client.get_map(map_name).blocking()
 
     # This causes a DESTROYED event
     test_map.destroy()

--- a/examples/monitoring/distributed_object_listener.py
+++ b/examples/monitoring/distributed_object_listener.py
@@ -8,7 +8,7 @@ def distributed_object_listener(event):
 client = hazelcast.HazelcastClient()
 
 # Register the listener
-reg_id = client.add_distributed_object_listener(distributed_object_listener)
+reg_id = client.add_distributed_object_listener(distributed_object_listener).result()
 
 map_name = "test_map"
 
@@ -22,6 +22,6 @@ test_map2 = client.get_map(map_name)
 test_map.destroy()
 
 # De-register the listener
-client.remove_distributed_object_listener(reg_id)
+client.remove_distributed_object_listener(reg_id).result()
 
 client.shutdown()

--- a/examples/org-website/topic_sample.py
+++ b/examples/org-website/topic_sample.py
@@ -8,7 +8,7 @@ def print_on_message(topic_message):
 # Start the Hazelcast Client and connect to an already running Hazelcast Cluster on 127.0.0.1
 hz = hazelcast.HazelcastClient()
 # Get a Topic called "my-distributed-topic"
-topic = hz.get_topic("my-distributed-topic")
+topic = hz.get_topic("my-distributed-topic").blocking()
 # Add a Listener to the Topic
 topic.add_listener(print_on_message)
 # Publish a message to the Topic

--- a/examples/topic/topic_example.py
+++ b/examples/topic/topic_example.py
@@ -9,7 +9,7 @@ def on_message(event):
 
 client = hazelcast.HazelcastClient()
 
-topic = client.get_topic("topic")
+topic = client.get_topic("topic").blocking()
 topic.add_listener(on_message)
 
 for i in range(10):

--- a/hazelcast/client.py
+++ b/hazelcast/client.py
@@ -522,7 +522,7 @@ class HazelcastClient(object):
             listener_func (function): Function to be called when a distributed object is created or destroyed.
 
         Returns:
-            str: A registration id which is used as a key to remove the listener.
+            hazelcast.future.Future[str]: A registration id which is used as a key to remove the listener.
         """
         is_smart = self.config.smart_routing
         request = client_add_distributed_object_listener_codec.encode_request(is_smart)
@@ -552,7 +552,7 @@ class HazelcastClient(object):
             registration_id (str): The id of registered listener.
 
         Returns:
-            bool: ``True`` if registration is removed, ``False`` otherwise.
+            hazelcast.future.Future[bool]: ``True`` if registration is removed, ``False`` otherwise.
         """
         return self._listener_service.deregister_listener(registration_id)
 

--- a/hazelcast/invocation.py
+++ b/hazelcast/invocation.py
@@ -261,7 +261,7 @@ class InvocationService(object):
         self._listener_service.register_listener(request,
                                                  codec.decode_response,
                                                  lambda reg_id: None,
-                                                 lambda m: codec.handle(m, self._backup_event_handler))
+                                                 lambda m: codec.handle(m, self._backup_event_handler)).result()
 
     def _backup_event_handler(self, correlation_id):
         invocation = self._pending.get(correlation_id, None)

--- a/hazelcast/protocol/client_message.py
+++ b/hazelcast/protocol/client_message.py
@@ -187,6 +187,11 @@ class InboundMessage(object):
         self.start_frame = self.start_frame.next
         self._next_frame = self.start_frame
 
+    def __repr__(self):
+        message_type = self.get_message_type()
+        correlation_id = self.get_correlation_id()
+        return "InboundMessage(message_type=%s, correlation_id=%s)" % (message_type, correlation_id)
+
 
 NULL_FRAME_BUF = bytearray(SIZE_OF_FRAME_LENGTH_AND_FLAGS)
 LE_INT.pack_into(NULL_FRAME_BUF, 0, SIZE_OF_FRAME_LENGTH_AND_FLAGS)

--- a/hazelcast/proxy/list.py
+++ b/hazelcast/proxy/list.py
@@ -114,7 +114,7 @@ class List(PartitionSpecificProxy):
             item_removed_func (function): To be called when an item is deleted from this list.
 
         Returns:
-            str: A registration id which is used as a key to remove the listener.
+            hazelcast.future.Future[str]: A registration id which is used as a key to remove the listener.
         """
         request = list_add_listener_codec.encode_request(self.name, include_value, self._is_smart)
 
@@ -341,7 +341,7 @@ class List(PartitionSpecificProxy):
             registration_id (str): Id of the listener to be deleted.
 
         Returns:
-            bool: ``True`` if the item listener is removed, ``False`` otherwise.
+            hazelcast.future.Future[bool]: ``True`` if the item listener is removed, ``False`` otherwise.
         """
         return self._deregister_listener(registration_id)
 

--- a/hazelcast/proxy/multi_map.py
+++ b/hazelcast/proxy/multi_map.py
@@ -28,7 +28,7 @@ class MultiMap(Proxy):
             clear_all_func (function): Function to be called when entries are cleared from map.
 
         Returns:
-            str: A registration id which is used as a key to remove the listener.
+            hazelcast.future.Future[str]: A registration id which is used as a key to remove the listener.
         """
         if key:
             codec = multi_map_add_entry_listener_to_key_codec
@@ -318,7 +318,7 @@ class MultiMap(Proxy):
             registration_id (str): Id of registered listener.
 
         Returns:
-            bool: ``True`` if registration is removed, ``False`` otherwise.
+            hazelcast.future.Future[bool]: ``True`` if registration is removed, ``False`` otherwise.
         """
         return self._deregister_listener(registration_id)
 

--- a/hazelcast/proxy/queue.py
+++ b/hazelcast/proxy/queue.py
@@ -79,7 +79,7 @@ class Queue(PartitionSpecificProxy):
             item_removed_func (function): Function to be called when an item is deleted from this set.
 
         Returns:
-            str: A registration id which is used as a key to remove the listener.
+            hazelcast.future.Future[str]: A registration id which is used as a key to remove the listener.
         """
         codec = queue_add_listener_codec
         request = codec.encode_request(self.name, include_value, self._is_smart)
@@ -306,7 +306,7 @@ class Queue(PartitionSpecificProxy):
             registration_id (str): Id of the listener to be deleted.
 
         Returns:
-            bool: ``True`` if the item listener is removed, ``False`` otherwise.
+            hazelcast.future.Future[bool]: ``True`` if the item listener is removed, ``False`` otherwise.
         """
         return self._deregister_listener(registration_id)
 

--- a/hazelcast/proxy/replicated_map.py
+++ b/hazelcast/proxy/replicated_map.py
@@ -42,7 +42,7 @@ class ReplicatedMap(Proxy):
             clear_all_func (function): Function to be called when entries are cleared from map.
 
         Returns:
-            str: A registration id which is used as a key to remove the listener.
+            hazelcast.future.Future[str]: A registration id which is used as a key to remove the listener.
         """
         if key and predicate:
             codec = replicated_map_add_entry_listener_to_key_with_predicate_codec
@@ -268,7 +268,7 @@ class ReplicatedMap(Proxy):
             registration_id (str): Id of registered listener.
 
         Returns:
-            bool: ``True`` if registration is removed, ``False`` otherwise.
+            hazelcast.future.Future[bool]: ``True`` if registration is removed, ``False`` otherwise.
         """
         return self._deregister_listener(registration_id)
 

--- a/hazelcast/proxy/set.py
+++ b/hazelcast/proxy/set.py
@@ -63,7 +63,7 @@ class Set(PartitionSpecificProxy):
             item_removed_func (function): Function to be called when an item is deleted from this set.
 
         Returns:
-            str: A registration id which is used as a key to remove the listener.
+            hazelcast.future.Future[str]: A registration id which is used as a key to remove the listener.
         """
         request = set_add_listener_codec.encode_request(self.name, include_value, self._is_smart)
 
@@ -187,7 +187,7 @@ class Set(PartitionSpecificProxy):
             registration_id (str): Id of the listener to be deleted.
 
         Returns:
-            bool: ``True`` if the item listener is removed, ``False`` otherwise.
+            hazelcast.future.Future[bool]: ``True`` if the item listener is removed, ``False`` otherwise.
         """
         return self._deregister_listener(registration_id)
 

--- a/hazelcast/proxy/topic.py
+++ b/hazelcast/proxy/topic.py
@@ -25,7 +25,7 @@ class Topic(PartitionSpecificProxy):
             on_message (function): Function to be called when a message is published.
 
         Returns:
-            str: A registration id which is used as a key to remove the listener.
+            hazelcast.future.Future[str]: A registration id which is used as a key to remove the listener.
         """
         codec = topic_add_message_listener_codec
         request = codec.encode_request(self.name, self._is_smart)
@@ -62,6 +62,6 @@ class Topic(PartitionSpecificProxy):
             registration_id (str): Registration id of the listener to be removed.
 
         Returns:
-            bool: ``True`` if the listener is removed, ``False`` otherwise.
+            hazelcast.future.Future[bool]: ``True`` if the listener is removed, ``False`` otherwise.
         """
         return self._deregister_listener(registration_id)

--- a/tests/proxy/distributed_objects_test.py
+++ b/tests/proxy/distributed_objects_test.py
@@ -51,7 +51,7 @@ class DistributedObjectsTest(SingleMemberTestCase):
 
     def test_add_distributed_object_listener_object_created(self):
         collector = event_collector()
-        self.client.add_distributed_object_listener(listener_func=collector)
+        self.client.add_distributed_object_listener(listener_func=collector).result()
 
         self.client.get_map("test-map")
 
@@ -65,7 +65,7 @@ class DistributedObjectsTest(SingleMemberTestCase):
     def test_add_distributed_object_listener_object_destroyed(self):
         collector = event_collector()
         m = self.client.get_map("test-map")
-        self.client.add_distributed_object_listener(listener_func=collector)
+        self.client.add_distributed_object_listener(listener_func=collector).result()
 
         m.destroy()
 
@@ -78,7 +78,7 @@ class DistributedObjectsTest(SingleMemberTestCase):
 
     def test_add_distributed_object_listener_object_created_and_destroyed(self):
         collector = event_collector()
-        self.client.add_distributed_object_listener(listener_func=collector)
+        self.client.add_distributed_object_listener(listener_func=collector).result()
 
         m = self.client.get_map("test-map")
         m.destroy()
@@ -96,10 +96,10 @@ class DistributedObjectsTest(SingleMemberTestCase):
 
     def test_remove_distributed_object_listener(self):
         collector = event_collector()
-        reg_id = self.client.add_distributed_object_listener(listener_func=collector)
+        reg_id = self.client.add_distributed_object_listener(listener_func=collector).result()
         m = self.client.get_map("test-map")
 
-        response = self.client.remove_distributed_object_listener(reg_id)
+        response = self.client.remove_distributed_object_listener(reg_id).result()
         self.assertTrue(response)
         m.destroy()
 
@@ -111,4 +111,4 @@ class DistributedObjectsTest(SingleMemberTestCase):
         self.assertTrueEventually(assert_event)
 
     def test_remove_invalid_distributed_object_listener(self):
-        self.assertFalse(self.client.remove_distributed_object_listener("invalid-reg-id"))
+        self.assertFalse(self.client.remove_distributed_object_listener("invalid-reg-id").result())


### PR DESCRIPTION
Listener service was waiting for the result of the future
in a blocking way and, returning the registration id string.

This is not in line with our other APIs in which we provide
non-blocking API.

Also, the slight behaviour change applied to Java client is
ported to Python client. https://github.com/hazelcast/hazelcast/pull/17646