### PR TITLE
Increase assertion timeout for set_ttl test

### DIFF
--- a/tests/proxy/map_test.py
+++ b/tests/proxy/map_test.py
@@ -445,7 +445,7 @@ class MapTest(SingleMemberTestCase):
         def evicted():
             self.assertFalse(self.map.contains_key("key"))
 
-        self.assertTrueEventually(evicted, 1)
+        self.assertTrueEventually(evicted, 5)
 
     def test_size(self):
         self._fill_map()


### PR DESCRIPTION
Increased the assertion timeout for the set_ttl test from 1 second
to 5 seconds. It is also 5 seconds in the master branch.

Closes #277