### PR TITLE
Add more logging for flaky add_distributed_object_listener_object_des…

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -58,13 +58,16 @@ class HazelcastTestCase(unittest.TestCase):
 
     def assertTrueEventually(self, assertion, timeout=30):
         timeout_time = time.time() + timeout
+        last_error = None
         while time.time() < timeout_time:
             try:
                 assertion()
                 return
-            except AssertionError:
+            except AssertionError as err:
+                last_error = err
                 time.sleep(0.1)
-        raise
+
+        raise last_error or Exception("Could not enter the assertion loop!")
 
     def assertSetEventually(self, event, timeout=5):
         is_set = event.wait(timeout)

--- a/tests/util.py
+++ b/tests/util.py
@@ -86,3 +86,15 @@ def open_connection_to_address(client, uuid):
     m.put(key, 0)
     m.destroy()
 
+
+class LoggingContext(object):
+    def __init__(self, logger, level):
+        self.logger = logger
+        self.level = level
+        self.old_level = logger.level
+
+    def __enter__(self):
+        self.logger.setLevel(self.level)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.logger.setLevel(self.old_level)


### PR DESCRIPTION
…troyed test

The test failed again recently on the nightly test runner. I could not
reproduce the problem locally, or see a problem in the implementation or test.

To understand the situation better, improved the `assertTrueEventually` utility
method to raise the last error occured and added a context manager
to change the log level for the duration of the test.

Also, improved some parts of the `add_distributed_object_listener` by removing
some unncessary closure definitions.