### PR TITLE
Update copyright year to 2021

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -239,7 +239,7 @@ License
 Copyright
 ---------
 
-Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
 
 Visit `www.hazelcast.com <http://www.hazelcast.com>`__ for more
 information.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,7 +64,7 @@ master_doc = "index"
 
 # General information about the project.
 project = u"Hazelcast Python Client"
-copyright = u"2020, Hazelcast Inc."
+copyright = u"2021, Hazelcast Inc."
 author = u"Hazelcast Inc. Developers"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/copyright.rst
+++ b/docs/copyright.rst
@@ -1,7 +1,7 @@
 Copyright
 =========
 
-Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
 
 Visit `www.hazelcast.com <http://www.hazelcast.com>`__ for more
 information.

--- a/tests/proxy/cp/hazelcast_cpsubsystem.xml
+++ b/tests/proxy/cp/hazelcast_cpsubsystem.xml
@@ -1,19 +1,3 @@
-<!--
-  ~ Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config

--- a/tests/proxy/hazelcast_crdtreplication_delayed.xml
+++ b/tests/proxy/hazelcast_crdtreplication_delayed.xml
@@ -1,19 +1,3 @@
-<!--
-  ~ Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config

--- a/tests/proxy/hazelcast_litemember.xml
+++ b/tests/proxy/hazelcast_litemember.xml
@@ -1,19 +1,3 @@
-<!--
-  ~ Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config

--- a/tests/proxy/hazelcast_mapstore.xml
+++ b/tests/proxy/hazelcast_mapstore.xml
@@ -1,19 +1,3 @@
-<!--
-  ~ Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config

--- a/tests/soak_test/hazelcast.xml
+++ b/tests/soak_test/hazelcast.xml
@@ -1,19 +1,3 @@
-<!--
-  ~ Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config


### PR DESCRIPTION
Updated the copyright year in corresponding places to 2021 and removed
unnecessary copyright headers from some xml files that are used in
tests.