### PR TITLE
Capture the address in the loop of connect_to_all_members timer

### DIFF
--- a/hazelcast/connection.py
+++ b/hazelcast/connection.py
@@ -255,7 +255,12 @@ class ConnectionManager(object):
                         break
 
                     if not self.get_connection(member.uuid):
-                        self._get_or_connect(address).add_done_callback(lambda f: connecting_addresses.discard(address))
+                        # Bind the address to the value
+                        # in this loop iteration
+                        def cb(_, address=address):
+                            connecting_addresses.discard(address)
+
+                        self._get_or_connect(address).add_done_callback(cb)
 
             self._connect_all_members_timer = self._reactor.add_timer(1, run)
 

--- a/hazelcast/cp.py
+++ b/hazelcast/cp.py
@@ -409,7 +409,7 @@ class ProxySessionManager(object):
             for session in list(self._sessions.values()):
                 if session.is_in_use():
 
-                    def cb(heartbeat_future):
+                    def cb(heartbeat_future, session=session):
                         if heartbeat_future.is_success():
                             return
 

--- a/hazelcast/listener.py
+++ b/hazelcast/listener.py
@@ -88,7 +88,7 @@ class ListenerService(object):
                 invocation = Invocation(deregister_request, connection=connection, timeout=six.MAXSIZE, urgent=True)
                 self._invocation_service.invoke(invocation)
 
-                def handler(f):
+                def handler(f, connection=connection):
                     e = f.exception()
                     if e:
                         if isinstance(e, (HazelcastClientNotActiveError, IOError, TargetDisconnectedError)):


### PR DESCRIPTION
There was a bug in the implementation of the connect_to_all_members
timer. In the loop, we were not capturing the address variable
correctly. As recommended in https://docs.python.org/3/faq/programming.html#why-do-lambdas-defined-in-a-loop-with-different-values-all-return-the-same-result
we are now binding the variable while creating the closure.