### PR TITLE
Increase cluster connection timeout

### DIFF
--- a/docs/client_connection_strategy.rst
+++ b/docs/client_connection_strategy.rst
@@ -58,7 +58,7 @@ below.
         retry_max_backoff=15,
         retry_multiplier=1.5,
         retry_jitter=0.2,
-        cluster_connect_timeout=20
+        cluster_connect_timeout=120
     )
 
 The following are configuration element descriptions:
@@ -75,7 +75,7 @@ The following are configuration element descriptions:
   default value is ``0``. It must be in range ``0`` to ``1``.
 - ``cluster_connect_timeout``: Timeout value in seconds for the client
   to give up to connect to the current cluster. Its default value is
-  ``20``.
+  ``120``.
 
 A pseudo-code is as follows:
 

--- a/hazelcast/client.py
+++ b/hazelcast/client.py
@@ -122,7 +122,7 @@ class HazelcastClient(object):
             set to ``1.0``.
         cluster_connect_timeout (float): Timeout value in seconds for the client to
             give up a connection attempt to the cluster. Must be non-negative.
-            By default, set to `20.0`.
+            By default, set to `120.0`.
         portable_version (int): Default value for the portable version if the
             class does not have the :func:`get_portable_version` method. Portable
             versions are used to differentiate two versions of the

--- a/hazelcast/config.py
+++ b/hazelcast/config.py
@@ -532,7 +532,7 @@ class _Config(object):
         self._retry_max_backoff = 30.0
         self._retry_jitter = 0.0
         self._retry_multiplier = 1.0
-        self._cluster_connect_timeout = 20.0
+        self._cluster_connect_timeout = 120.0
         self._portable_version = 0
         self._data_serializable_factories = {}
         self._portable_factories = {}

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -306,7 +306,7 @@ class ConfigTest(unittest.TestCase):
 
     def test_cluster_connect_timeout(self):
         config = self.config
-        self.assertEqual(20, config.cluster_connect_timeout)
+        self.assertEqual(120, config.cluster_connect_timeout)
 
         with self.assertRaises(ValueError):
             config.cluster_connect_timeout = -1


### PR DESCRIPTION
As discussed within the team, cluster connection timeout is
increased to 120 seconds to handle cluster restarts correctly
without an extra configuration in environments like kubernetes.