### PR TITLE
[4.0.z] Correct the client name in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -210,7 +210,7 @@ If you are planning to contribute:
 Testing
 ^^^^^^^
 
-In order to test Hazelcast Node.js client locally, you will need the
+In order to test Hazelcast Python client locally, you will need the
 following:
 
 -  Java 8 or newer


### PR DESCRIPTION
It seems that we forget to change the clients name while copying
the content from the Node.js client's README.

This change updates the name of the client.