### PR TITLE
Make client.config private

### DIFF
--- a/hazelcast/cluster.py
+++ b/hazelcast/cluster.py
@@ -108,10 +108,9 @@ class ClusterService(object):
 
 
 class _InternalClusterService(object):
-    def __init__(self, client):
+    def __init__(self, client, config):
         self._client = client
         self._connection_manager = None
-        config = client.config
         self._labels = frozenset(config.labels)
         self._listeners = {}
         self._member_list_snapshot = _EMPTY_SNAPSHOT

--- a/hazelcast/invocation.py
+++ b/hazelcast/invocation.py
@@ -84,8 +84,7 @@ class Invocation(object):
 class InvocationService(object):
     _CLEAN_RESOURCES_PERIOD = 0.1
 
-    def __init__(self, client, reactor):
-        config = client.config
+    def __init__(self, client, config, reactor):
         smart_routing = config.smart_routing
         if smart_routing:
             self._do_invoke = self._invoke_smart

--- a/hazelcast/lifecycle.py
+++ b/hazelcast/lifecycle.py
@@ -84,12 +84,11 @@ class LifecycleService(object):
 
 
 class _InternalLifecycleService(object):
-    def __init__(self, client):
-        self._client = client
+    def __init__(self, config):
         self.running = False
         self._listeners = {}
 
-        lifecycle_listeners = client.config.lifecycle_listeners
+        lifecycle_listeners = config.lifecycle_listeners
         if lifecycle_listeners:
             for listener in lifecycle_listeners:
                 self.add_listener(listener)

--- a/hazelcast/listener.py
+++ b/hazelcast/listener.py
@@ -40,11 +40,11 @@ class _EventRegistration(object):
 
 
 class ListenerService(object):
-    def __init__(self, client, connection_manager, invocation_service):
+    def __init__(self, client, config, connection_manager, invocation_service):
         self._client = client
         self._connection_manager = connection_manager
         self._invocation_service = invocation_service
-        self._is_smart = client.config.smart_routing
+        self._is_smart = config.smart_routing
         self._active_registrations = {}  # Dict of user_registration_id, ListenerRegistration
         self._registration_lock = threading.RLock()
         self._event_handlers = {}

--- a/hazelcast/near_cache.py
+++ b/hazelcast/near_cache.py
@@ -261,15 +261,15 @@ class NearCache(dict):
 
 
 class NearCacheManager(object):
-    def __init__(self, client, serialization_service):
-        self._client = client
+    def __init__(self, config, serialization_service):
+        self._config = config
         self._serialization_service = serialization_service
         self._caches = {}
 
     def get_or_create_near_cache(self, name):
         near_cache = self._caches.get(name, None)
         if not near_cache:
-            near_cache_config = self._client.config.near_caches.get(name, None)
+            near_cache_config = self._config.near_caches.get(name, None)
             if not near_cache_config:
                 raise ValueError("Cannot find a near cache configuration with the name '%s'" % name)
 

--- a/hazelcast/statistics.py
+++ b/hazelcast/statistics.py
@@ -25,13 +25,14 @@ class Statistics(object):
 
     _DEFAULT_PROBE_VALUE = 0
 
-    def __init__(self, client, reactor, connection_manager, invocation_service, near_cache_manager):
+    def __init__(
+        self, client, config, reactor, connection_manager, invocation_service, near_cache_manager
+    ):
         self._client = client
         self._reactor = reactor
         self._connection_manager = connection_manager
         self._invocation_service = invocation_service
         self._near_cache_manager = near_cache_manager
-        config = client.config
         self._enabled = config.statistics_enabled
         self._period = config.statistics_period
         self._statistics_timer = None

--- a/tests/invocation_test.py
+++ b/tests/invocation_test.py
@@ -150,8 +150,8 @@ class InvocationTest(unittest.TestCase):
         )
 
     def _start_service(self, config=_Config()):
-        c = MagicMock(config=config)
-        invocation_service = InvocationService(c, c._reactor)
+        c = MagicMock()
+        invocation_service = InvocationService(c, config, c._reactor)
         self.service = invocation_service
         invocation_service.init(
             c._internal_partition_service, c._connection_manager, c._listener_service

--- a/tests/proxy/map_nearcache_test.py
+++ b/tests/proxy/map_nearcache_test.py
@@ -23,7 +23,7 @@ class MapTest(SingleMemberTestCase):
         return config
 
     def setUp(self):
-        name = list(self.client.config.near_caches.keys())[0]
+        name = list(self.client._config.near_caches.keys())[0]
         self.map = self.client.get_map(name).blocking()
 
     def tearDown(self):

--- a/tests/statistics_test.py
+++ b/tests/statistics_test.py
@@ -103,7 +103,7 @@ class StatisticsTest(HazelcastTestCase):
         # in different platforms. So, first try to get these statistics and then check the
         # response content
 
-        s = Statistics(client, None, None, None, None)
+        s = Statistics(client, client._config, None, None, None, None)
         psutil_stats = s._get_os_and_runtime_stats()
         for stat_name in psutil_stats:
             self.assertEqual(1, result.count(stat_name))


### PR DESCRIPTION
I don't like the idea of making the config public because it is
not read-only after the creation yet. Instead, it is made private
for the time being. We may reconsider making it public later.