### PR TITLE
Get rid of the unnecessary newlines in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,14 +88,8 @@ Usage
     # get request is received. Note that, the set request above was
     # blocking since it calls ".result()" on the returned Future, whereas
     # the get request below is non-blocking.
-
-
-    def callback(future):
-        # Outputs "value"
-        print(future.result())
-
-
-    distributed_map.get("key").add_done_callback(callback)
+    get_future = distributed_map.get("key")
+    get_future.add_done_callback(lambda future: print(future.result()))
 
     # Do other operations. The operations below won't wait for
     # the get request above to complete.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,14 +47,8 @@ Overview
     # get request is received. Note that, the set request above was
     # blocking since it calls ".result()" on the returned Future, whereas
     # the get request below is non-blocking.
-
-
-    def callback(future):
-        # Outputs "value"
-        print(future.result())
-
-
-    distributed_map.get("key").add_done_callback(callback)
+    get_future = distributed_map.get("key")
+    get_future.add_done_callback(lambda future: print(future.result()))
 
     # Do other operations. The operations below won't wait for
     # the get request above to complete.
@@ -63,7 +57,6 @@ Overview
 
     # Shutdown the client.
     client.shutdown()
-
 
 
 .. toctree::


### PR DESCRIPTION
As pointed out in the code review for #266, there were
unnecessary newlines around the top-level callback function
definition, but we left it as it is since PEP8 recommends
such newlines.

Changed that part to use lambdas so that we can get rid of
the newlines.