### PR TITLE
Add ability to use enum literals in config

### DIFF
--- a/docs/client_connection_strategy.rst
+++ b/docs/client_connection_strategy.rst
@@ -38,6 +38,8 @@ starting and reconnecting modes.
 
     client = hazelcast.HazelcastClient(
         async_start=False,
+        # You can also set this to "ON"
+        # without importing anything.
         reconnect_mode=ReconnectMode.ON
     )
 

--- a/docs/securing_client_connection.rst
+++ b/docs/securing_client_connection.rst
@@ -51,6 +51,8 @@ configuration and then go over the configuration options one by one:
         ssl_certfile="/home/hazelcast/certfile.pem",
         ssl_keyfile="/home/hazelcast/keyfile.pem",
         ssl_password="keyfile-password",
+        # You can also set this to "TLSv1_3"
+        # without importing anything.
         ssl_protocol=SSLProtocol.TLSv1_3,
         ssl_ciphers="DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA"
     )
@@ -188,6 +190,8 @@ follows:
     from hazelcast.config import SSLProtocol
 
     client = hazelcast.HazelcastClient(
+        # You can also set this to "TLSv1_3"
+        # without importing anything.
         ssl_protocol=SSLProtocol.TLSv1_3
     )
 

--- a/docs/securing_client_connection.rst
+++ b/docs/securing_client_connection.rst
@@ -190,8 +190,6 @@ follows:
     from hazelcast.config import SSLProtocol
 
     client = hazelcast.HazelcastClient(
-        # You can also set this to "TLSv1_3"
-        # without importing anything.
         ssl_protocol=SSLProtocol.TLSv1_3
     )
 

--- a/docs/using_python_client_with_hazelcast_imdg.rst
+++ b/docs/using_python_client_with_hazelcast_imdg.rst
@@ -1745,6 +1745,8 @@ configuration, its default value is used.
                 "invalidate_on_change": True,
                 "time_to_live": 60,
                 "max_idle": 30,
+                # You can also set these to "OBJECT"
+                # or "LRU" without importing anything.
                 "in_memory_format": InMemoryFormat.OBJECT,
                 "eviction_policy": EvictionPolicy.LRU,
                 "eviction_max_size": 100,

--- a/docs/using_python_client_with_hazelcast_imdg.rst
+++ b/docs/using_python_client_with_hazelcast_imdg.rst
@@ -1746,7 +1746,7 @@ configuration, its default value is used.
                 "time_to_live": 60,
                 "max_idle": 30,
                 # You can also set these to "OBJECT"
-                # or "LRU" without importing anything.
+                # and "LRU" without importing anything.
                 "in_memory_format": InMemoryFormat.OBJECT,
                 "eviction_policy": EvictionPolicy.LRU,
                 "eviction_max_size": 100,

--- a/hazelcast/client.py
+++ b/hazelcast/client.py
@@ -78,8 +78,9 @@ class HazelcastClient(object):
             it will be encoded as UTF-8 before using it to decrypt the key.
             Alternatively a string, bytes, or bytearray value may be supplied
             directly as the password.
-        ssl_protocol (int): Protocol version used in SSL communication.
-            By default, set to ``SSLProtocol.TLSv1_2``.
+        ssl_protocol (int|str): Protocol version used in SSL communication.
+            By default, set to ``TLSv1_2``. See the
+            :class:`hazelcast.config.SSLProtocol` for possible values.
         ssl_ciphers (str): String in the OpenSSL cipher list format to set the
             available ciphers for sockets. More than one cipher can be set by
             separating them with a colon.
@@ -91,8 +92,9 @@ class HazelcastClient(object):
             cluster and becomes ready. If set to ``False``, :class:`HazelcastClient`
             will block until a cluster connection established and it is ready to use
             the client instance. By default, set to ``False``.
-        reconnect_mode (int): Defines how a client reconnects to cluster after a
-            disconnect. By default, set to ``ReconnectMode.ON``.
+        reconnect_mode (int|str): Defines how a client reconnects to cluster after a
+            disconnect. By default, set to ``ON``. See the
+            :class:`hazelcast.config.ReconnectMode` for possible values.
         retry_initial_backoff (float): Wait period in seconds after the first failure
             before retrying. Must be non-negative. By default, set to ``1.0``.
         retry_max_backoff (float): Upper bound for the backoff interval in seconds.
@@ -164,9 +166,10 @@ class HazelcastClient(object):
             set to ``True``.
         is_big_endian (bool): Defines if big-endian is used as the byte order
             for the serialization. By default, set to ``True``.
-        default_int_type (int): Defines how the ``int``/``long`` type is
+        default_int_type (int|str): Defines how the ``int``/``long`` type is
             represented on the cluster side. By default, it is serialized
-            as ``IntType.INT`` (``32`` bits).
+            as ``INT`` (``32`` bits). See the
+            :class:`hazelcast.config.IntType` for possible values.
         global_serializer (hazelcast.serialization.api.StreamSerializer):
             Defines the global serializer. This serializer
             is registered as a fallback serializer to handle all other objects
@@ -198,16 +201,18 @@ class HazelcastClient(object):
             - **invalidate_on_change** (bool): Enables cluster-assisted invalidate
               on change behavior. When set to ``True``, entries are invalidated
               when they are changed in cluster. By default, set to ``True``.
-            - **in_memory_format** (int): Specifies in which format data will be
-              stored in the Near Cache. By default, set to ``InMemoryFormat.BINARY``.
+            - **in_memory_format** (int|str): Specifies in which format data will be
+              stored in the Near Cache. By default, set to ``BINARY``. See the
+              :class:`hazelcast.config.InMemoryFormat` for possible values.
             - **time_to_live** (float): Maximum number of seconds that an entry can
               stay in cache. When not set, entries won't be evicted due
               to expiration.
             - **max_idle** (float): Maximum number of seconds that an entry can stay
               in the Near Cache until it is accessed. When not set, entries won't be
               evicted due to inactivity.
-            - **eviction_policy** (int): Defines eviction policy configuration.
-              By default, set to ``EvictionPolicy.LRU``.
+            - **eviction_policy** (int|str): Defines eviction policy configuration.
+              By default, set to ``LRU``. See the
+              :class:`hazelcast.config.EvictionPolicy` for possible values.
             - **eviction_max_size** (int): Defines maximum number of entries kept in
               the memory before eviction kicks in. By default, set to ``10000``.
             - **eviction_sampling_count** (int): Number of random entries that are

--- a/hazelcast/config.py
+++ b/hazelcast/config.py
@@ -216,7 +216,7 @@ class BitmapIndexOptions(object):
 
     @unique_key.setter
     def unique_key(self, value):
-        try_to_set_enum_value(self, value, QueryConstants, "_unique_key")
+        self._unique_key = try_to_set_enum_value(value, QueryConstants)
 
     @property
     def unique_key_transformation(self):
@@ -224,7 +224,7 @@ class BitmapIndexOptions(object):
     
     @unique_key_transformation.setter
     def unique_key_transformation(self, value):
-        try_to_set_enum_value(self, value, UniqueKeyTransformation, "_unique_key_transformation")
+        self._unique_key_transformation = try_to_set_enum_value(value, UniqueKeyTransformation)
 
     @classmethod
     def from_dict(cls, d):
@@ -282,7 +282,7 @@ class IndexConfig(object):
 
     @type.setter
     def type(self, value):
-        try_to_set_enum_value(self, value, IndexType, "_type")
+        self._type = try_to_set_enum_value(value, IndexType)
 
     @property
     def attributes(self):
@@ -648,7 +648,7 @@ class _Config(object):
 
     @ssl_protocol.setter
     def ssl_protocol(self, value):
-        try_to_set_enum_value(self, value, SSLProtocol, "_ssl_protocol")
+        self._ssl_protocol = try_to_set_enum_value(value, SSLProtocol)
 
     @property
     def ssl_ciphers(self):
@@ -689,7 +689,7 @@ class _Config(object):
 
     @reconnect_mode.setter
     def reconnect_mode(self, value):
-        try_to_set_enum_value(self, value, ReconnectMode, "_reconnect_mode")
+        self._reconnect_mode = try_to_set_enum_value(value, ReconnectMode)
 
     @property
     def retry_initial_backoff(self):
@@ -864,7 +864,7 @@ class _Config(object):
 
     @default_int_type.setter
     def default_int_type(self, value):
-        try_to_set_enum_value(self, value, IntType, "_default_int_type")
+        self._default_int_type = try_to_set_enum_value(value, IntType)
 
     @property
     def global_serializer(self):
@@ -1168,7 +1168,7 @@ class _NearCacheConfig(object):
 
     @in_memory_format.setter
     def in_memory_format(self, value):
-        try_to_set_enum_value(self, value, InMemoryFormat, "_in_memory_format")
+        self._in_memory_format = try_to_set_enum_value(value, InMemoryFormat)
 
     @property
     def time_to_live(self):
@@ -1202,7 +1202,7 @@ class _NearCacheConfig(object):
 
     @eviction_policy.setter
     def eviction_policy(self, value):
-        try_to_set_enum_value(self, value, EvictionPolicy, "_eviction_policy")
+        self._eviction_policy = try_to_set_enum_value(value, EvictionPolicy)
 
     @property
     def eviction_max_size(self):

--- a/hazelcast/config.py
+++ b/hazelcast/config.py
@@ -4,7 +4,7 @@ from hazelcast import six
 from hazelcast.errors import InvalidConfigurationError
 from hazelcast.serialization.api import StreamSerializer, IdentifiedDataSerializable, Portable
 from hazelcast.serialization.portable.classdef import ClassDefinition
-from hazelcast.util import check_not_none, number_types, LoadBalancer, none_type, get_attr_name
+from hazelcast.util import check_not_none, number_types, LoadBalancer, none_type, try_to_set_enum_value
 
 
 class IntType(object):
@@ -216,21 +216,15 @@ class BitmapIndexOptions(object):
 
     @unique_key.setter
     def unique_key(self, value):
-        if get_attr_name(QueryConstants, value):
-            self._unique_key = value
-        else:
-            raise TypeError("unique_key must be of type QueryConstants")
-    
+        try_to_set_enum_value(self, value, QueryConstants, "_unique_key")
+
     @property
     def unique_key_transformation(self):
         return self._unique_key_transformation
     
     @unique_key_transformation.setter
     def unique_key_transformation(self, value):
-        if get_attr_name(UniqueKeyTransformation, value):
-            self._unique_key_transformation = value
-        else:
-            raise TypeError("unique_key_transformation must be of type UniqueKeyTransformation")
+        try_to_set_enum_value(self, value, UniqueKeyTransformation, "_unique_key_transformation")
 
     @classmethod
     def from_dict(cls, d):
@@ -288,10 +282,7 @@ class IndexConfig(object):
 
     @type.setter
     def type(self, value):
-        if get_attr_name(IndexType, value):
-            self._type = value
-        else:
-            raise TypeError("type must be of type IndexType")
+        try_to_set_enum_value(self, value, IndexType, "_type")
 
     @property
     def attributes(self):
@@ -300,6 +291,8 @@ class IndexConfig(object):
     @attributes.setter
     def attributes(self, value):
         if isinstance(value, list):
+            for attribute in value:
+                IndexUtil.validate_attribute(attribute)
             self._attributes = value
         else:
             raise TypeError("attributes must be a list")
@@ -655,10 +648,7 @@ class _Config(object):
 
     @ssl_protocol.setter
     def ssl_protocol(self, value):
-        if get_attr_name(SSLProtocol, value):
-            self._ssl_protocol = value
-        else:
-            raise TypeError("ssl_protocol must be of type SSLProtocol")
+        try_to_set_enum_value(self, value, SSLProtocol, "_ssl_protocol")
 
     @property
     def ssl_ciphers(self):
@@ -699,10 +689,7 @@ class _Config(object):
 
     @reconnect_mode.setter
     def reconnect_mode(self, value):
-        if get_attr_name(ReconnectMode, value):
-            self._reconnect_mode = value
-        else:
-            raise TypeError("reconnect_mode must be a type of ReconnectMode")
+        try_to_set_enum_value(self, value, ReconnectMode, "_reconnect_mode")
 
     @property
     def retry_initial_backoff(self):
@@ -877,10 +864,7 @@ class _Config(object):
 
     @default_int_type.setter
     def default_int_type(self, value):
-        if get_attr_name(IntType, value):
-            self._default_int_type = value
-        else:
-            raise TypeError("default_int_type must be of type IntType")
+        try_to_set_enum_value(self, value, IntType, "_default_int_type")
 
     @property
     def global_serializer(self):
@@ -1184,10 +1168,7 @@ class _NearCacheConfig(object):
 
     @in_memory_format.setter
     def in_memory_format(self, value):
-        if get_attr_name(InMemoryFormat, value):
-            self._in_memory_format = value
-        else:
-            raise TypeError("in_memory_format must be of the type InMemoryFormat")
+        try_to_set_enum_value(self, value, InMemoryFormat, "_in_memory_format")
 
     @property
     def time_to_live(self):
@@ -1221,10 +1202,7 @@ class _NearCacheConfig(object):
 
     @eviction_policy.setter
     def eviction_policy(self, value):
-        if get_attr_name(EvictionPolicy, value):
-            self._eviction_policy = value
-        else:
-            raise TypeError("eviction_policy must be of type EvictionPolicy")
+        try_to_set_enum_value(self, value, EvictionPolicy, "_eviction_policy")
 
     @property
     def eviction_max_size(self):

--- a/hazelcast/config.py
+++ b/hazelcast/config.py
@@ -4,7 +4,7 @@ from hazelcast import six
 from hazelcast.errors import InvalidConfigurationError
 from hazelcast.serialization.api import StreamSerializer, IdentifiedDataSerializable, Portable
 from hazelcast.serialization.portable.classdef import ClassDefinition
-from hazelcast.util import check_not_none, number_types, LoadBalancer, none_type, try_to_set_enum_value
+from hazelcast.util import check_not_none, number_types, LoadBalancer, none_type, try_to_get_enum_value
 
 
 class IntType(object):
@@ -216,7 +216,7 @@ class BitmapIndexOptions(object):
 
     @unique_key.setter
     def unique_key(self, value):
-        self._unique_key = try_to_set_enum_value(value, QueryConstants)
+        self._unique_key = try_to_get_enum_value(value, QueryConstants)
 
     @property
     def unique_key_transformation(self):
@@ -224,7 +224,7 @@ class BitmapIndexOptions(object):
     
     @unique_key_transformation.setter
     def unique_key_transformation(self, value):
-        self._unique_key_transformation = try_to_set_enum_value(value, UniqueKeyTransformation)
+        self._unique_key_transformation = try_to_get_enum_value(value, UniqueKeyTransformation)
 
     @classmethod
     def from_dict(cls, d):
@@ -282,7 +282,7 @@ class IndexConfig(object):
 
     @type.setter
     def type(self, value):
-        self._type = try_to_set_enum_value(value, IndexType)
+        self._type = try_to_get_enum_value(value, IndexType)
 
     @property
     def attributes(self):
@@ -648,7 +648,7 @@ class _Config(object):
 
     @ssl_protocol.setter
     def ssl_protocol(self, value):
-        self._ssl_protocol = try_to_set_enum_value(value, SSLProtocol)
+        self._ssl_protocol = try_to_get_enum_value(value, SSLProtocol)
 
     @property
     def ssl_ciphers(self):
@@ -689,7 +689,7 @@ class _Config(object):
 
     @reconnect_mode.setter
     def reconnect_mode(self, value):
-        self._reconnect_mode = try_to_set_enum_value(value, ReconnectMode)
+        self._reconnect_mode = try_to_get_enum_value(value, ReconnectMode)
 
     @property
     def retry_initial_backoff(self):
@@ -864,7 +864,7 @@ class _Config(object):
 
     @default_int_type.setter
     def default_int_type(self, value):
-        self._default_int_type = try_to_set_enum_value(value, IntType)
+        self._default_int_type = try_to_get_enum_value(value, IntType)
 
     @property
     def global_serializer(self):
@@ -1168,7 +1168,7 @@ class _NearCacheConfig(object):
 
     @in_memory_format.setter
     def in_memory_format(self, value):
-        self._in_memory_format = try_to_set_enum_value(value, InMemoryFormat)
+        self._in_memory_format = try_to_get_enum_value(value, InMemoryFormat)
 
     @property
     def time_to_live(self):
@@ -1202,7 +1202,7 @@ class _NearCacheConfig(object):
 
     @eviction_policy.setter
     def eviction_policy(self, value):
-        self._eviction_policy = try_to_set_enum_value(value, EvictionPolicy)
+        self._eviction_policy = try_to_get_enum_value(value, EvictionPolicy)
 
     @property
     def eviction_max_size(self):

--- a/hazelcast/proxy/map.py
+++ b/hazelcast/proxy/map.py
@@ -167,9 +167,21 @@ class Map(Proxy):
 
         Args:
             attributes (list[str]): List of indexed attributes.
-            index_type (int): Type of the index.
+            index_type (int|str): Type of the index. By default, set to ``SORTED``.
+                See the :class:`hazelcast.config.IndexType` for possible values.
             name (str): Name of the index.
             bitmap_index_options (dict): Bitmap index options.
+
+                - **unique_key:** (str): The unique key attribute is used as a
+                  source of values which uniquely identify each entry being
+                  inserted into an index. Defaults to ``KEY_ATTRIBUTE_NAME``.
+                  See the :class:`hazelcast.config.QueryConstants` for possible
+                  values.
+                - **unique_key_transformation** (int|str): The transformation is
+                  applied to every value extracted from the unique key attribue.
+                  Defaults to ``OBJECT``. See the
+                  :class:`hazelcast.config.UniqueKeyTransformation` for possible
+                  values.
 
         Returns:
             hazelcast.future.Future[None]:

--- a/hazelcast/util.py
+++ b/hazelcast/util.py
@@ -209,6 +209,31 @@ def get_attr_name(cls, value):
     return None
 
 
+def _get_enum_value(cls, key):
+    if isinstance(key, six.string_types):
+        return getattr(cls, key, None)
+    return None
+
+
+def try_to_set_enum_value(obj, value, enum_class, field_name):
+    if get_attr_name(enum_class, value):
+        # If the value given by the user corresponds
+        # to value of the one of the enum members,
+        # it is okay to set it directly
+        setattr(obj, field_name, value)
+    else:
+        # We couldn't find a enum member name for the
+        # given value. Try to match the given config
+        # option with enum member names and get value
+        # associated with it.
+        enum_value = _get_enum_value(enum_class, value)
+        if enum_value is not None:
+            setattr(obj, field_name, enum_value)
+        else:
+            raise TypeError("%s must be equal to one of the values or "
+                            "names of the members of the %s" % (field_name[1:], enum_class.__name__))
+
+
 number_types = (six.integer_types, float)
 none_type = type(None)
 

--- a/hazelcast/util.py
+++ b/hazelcast/util.py
@@ -215,7 +215,7 @@ def _get_enum_value(cls, key):
     return None
 
 
-def try_to_set_enum_value(value, enum_class):
+def try_to_get_enum_value(value, enum_class):
     if get_attr_name(enum_class, value):
         # If the value given by the user corresponds
         # to value of the one of the enum members,

--- a/hazelcast/util.py
+++ b/hazelcast/util.py
@@ -215,12 +215,12 @@ def _get_enum_value(cls, key):
     return None
 
 
-def try_to_set_enum_value(obj, value, enum_class, field_name):
+def try_to_set_enum_value(value, enum_class):
     if get_attr_name(enum_class, value):
         # If the value given by the user corresponds
         # to value of the one of the enum members,
         # it is okay to set it directly
-        setattr(obj, field_name, value)
+        return value
     else:
         # We couldn't find a enum member name for the
         # given value. Try to match the given config
@@ -228,10 +228,10 @@ def try_to_set_enum_value(obj, value, enum_class, field_name):
         # associated with it.
         enum_value = _get_enum_value(enum_class, value)
         if enum_value is not None:
-            setattr(obj, field_name, enum_value)
+            return enum_value
         else:
             raise TypeError("%s must be equal to one of the values or "
-                            "names of the members of the %s" % (field_name[1:], enum_class.__name__))
+                            "names of the members of the %s" % (value, enum_class.__name__))
 
 
 number_types = (six.integer_types, float)


### PR DESCRIPTION
This PR adds the ability to use enum literals in the config
to make it easier to set these options, without importing anything.

When a value for enum is set, we first check if it is an actual
value for an enum(i.e., 0 for SSLProtocol.SSLv2). If it is, we
directly use that. If not, and the given configuration value is
a string, we try to get the enum member associated with that name.
If it matches to any member(i.e., SSLv2 for SSLProtocol.SSLv2),
we get the value associated with it and set it as the value.

If none of the above works, we throw TypeError as before.

Closes #228 