### PR TITLE
Correctly handle memberlist in case of split brain

### DIFF
--- a/hazelcast/listener.py
+++ b/hazelcast/listener.py
@@ -188,6 +188,7 @@ class ClusterViewListenerService(object):
         self._listener_added_connection = connection
         request = client_add_cluster_view_listener_codec.encode_request()
         invocation = Invocation(request, connection=connection, event_handler=self._handler(connection), urgent=True)
+        self._cluster_service.clear_member_list_version()
         self._invocation_service.invoke(invocation)
 
         def callback(f):


### PR DESCRIPTION
Port of the following Java PR

https://github.com/hazelcast/hazelcast/pull/17147

I couldn't add the test in that PR because that requires blocking
the communication between some members, which is not possible via
the remote controller.