### PR TITLE
Coalesce multiple client messages if possible before writing

### DIFF
--- a/tests/reactor_test.py
+++ b/tests/reactor_test.py
@@ -303,3 +303,19 @@ class AsyncoreConnectionTest(HazelcastTestCase):
             self.assertEqual(size, conn.receive_buffer_size)
         finally:
             conn._inner_close()
+
+    def test_send_buffer_size(self):
+        # When the SO_SNDBUF option is set, we should try
+        # to use that value while trying to write something.
+        config = _Config()
+        size = 64 * 1024
+        config.socket_options = [
+            (socket.SOL_SOCKET, socket.SO_SNDBUF, size)
+        ]
+        conn = AsyncoreConnection(MagicMock(map=dict()), None, None, self.member.address, config, None)
+
+        try:
+            # By default this is set to 128000
+            self.assertEqual(size, conn.send_buffer_size)
+        finally:
+            conn._inner_close()


### PR DESCRIPTION
This is an optimization for the non-blocking usage where there are
multiple in-flight messages. We now coalesce them into a single buffer
and try to write it to the wire.

Before coming up with this solution, I tried a couple of different ones.
Here is the list of the main ones, and why they didn't work out:

- Having a single, pre-allocated bytearray per connection, and copying
message bytes into it. Even with the usage of `memoryview`s, slicing and
copying were so expensive.

- Implementing framed outbound client messages, and writing frame bytes
into a write buffer in the reactor thread. That resulted in approx. %5
throughput increase for balanced workloads.

This way of implementation results in approx. %10 throughput increase for
balanced workloads.