### PR TITLE
[3.12.z] - Fix remove_distributed_object_listener test

### DIFF
--- a/tests/proxy/distributed_objects_test.py
+++ b/tests/proxy/distributed_objects_test.py
@@ -1,3 +1,5 @@
+import time
+
 import hazelcast
 from hazelcast.core import DistributedObjectEventType
 
@@ -95,16 +97,21 @@ class DistributedObjectsTest(SingleMemberTestCase):
         reg_id = self.client.add_distributed_object_listener(listener_func=collector)
         m = self.client.get_map("test-map")
 
-        response = self.client.remove_distributed_object_listener(reg_id)
-        self.assertTrue(response)
-        m.destroy()
-
-        # only map creation should be notified
         def assert_event():
             self.assertEqual(1, len(collector.events))
             event = collector.events[0]
             self.assertDistributedObjectEvent(event, "test-map", MAP_SERVICE, DistributedObjectEventType.CREATED)
+
         self.assertTrueEventually(assert_event)
+
+        response = self.client.remove_distributed_object_listener(reg_id)
+        self.assertTrue(response)
+        m.destroy()
+
+        time.sleep(1)
+
+        # We should only receive the map created event
+        assert_event()
 
     def test_remove_invalid_distributed_object_listener(self):
         self.assertFalse(self.client.remove_distributed_object_listener("invalid-reg-id"))


### PR DESCRIPTION
In the test, we were creating a map, and then immediately remove
the listener. This works most of the time, but sometimes, event
messages may arrive later, after we got a response from the get_map
request. If we remove the listener after the get_map response, but
before the late event, we will miss the event.

Test is modified to wait for the created event, then removing the
listener, then sleeping for a while and checking that there are no
further events.

Backport of #261
Closes #280