### PR TITLE
Add Python 3.8 and 3.9 to supported versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,9 @@ setup(
             'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
+            'Programming Language :: Python :: 3.8',
+            'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: Implementation :: CPython',
-            # 'Programming Language :: Python :: Implementation :: PyPy',
             'Topic :: Software Development :: Libraries :: Python Modules'
 
         ],


### PR DESCRIPTION
We could say this we also support these versions after running
the test suite on them successfully. See
http://jenkins.hazelcast.com/view/Clients/job/python3.8-lab-master/2/console
and
http://jenkins.hazelcast.com/view/Clients/job/python3.9-lab-master/1/console