### PR TITLE
Implement ObjectDataInput#skip_bytes

### DIFF
--- a/hazelcast/serialization/input.py
+++ b/hazelcast/serialization/input.py
@@ -36,7 +36,14 @@ class _ObjectDataInput(ObjectDataInput):
         self._pos += _len
 
     def skip_bytes(self, count):
-        raise NotImplementedError("skip_bytes not implemented!!!")
+        if count <= 0:
+            return 0
+
+        if self._pos + count > self._size:
+            count = self._size - self._pos
+
+        self._pos += count
+        return count
 
     def read_boolean(self, position=None):
         return self.read_byte(position) != 0

--- a/tests/serialization/input_test.py
+++ b/tests/serialization/input_test.py
@@ -51,6 +51,21 @@ class InputTestCase(unittest.TestCase):
         self.assertEqual(0, initial_pos)
         self.assertEqual(six.unichr(0x00e7), char)
 
+    def test_skip_bytes(self):
+        inp = _ObjectDataInput(bytearray(10))
+        self.assertEqual(0, inp.position())
+        self.assertEqual(4, inp.skip_bytes(4))
+        self.assertEqual(4, inp.position())
 
-if __name__ == '__main__':
-    unittest.main()
+    def test_skip_bytes_when_count_greater_than_remaining(self):
+        inp = _ObjectDataInput(bytearray(10))
+        inp.set_position(8)
+        self.assertEqual(2, inp.skip_bytes(4))
+        self.assertEqual(10, inp.position())
+
+    def test_skip_bytes_when_count_is_not_positive(self):
+        inp = _ObjectDataInput(bytearray(10))
+        self.assertEqual(0, inp.skip_bytes(0))
+        self.assertEqual(0, inp.position())
+        self.assertEqual(0, inp.skip_bytes(-1))
+        self.assertEqual(0, inp.position())


### PR DESCRIPTION
The Functionality of missing `skip_bytes` is implemented and some
unit tests are added.

Closes #255