### PR TITLE
Avoid possible race on BackupAcksTest

### DIFF
--- a/tests/backup_acks_test.py
+++ b/tests/backup_acks_test.py
@@ -30,10 +30,14 @@ class BackupAcksTest(HazelcastTestCase):
             cluster_name=self.cluster.id,
             fail_on_indeterminate_operation_state=True,
         )
-        m = self.client.get_map("test")
+        m = self.client.get_map("test").blocking()
+
+        # TODO: Remove the next line once
+        # https://github.com/hazelcast/hazelcast/issues/9398 is fixed
+        m.get(1)
 
         # it's enough for this operation to succeed
-        m.set(1, 2).result()
+        m.set(1, 2)
 
     def test_lost_backups_on_smart_mode_with_fail_on_indeterminate_operation_state(self):
         self.client = HazelcastClient(


### PR DESCRIPTION
It might be the case that the replica node could not finish its
partition table initialization when it receives the backup operation
request from the primary node. That can cause the backup request to
be dropped which can result in test failure since there won't be any
backup acks from the replica node.

This won't be needed when the https://github.com/hazelcast/hazelcast/issues/9398
is fixed. Until then, a call like `map.get(1)` should be enough as a
workaround.

See Also: https://github.com/hazelcast/hazelcast-nodejs-client/pull/693