### PR TITLE
Replace utf with string in public API

### DIFF
--- a/docs/serialization.rst
+++ b/docs/serialization.rst
@@ -98,16 +98,16 @@ The following is an example of a class that extends
             return 1
 
         def write_data(self, output):
-            output.write_utf(self.street)
+            output.write_string(self.street)
             output.write_int(self.zip_code)
-            output.write_utf(self.city)
-            output.write_utf(self.state)
+            output.write_string(self.city)
+            output.write_string(self.state)
 
         def read_data(self, input):
-            self.street = input.read_utf()
+            self.street = input.read_string()
             self.zip_code = input.read_int()
-            self.city = input.read_utf()
-            self.state = input.read_utf()
+            self.city = input.read_string()
+            self.state = input.read_string()
 
 
 .. Note:: Refer to ``ObjectDataInput``/``ObjectDataOutput`` classes in
@@ -199,10 +199,10 @@ following:
             return 1
 
         def write_portable(self, writer):
-            writer.write_utf("foo", self.foo)
+            writer.write_string("foo", self.foo)
 
         def read_portable(self, reader):
-            self.foo = reader.read_utf("foo")
+            self.foo = reader.read_string("foo")
 
 
 .. Note:: Refer to ``PortableReader``/``PortableWriter`` classes in the
@@ -299,12 +299,12 @@ Foo class:
             return 2
 
         def write_portable(self, writer):
-            writer.write_utf("foo", self.foo)
-            writer.write_utf("foo2", self.foo2)
+            writer.write_string("foo", self.foo)
+            writer.write_string("foo2", self.foo2)
 
         def read_portable(self, reader):
-            self.foo = reader.read_utf("foo")
-            self.foo2 = reader.read_utf("foo2")
+            self.foo = reader.read_string("foo")
+            self.foo2 = reader.read_string("foo2")
 
 You should consider the following when you perform versioning:
 
@@ -377,10 +377,10 @@ Let’s say your custom ``MusicianSerializer`` will serialize
             pass
 
         def write(self, output, obj):
-            output.write_utf(obj.name)
+            output.write_string(obj.name)
 
         def read(self, input):
-            name = input.read_utf()
+            name = input.read_string()
             return Musician(name)
 
 Note that the serializer ``id`` must be unique as Hazelcast will use it
@@ -487,10 +487,10 @@ is shown below.
             pass
 
         def write(self, output, obj):
-            output.write_utf(some_third_party_serializer.serialize(obj))
+            output.write_string(some_third_party_serializer.serialize(obj))
 
         def read(self, input):
-            return some_third_party_serializer.deserialize(input.read_utf())
+            return some_third_party_serializer.deserialize(input.read_string())
 
 You should register the global serializer to the client.
 

--- a/docs/using_python_client_with_hazelcast_imdg.rst
+++ b/docs/using_python_client_with_hazelcast_imdg.rst
@@ -1150,10 +1150,10 @@ The following is an example for ``EntryProcessor`` which is an
             self.value = value
 
         def read_data(self, object_data_input):
-            self.value = object_data_input.read_utf()
+            self.value = object_data_input.read_string()
 
         def write_data(self, object_data_output):
-            object_data_output.write_utf(self.value)
+            object_data_output.write_string(self.value)
 
         def get_factory_id(self):
             return 5
@@ -1364,13 +1364,13 @@ Assume that you have an ``employee`` map containing the instances of
             return 1000
 
         def read_portable(self, reader):
-            self.name = reader.read_utf("name")
+            self.name = reader.read_string("name")
             self.age = reader.read_int("age")
             self.active = reader.read_boolean("active")
             self.salary = reader.read_double("salary")
 
         def write_portable(self, writer):
-            writer.write_utf("name", self.name)
+            writer.write_string("name", self.name)
             writer.write_int("age", self.age)
             writer.write_boolean("active", self.active)
             writer.write_double("salary", self.salary)

--- a/examples/map/map_portable_query_example.py
+++ b/examples/map/map_portable_query_example.py
@@ -14,11 +14,11 @@ class Employee(Portable):
         self.age = age
 
     def write_portable(self, writer):
-        writer.write_utf("name", self.name)
+        writer.write_string("name", self.name)
         writer.write_int("age", self.age)
 
     def read_portable(self, reader):
-        self.name = reader.read_utf("name")
+        self.name = reader.read_string("name")
         self.age = reader.read_int("age")
 
     def get_factory_id(self):

--- a/examples/map/map_portable_versioning_example.py
+++ b/examples/map/map_portable_versioning_example.py
@@ -20,11 +20,11 @@ class Employee(Portable):
         self.age = age
 
     def write_portable(self, writer):
-        writer.write_utf("name", self.name)
+        writer.write_string("name", self.name)
         writer.write_int("age", self.age)
 
     def read_portable(self, reader):
-        self.name = reader.read_utf("name")
+        self.name = reader.read_string("name")
         self.age = reader.read_int("age")
 
     def get_factory_id(self):
@@ -57,14 +57,14 @@ class Employee2(Portable):
         self.manager = manager
 
     def write_portable(self, writer):
-        writer.write_utf("name", self.name)
+        writer.write_string("name", self.name)
         writer.write_int("age", self.age)
-        writer.write_utf("manager", self.manager)
+        writer.write_string("manager", self.manager)
 
     def read_portable(self, reader):
-        self.name = reader.read_utf("name")
+        self.name = reader.read_string("name")
         self.age = reader.read_int("age")
-        self.manager = reader.read_utf("manager")
+        self.manager = reader.read_string("manager")
 
     def get_factory_id(self):
         return self.FACTORY_ID
@@ -103,14 +103,14 @@ class Employee3(Portable):
         self.manager = manager
 
     def write_portable(self, writer):
-        writer.write_utf("name", self.name)
-        writer.write_utf("age", self.age)
-        writer.write_utf("manager", self.manager)
+        writer.write_string("name", self.name)
+        writer.write_string("age", self.age)
+        writer.write_string("manager", self.manager)
 
     def read_portable(self, reader):
-        self.name = reader.read_utf("name")
-        self.age = reader.read_utf("age")
-        self.manager = reader.read_utf("manager")
+        self.name = reader.read_string("name")
+        self.age = reader.read_string("age")
+        self.manager = reader.read_string("manager")
 
     def get_factory_id(self):
         return self.FACTORY_ID

--- a/examples/org-website/custom_serializer_sample.py
+++ b/examples/org-website/custom_serializer_sample.py
@@ -10,10 +10,10 @@ class CustomSerializableType(object):
 
 class CustomSerializer(StreamSerializer):
     def write(self, out, obj):
-        out.write_utf(obj.value)
+        out.write_string(obj.value)
 
     def read(self, inp):
-        return CustomSerializableType(inp.read_utf())
+        return CustomSerializableType(inp.read_string())
 
     def get_type_id(self):
         return 10

--- a/examples/org-website/executor_service_sample.py
+++ b/examples/org-website/executor_service_sample.py
@@ -11,10 +11,10 @@ class MessagePrinter(Portable):
         self.message = message
 
     def write_portable(self, writer):
-        writer.write_utf("message", self.message)
+        writer.write_string("message", self.message)
 
     def read_portable(self, reader):
-        self.message = reader.read_utf("message")
+        self.message = reader.read_string("message")
 
     def get_factory_id(self):
         return self.FACTORY_ID

--- a/examples/org-website/identified_data_serializable_sample.py
+++ b/examples/org-website/identified_data_serializable_sample.py
@@ -13,11 +13,11 @@ class Employee(IdentifiedDataSerializable):
 
     def read_data(self, object_data_input):
         self.id = object_data_input.read_int()
-        self.name = object_data_input.read_utf()
+        self.name = object_data_input.read_string()
 
     def write_data(self, object_data_output):
         object_data_output.write_int(self.id)
-        object_data_output.write_utf(self.name)
+        object_data_output.write_string(self.name)
 
     def get_factory_id(self):
         return self.FACTORY_ID

--- a/examples/org-website/portable_serializable_sample.py
+++ b/examples/org-website/portable_serializable_sample.py
@@ -12,15 +12,15 @@ class Customer(Portable):
         self.name = name
         self.last_order = last_order
 
-    def read_portable(self, object_data_input):
-        self.id = object_data_input.read_int("id")
-        self.name = object_data_input.read_utf("name")
-        self.last_order = object_data_input.read_long("last_order")
+    def read_portable(self, reader):
+        self.id = reader.read_int("id")
+        self.name = reader.read_string("name")
+        self.last_order = reader.read_long("last_order")
 
-    def write_portable(self, object_data_output):
-        object_data_output.write_int("id", self.id)
-        object_data_output.write_utf("name", self.name)
-        object_data_output.write_long("last_order", self.last_order)
+    def write_portable(self, writer):
+        writer.write_int("id", self.id)
+        writer.write_string("name", self.name)
+        writer.write_long("last_order", self.last_order)
 
     def get_factory_id(self):
         return self.FACTORY_ID

--- a/examples/org-website/query_sample.py
+++ b/examples/org-website/query_sample.py
@@ -14,12 +14,12 @@ class User(Portable):
         self.active = active
 
     def write_portable(self, writer):
-        writer.write_utf("username", self.username)
+        writer.write_string("username", self.username)
         writer.write_int("age", self.age)
         writer.write_boolean("active", self.active)
 
     def read_portable(self, reader):
-        self.username = reader.read_utf("username")
+        self.username = reader.read_string("username")
         self.age = reader.read_int("age")
         self.active = reader.read_boolean("active")
 

--- a/examples/serialization/global_serialization_example.py
+++ b/examples/serialization/global_serialization_example.py
@@ -23,12 +23,12 @@ class GlobalSerializer(StreamSerializer):
         super(GlobalSerializer, self).__init__()
 
     def read(self, inp):
-        utf = inp.read_utf()
-        obj = cPickle.loads(utf.encode())
+        string = inp.read_string()
+        obj = cPickle.loads(string.encode())
         return obj
 
     def write(self, out, obj):
-        out.write_utf(cPickle.dumps(obj, 0).decode("utf-8"))
+        out.write_string(cPickle.dumps(obj, 0).decode("utf-8"))
 
     def get_type_id(self):
         return self.GLOBAL_SERIALIZER_ID

--- a/examples/serialization/identified_data_serializable_example.py
+++ b/examples/serialization/identified_data_serializable_example.py
@@ -14,12 +14,12 @@ class Student(IdentifiedDataSerializable):
 
     def read_data(self, object_data_input):
         self.id = object_data_input.read_int()
-        self.name = object_data_input.read_utf()
+        self.name = object_data_input.read_string()
         self.gpa = object_data_input.read_float()
 
     def write_data(self, object_data_output):
         object_data_output.write_int(self.id)
-        object_data_output.write_utf(self.name)
+        object_data_output.write_string(self.name)
         object_data_output.write_float(self.gpa)
 
     def get_factory_id(self):

--- a/examples/serialization/portable_example.py
+++ b/examples/serialization/portable_example.py
@@ -13,14 +13,14 @@ class Engineer(Portable):
         self.languages = languages
 
     def read_portable(self, reader):
-        self.name = reader.read_utf("name")
+        self.name = reader.read_string("name")
         self.age = reader.read_int("age")
-        self.languages = reader.read_utf_array("languages")
+        self.languages = reader.read_string_array("languages")
 
     def write_portable(self, writer):
-        writer.write_utf("name", self.name)
+        writer.write_string("name", self.name)
         writer.write_int("age", self.age)
-        writer.write_utf_array("languages", self.languages)
+        writer.write_string_array("languages", self.languages)
 
     def get_factory_id(self):
         return self.FACTORY_ID

--- a/hazelcast/predicate.py
+++ b/hazelcast/predicate.py
@@ -149,7 +149,7 @@ class _SqlPredicate(_AbstractPredicate):
         self.sql = expression
 
     def write_data(self, output):
-        output.write_utf(self.sql)
+        output.write_string(self.sql)
 
     def __repr__(self):
         return "SqlPredicate(sql='%s')" % self.sql
@@ -179,7 +179,7 @@ class _BetweenPredicate(_AbstractPredicate):
         self.to = to
 
     def write_data(self, output):
-        output.write_utf(self.attribute)
+        output.write_string(self.attribute)
         output.write_object(self.to)
         output.write_object(self.from_)
 
@@ -199,7 +199,7 @@ class _EqualPredicate(_AbstractPredicate):
         self.value = value
 
     def write_data(self, output):
-        output.write_utf(self.attribute)
+        output.write_string(self.attribute)
         output.write_object(self.value)
 
     def __repr__(self):
@@ -216,7 +216,7 @@ class _GreaterLessPredicate(_AbstractPredicate):
         self.is_less = is_less
 
     def write_data(self, output):
-        output.write_utf(self.attribute)
+        output.write_string(self.attribute)
         output.write_object(self.value)
         output.write_boolean(self.is_equal)
         output.write_boolean(self.is_less)
@@ -238,8 +238,8 @@ class _LikePredicate(_AbstractPredicate):
         self.expression = pattern
 
     def write_data(self, output):
-        output.write_utf(self.attribute)
-        output.write_utf(self.expression)
+        output.write_string(self.attribute)
+        output.write_string(self.expression)
 
     def __repr__(self):
         return "LikePredicate(attribute='%s', expression='%s')" % (self.attribute, self.expression)
@@ -260,7 +260,7 @@ class _InPredicate(_AbstractPredicate):
         self.values = values
 
     def write_data(self, output):
-        output.write_utf(self.attribute)
+        output.write_string(self.attribute)
         output.write_int(len(self.values))
         for value in self.values:
             output.write_object(value)
@@ -279,7 +279,7 @@ class _InstanceOfPredicate(_AbstractPredicate):
         self.class_name = class_name
 
     def write_data(self, output):
-        output.write_utf(self.class_name)
+        output.write_string(self.class_name)
 
     def __repr__(self):
         return "InstanceOfPredicate(class_name='%s')" % self.class_name
@@ -320,8 +320,8 @@ class _RegexPredicate(_AbstractPredicate):
         self.pattern = pattern
 
     def write_data(self, output):
-        output.write_utf(self.attribute)
-        output.write_utf(self.pattern)
+        output.write_string(self.attribute)
+        output.write_string(self.pattern)
 
     def __repr__(self):
         return "RegexPredicate(attribute='%s', pattern='%s')" % (self.attribute, self.pattern)
@@ -376,7 +376,7 @@ class _PagingPredicate(_AbstractPredicate, PagingPredicate):
         output.write_object(self.comparator)
         output.write_int(self.page)
         output.write_int(self._page_size)
-        output.write_utf(get_attr_name(IterationType, self.iteration_type))
+        output.write_string(get_attr_name(IterationType, self.iteration_type))
         output.write_int(len(self.anchor_list))
         for nearest_page, (anchor_key, anchor_value) in self.anchor_list:
             output.write_int(nearest_page)

--- a/hazelcast/serialization/api.py
+++ b/hazelcast/serialization/api.py
@@ -100,8 +100,20 @@ class ObjectDataOutput(object):
         """
         raise NotImplementedError()
 
+    def write_string(self, val):
+        """Writes UTF-8 string to this output stream.
+
+        Args:
+            val (str): The UTF-8 string to be written.
+        """
+        raise NotImplementedError()
+
     def write_utf(self, val):
         """Writes UTF-8 string to this output stream.
+
+        .. deprecated:: 4.1
+            This method is deprecated and will be removed in the
+            next major version. Use :func:`write_string` instead.
 
         Args:
             val (str): The UTF-8 string to be written.
@@ -172,8 +184,20 @@ class ObjectDataOutput(object):
         """
         raise NotImplementedError()
 
+    def write_string_array(self, val):
+        """Writes a UTF-8 String array to this output stream.
+
+        Args:
+            val (list[str]): The UTF-8 String array to be written.
+        """
+        raise NotImplementedError()
+
     def write_utf_array(self, val):
         """Writes a UTF-8 String array to this output stream.
+
+        .. deprecated:: 4.1
+            This method is deprecated and will be removed in the
+            next major version. Use :func:`write_string_array` instead.
 
         Args:
             val (list[str]): The UTF-8 String array to be written.
@@ -314,8 +338,20 @@ class ObjectDataInput(object):
         """
         raise NotImplementedError()
 
+    def read_string(self):
+        """Reads a UTF-8 string from input stream and returns it.
+
+        Returns:
+            str: The UTF-8 string read.
+        """
+        raise NotImplementedError()
+
     def read_utf(self):
         """Reads a UTF-8 string from input stream and returns it.
+
+        .. deprecated:: 4.1
+            This method is deprecated and will be removed in the
+            next major version. Use :func:`read_string` instead.
 
         Returns:
             str: The UTF-8 string read.
@@ -386,8 +422,20 @@ class ObjectDataInput(object):
         """
         raise NotImplementedError()
 
+    def read_string_array(self):
+        """Reads a UTF-8 string array from input stream and returns it.
+
+        Returns:
+            list[str]: The UTF-8 string array read.
+        """
+        raise NotImplementedError()
+
     def read_utf_array(self):
         """Reads a UTF-8 string array from input stream and returns it.
+
+        .. deprecated:: 4.1
+            This method is deprecated and will be removed in the
+            next major version. Use :func:`read_string_array` instead.
 
         Returns:
             list[str]: The UTF-8 string array read.
@@ -634,8 +682,23 @@ class PortableReader(object):
         """
         raise NotImplementedError()
 
+    def read_string(self, field_name):
+        """Reads a UTF-8 String.
+
+        Args:
+            field_name (str): Name of the field.
+
+        Returns:
+            str: The UTF-8 String read.
+        """
+        raise NotImplementedError()
+
     def read_utf(self, field_name):
         """Reads a UTF-8 String.
+
+        .. deprecated:: 4.1
+            This method is deprecated and will be removed in the
+            next major version. Use :func:`read_string` instead.
 
         Args:
             field_name (str): Name of the field.
@@ -810,8 +873,23 @@ class PortableReader(object):
         """
         raise NotImplementedError()
 
+    def read_string_array(self, field_name):
+        """Reads a UTF-8 String array.
+
+        Args:
+            field_name (str): Name of the field.
+
+        Returns:
+            str: The UTF-8 String array read.
+        """
+        raise NotImplementedError()
+
     def read_utf_array(self, field_name):
         """Reads a UTF-8 String array.
+
+        .. deprecated:: 4.1
+            This method is deprecated and will be removed in the
+            next major version. Use :func:`read_string_array` instead.
 
         Args:
             field_name (str): Name of the field.
@@ -865,8 +943,21 @@ class PortableWriter(object):
         """
         raise NotImplementedError()
 
+    def write_string(self, field_name, value):
+        """Writes an UTF string.
+
+        Args:
+            field_name (str): Name of the field.
+            value (str): UTF string value to be written.
+        """
+        raise NotImplementedError()
+
     def write_utf(self, field_name, value):
         """Writes an UTF string.
+
+        .. deprecated:: 4.1
+            This method is deprecated and will be removed in the
+            next major version. Use :func:`write_string` instead.
 
         Args:
             field_name (str): Name of the field.
@@ -1019,8 +1110,21 @@ class PortableWriter(object):
         """
         raise NotImplementedError()
 
+    def write_string_array(self, field_name, values):
+        """Writes a UTF-8 String array.
+
+        Args:
+            field_name (str): Name of the field.
+            values: (str): UTF-8 String array to be written.
+        """
+        raise NotImplementedError()
+
     def write_utf_array(self, field_name, values):
         """Writes a UTF-8 String array.
+
+        .. deprecated:: 4.1
+            This method is deprecated and will be removed in the
+            next major version. Use :func:`write_string_array` instead.
 
         Args:
             field_name (str): Name of the field.

--- a/hazelcast/serialization/input.py
+++ b/hazelcast/serialization/input.py
@@ -84,7 +84,7 @@ class _ObjectDataInput(ObjectDataInput):
         self._check_available(self._pos, DOUBLE_SIZE_IN_BYTES)
         return self._read_from_buff(self._FMT_DOUBLE, DOUBLE_SIZE_IN_BYTES, position)
 
-    def read_utf(self):
+    def read_string(self):
         length = self.read_int()
         if length == NULL_ARRAY_LENGTH:
             return None
@@ -124,8 +124,8 @@ class _ObjectDataInput(ObjectDataInput):
     def read_short_array(self):
         return self._read_array_fnc(self.read_short)
 
-    def read_utf_array(self):
-        return self._read_array_fnc(self.read_utf)
+    def read_string_array(self):
+        return self._read_array_fnc(self.read_string)
 
     def read_object(self):
         return self._service.read_object(self)
@@ -146,6 +146,12 @@ class _ObjectDataInput(ObjectDataInput):
         if self._is_big_endian:
             return "BIG_ENDIAN"
         return "LITTLE_ENDIAN"
+
+    def read_utf(self):
+        return self.read_string()
+
+    def read_utf_array(self):
+        return self.read_string_array()
 
     # HELPERS
     def _check_available(self, position, size):

--- a/hazelcast/serialization/output.py
+++ b/hazelcast/serialization/output.py
@@ -77,7 +77,7 @@ class _ObjectDataOutput(ObjectDataOutput):
         self._FMT_DOUBLE.pack_into(self._buffer, self._pos, val)
         self._pos += DOUBLE_SIZE_IN_BYTES
 
-    def write_utf(self, val):
+    def write_string(self, val):
         if val is None:
             self.write_int(NULL_ARRAY_LENGTH)
         else:
@@ -124,8 +124,8 @@ class _ObjectDataOutput(ObjectDataOutput):
     def write_short_array(self, val):
         self._write_array_fnc(val, self.write_short)
 
-    def write_utf_array(self, val):
-        self._write_array_fnc(val, self.write_utf)
+    def write_string_array(self, val):
+        self._write_array_fnc(val, self.write_string)
 
     def write_object(self, val):
         self._service.write_object(self, val)
@@ -148,8 +148,14 @@ class _ObjectDataOutput(ObjectDataOutput):
         self._pos = position
 
     def write_zero_bytes(self, count):
-        for i in range(0, count):
+        for _ in range(0, count):
             self._write(0)
+
+    def write_utf(self, val):
+        self.write_string(val)
+
+    def write_utf_array(self, val):
+        self.write_string_array(val)
 
     # HELPERS
     def _write_array_fnc(self, val, item_write_fnc):
@@ -179,10 +185,10 @@ class _ObjectDataOutput(ObjectDataOutput):
 
 
 class EmptyObjectDataOutput(ObjectDataOutput):
-    def write_utf_array(self, val):
+    def write_string_array(self, val):
         pass
 
-    def write_utf(self, val):
+    def write_string(self, val):
         pass
 
     def write_short_array(self, val):
@@ -249,4 +255,10 @@ class EmptyObjectDataOutput(ObjectDataOutput):
         raise NotImplementedError("to_byte_array not implemented")
 
     def get_byte_order(self):
+        pass
+
+    def write_utf(self, val):
+        pass
+
+    def write_utf_array(self, val):
         pass

--- a/hazelcast/serialization/portable/classdef.py
+++ b/hazelcast/serialization/portable/classdef.py
@@ -12,7 +12,8 @@ class FieldType(object):
     LONG = 6
     FLOAT = 7
     DOUBLE = 8
-    UTF = 9
+    UTF = 9  # Defined for backwards compatibility.
+    STRING = 9
     PORTABLE_ARRAY = 10
     BYTE_ARRAY = 11
     BOOLEAN_ARRAY = 12
@@ -22,7 +23,8 @@ class FieldType(object):
     LONG_ARRAY = 16
     FLOAT_ARRAY = 17
     DOUBLE_ARRAY = 18
-    UTF_ARRAY = 19
+    UTF_ARRAY = 19  # Defined for backwards compatibility.
+    STRING_ARRAY = 19
 
 
 class FieldDefinition(object):
@@ -183,9 +185,17 @@ class ClassDefinitionBuilder(object):
         self._add_field_by_type(field_name, FieldType.DOUBLE, self.version)
         return self
 
-    def add_utf_field(self, field_name):
-        self._add_field_by_type(field_name, FieldType.UTF, self.version)
+    def add_string_field(self, field_name):
+        self._add_field_by_type(field_name, FieldType.STRING, self.version)
         return self
+
+    def add_utf_field(self, field_name):
+        """
+        .. deprecated:: 4.1
+            This method is deprecated and will be removed in the
+            next major version. Use :func:`add_string_field` instead.
+        """
+        return self.add_string_field(field_name)
 
     def add_portable_array_field(self, field_name, class_def):
         if class_def.class_id is None or class_def.class_id == 0:
@@ -231,9 +241,17 @@ class ClassDefinitionBuilder(object):
         self._add_field_by_type(field_name, FieldType.DOUBLE_ARRAY, self.version)
         return self
 
-    def add_utf_array_field(self, field_name):
-        self._add_field_by_type(field_name, FieldType.UTF_ARRAY, self.version)
+    def add_string_array_field(self, field_name):
+        self._add_field_by_type(field_name, FieldType.STRING_ARRAY, self.version)
         return self
+
+    def add_utf_array_field(self, field_name):
+        """
+        .. deprecated:: 4.1
+            This method is deprecated and will be removed in the
+            next major version. Use :func:`add_string_array_field` instead.
+        """
+        return self.add_string_array_field(field_name)
 
     def add_field_def(self, field_def):
         self._check()

--- a/hazelcast/serialization/portable/reader.py
+++ b/hazelcast/serialization/portable/reader.py
@@ -71,12 +71,12 @@ class DefaultPortableReader(PortableReader):
         pos = self._read_position(field_name, FieldType.DOUBLE)
         return self._in.read_double(pos)
 
-    def read_utf(self, field_name):
+    def read_string(self, field_name):
         cur_pos = self._in.position()
         try:
-            pos = self._read_position(field_name, FieldType.UTF)
+            pos = self._read_position(field_name, FieldType.STRING)
             self._in.set_position(pos)
-            return self._in.read_utf()
+            return self._in.read_string()
         finally:
             self._in.set_position(cur_pos)
 
@@ -177,12 +177,12 @@ class DefaultPortableReader(PortableReader):
         finally:
             self._in.set_position(current_pos)
 
-    def read_utf_array(self, field_name):
+    def read_string_array(self, field_name):
         current_pos = self._in.position()
         try:
-            pos = self._read_position(field_name, FieldType.UTF_ARRAY)
+            pos = self._read_position(field_name, FieldType.STRING_ARRAY)
             self._in.set_position(pos)
-            return self._in.read_utf_array()
+            return self._in.read_string_array()
         finally:
             self._in.set_position(current_pos)
 
@@ -218,6 +218,12 @@ class DefaultPortableReader(PortableReader):
             return portables
         finally:
             self._in.set_position(current_pos)
+
+    def read_utf(self, field_name):
+        return self.read_string(field_name)
+
+    def read_utf_array(self, field_name):
+        return self.read_string_array(field_name)
 
     def get_raw_data_input(self):
         if not self._raw:
@@ -394,19 +400,19 @@ class MorphingPortableReader(DefaultPortableReader):
         self.validate_type_compatibility(fd, FieldType.CHAR)
         return super(MorphingPortableReader, self).read_char(field_name)
 
-    def read_utf(self, field_name):
+    def read_string(self, field_name):
         fd = self._class_def.get_field(field_name)
         if fd is None:
             return None
-        self.validate_type_compatibility(fd, FieldType.UTF)
-        return super(MorphingPortableReader, self).read_utf(field_name)
+        self.validate_type_compatibility(fd, FieldType.STRING)
+        return super(MorphingPortableReader, self).read_string(field_name)
 
-    def read_utf_array(self, field_name):
+    def read_string_array(self, field_name):
         fd = self._class_def.get_field(field_name)
         if fd is None:
             return None
-        self.validate_type_compatibility(fd, FieldType.UTF_ARRAY)
-        return super(MorphingPortableReader, self).read_utf_array(field_name)
+        self.validate_type_compatibility(fd, FieldType.STRING_ARRAY)
+        return super(MorphingPortableReader, self).read_string_array(field_name)
 
     def read_short_array(self, field_name):
         fd = self._class_def.get_field(field_name)
@@ -477,6 +483,12 @@ class MorphingPortableReader(DefaultPortableReader):
             return None
         self.validate_type_compatibility(fd, FieldType.PORTABLE_ARRAY)
         return super(MorphingPortableReader, self).read_portable_array(field_name)
+
+    def read_utf(self, field_name):
+        return self.read_string(field_name)
+
+    def read_utf_array(self, field_name):
+        return self.read_string_array(field_name)
 
     def validate_type_compatibility(self, field_def, expected_type):
         if field_def.field_type != expected_type:

--- a/hazelcast/serialization/portable/writer.py
+++ b/hazelcast/serialization/portable/writer.py
@@ -57,9 +57,9 @@ class DefaultPortableWriter(PortableWriter):
         self._set_position(field_name, FieldType.DOUBLE)
         self._out.write_double(value)
 
-    def write_utf(self, field_name, value):
-        self._set_position(field_name, FieldType.UTF)
-        self._out.write_utf(value)
+    def write_string(self, field_name, value):
+        self._set_position(field_name, FieldType.STRING)
+        self._out.write_string(value)
 
     def write_byte_array(self, field_name, values):
         self._set_position(field_name, FieldType.BYTE_ARRAY)
@@ -93,9 +93,9 @@ class DefaultPortableWriter(PortableWriter):
         self._set_position(field_name, FieldType.DOUBLE_ARRAY)
         self._out.write_double_array(values)
 
-    def write_utf_array(self, field_name, values):
-        self._set_position(field_name, FieldType.UTF_ARRAY)
-        self._out.write_utf_array(values)
+    def write_string_array(self, field_name, values):
+        self._set_position(field_name, FieldType.STRING_ARRAY)
+        self._out.write_string_array(values)
 
     def write_portable(self, field_name, portable):
         fd = self._set_position(field_name, FieldType.PORTABLE)
@@ -139,6 +139,12 @@ class DefaultPortableWriter(PortableWriter):
             self._out.write_int(_pos_val, self._offset + _index * INT_SIZE_IN_BYTES)
         self._raw = True
         return self._out
+
+    def write_utf(self, field_name, value):
+        self.write_string(field_name, value)
+
+    def write_utf_array(self, field_name, values):
+        self.write_string_array(field_name, values)
 
     # internal
     def _set_position(self, field_name, field_type):
@@ -222,8 +228,8 @@ class ClassDefinitionWriter(PortableWriter):
     def write_double(self, field_name, value):
         self._builder.add_double_field(field_name)
 
-    def write_utf(self, field_name, value):
-        self._builder.add_utf_field(field_name)
+    def write_string(self, field_name, value):
+        self._builder.add_string_field(field_name)
 
     def write_byte_array(self, field_name, values):
         self._builder.add_byte_array_field(field_name)
@@ -249,8 +255,8 @@ class ClassDefinitionWriter(PortableWriter):
     def write_double_array(self, field_name, values):
         self._builder.add_double_array_field(field_name)
 
-    def write_utf_array(self, field_name, values):
-        self._builder.add_utf_array_field(field_name)
+    def write_string_array(self, field_name, values):
+        self._builder.add_string_array_field(field_name)
 
     def write_portable(self, field_name, portable):
         if portable is None:
@@ -294,6 +300,12 @@ class ClassDefinitionWriter(PortableWriter):
 
     def get_raw_data_output(self):
         return EmptyObjectDataOutput()
+
+    def write_utf(self, field_name, value):
+        self.write_string(field_name, value)
+
+    def write_utf_array(self, field_name, values):
+        self.write_string_array(field_name, values)
 
     def _create_nested_class_def(self, portable, nested_builder):
         _writer = ClassDefinitionWriter(self.portable_context, class_def_builder=nested_builder)

--- a/hazelcast/serialization/serializer.py
+++ b/hazelcast/serialization/serializer.py
@@ -122,10 +122,10 @@ class DoubleSerializer(BaseSerializer):
 
 class StringSerializer(BaseSerializer):
     def read(self, inp):
-        return inp.read_utf()
+        return inp.read_string()
 
     def write(self, out, obj):
-        out.write_utf(obj)
+        out.write_string(obj)
 
     def get_type_id(self):
         return CONSTANT_TYPE_STRING
@@ -150,10 +150,10 @@ class UuidSerializer(BaseSerializer):
 
 class HazelcastJsonValueSerializer(BaseSerializer):
     def read(self, inp):
-        return HazelcastJsonValue(inp.read_utf())
+        return HazelcastJsonValue(inp.read_string())
 
     def write(self, out, obj):
-        out.write_utf(obj.to_string())
+        out.write_string(obj.to_string())
 
     def get_type_id(self):
         return JAVASCRIPT_JSON_SERIALIZATION_TYPE
@@ -243,7 +243,7 @@ class DoubleArraySerializer(BaseSerializer):
 
 class StringArraySerializer(BaseSerializer):
     def read(self, inp):
-        return inp.read_utf_array()
+        return inp.read_string_array()
 
     # "write(self, out, obj)" is never called so not implemented here
 
@@ -301,7 +301,7 @@ class BigIntegerSerializer(BaseSerializer):
 
 class JavaClassSerializer(BaseSerializer):
     def read(self, inp):
-        return inp.read_utf()
+        return inp.read_string()
 
     # "write(self, out, obj)" is never called so not implemented here
 
@@ -341,11 +341,11 @@ class LinkedListSerializer(BaseSerializer):
 
 class PythonObjectSerializer(BaseSerializer):
     def read(self, inp):
-        str = inp.read_utf().encode()
+        str = inp.read_string().encode()
         return cPickle.loads(str)
 
     def write(self, out, obj):
-        out.write_utf(cPickle.dumps(obj, 0).decode("utf-8"))
+        out.write_string(cPickle.dumps(obj, 0).decode("utf-8"))
 
     def get_type_id(self):
         return PYTHON_TYPE_PICKLE

--- a/tests/predicate_test.py
+++ b/tests/predicate_test.py
@@ -311,11 +311,11 @@ class NestedPredicatePortableTest(SingleMemberTestCase):
             return 15
 
         def write_portable(self, writer):
-            writer.write_utf("name", self.name)
+            writer.write_string("name", self.name)
             writer.write_portable("limb", self.limb)
 
         def read_portable(self, reader):
-            self.name = reader.read_utf("name")
+            self.name = reader.read_string("name")
             self.limb = reader.read_portable("limb")
 
         def __eq__(self, other):
@@ -338,10 +338,10 @@ class NestedPredicatePortableTest(SingleMemberTestCase):
             return 2
 
         def write_portable(self, writer):
-            writer.write_utf("name", self.name)
+            writer.write_string("name", self.name)
 
         def read_portable(self, reader):
-            self.name = reader.read_utf("name")
+            self.name = reader.read_string("name")
 
         def __eq__(self, other):
             return isinstance(other, self.__class__) and self.name == other.name

--- a/tests/proxy/cp/atomic_reference_test.py
+++ b/tests/proxy/cp/atomic_reference_test.py
@@ -14,7 +14,7 @@ class AppendString(IdentifiedDataSerializable):
         self.suffix = suffix
 
     def write_data(self, object_data_output):
-        object_data_output.write_utf(self.suffix)
+        object_data_output.write_string(self.suffix)
 
     def read_data(self, object_data_input):
         pass

--- a/tests/proxy/executor_test.py
+++ b/tests/proxy/executor_test.py
@@ -12,10 +12,10 @@ class _AppendTask(IdentifiedDataSerializable):
         self.message = message
 
     def write_data(self, object_data_output):
-        object_data_output.write_utf(self.message)
+        object_data_output.write_string(self.message)
 
     def read_data(self, object_data_input):
-        self.message = object_data_input.read_utf()
+        self.message = object_data_input.read_string()
 
     def get_factory_id(self):
         return 66

--- a/tests/proxy/map_test.py
+++ b/tests/proxy/map_test.py
@@ -20,10 +20,10 @@ class EntryProcessor(IdentifiedDataSerializable):
         self.value = value
 
     def write_data(self, object_data_output):
-        object_data_output.write_utf(self.value)
+        object_data_output.write_string(self.value)
 
     def read_data(self, object_data_input):
-        self.value = object_data_input.read()
+        self.value = object_data_input.read_string()
 
     def get_factory_id(self):
         return self.FACTORY_ID

--- a/tests/serialization/binary_compatibility/reference_objects.py
+++ b/tests/serialization/binary_compatibility/reference_objects.py
@@ -209,7 +209,7 @@ class AnIdentifiedDataSerializable(IdentifiedDataSerializable):
         out.write_float(self.f)
         out.write_int(self.i)
         out.write_long(self.l)
-        out.write_utf(self.string)
+        out.write_string(self.string)
 
         out.write_boolean_array(self.booleans)
         out.write_byte_array(self.bytes_)
@@ -219,7 +219,7 @@ class AnIdentifiedDataSerializable(IdentifiedDataSerializable):
         out.write_float_array(self.floats)
         out.write_int_array(self.ints)
         out.write_long_array(self.longs)
-        out.write_utf_array(self.strings)
+        out.write_string_array(self.strings)
 
         out.write_boolean_array(self.booleans_none)
         out.write_byte_array(self.bytes_none)
@@ -229,7 +229,7 @@ class AnIdentifiedDataSerializable(IdentifiedDataSerializable):
         out.write_float_array(self.floats_none)
         out.write_int_array(self.ints_none)
         out.write_long_array(self.longs_none)
-        out.write_utf_array(self.strings_none)
+        out.write_string_array(self.strings_none)
 
         self.bytes_size = len(self.bytes_)
         out.write_byte(self.bytes_size)
@@ -258,7 +258,7 @@ class AnIdentifiedDataSerializable(IdentifiedDataSerializable):
         self.f = inp.read_float()
         self.i = inp.read_int()
         self.l = inp.read_long()
-        self.string = inp.read_utf()
+        self.string = inp.read_string()
 
         self.booleans = inp.read_boolean_array()
         self.bytes_ = inp.read_byte_array()
@@ -268,7 +268,7 @@ class AnIdentifiedDataSerializable(IdentifiedDataSerializable):
         self.floats = inp.read_float_array()
         self.ints = inp.read_int_array()
         self.longs = inp.read_long_array()
-        self.strings = inp.read_utf_array()
+        self.strings = inp.read_string_array()
 
         self.booleans_none = inp.read_boolean_array()
         self.bytes_none = inp.read_byte_array()
@@ -278,7 +278,7 @@ class AnIdentifiedDataSerializable(IdentifiedDataSerializable):
         self.floats_none = inp.read_float_array()
         self.ints_none = inp.read_int_array()
         self.longs_none = inp.read_long_array()
-        self.strings_none = inp.read_utf_array()
+        self.strings_none = inp.read_string_array()
 
         self.bytes_size = inp.read_byte()
         self.bytes_fully = bytearray(self.bytes_size)
@@ -434,7 +434,7 @@ class APortable(Portable):
         writer.write_float("f", self.f)
         writer.write_int("i", self.i)
         writer.write_long("l", self.l)
-        writer.write_utf("str", self.string)
+        writer.write_string("str", self.string)
         if self.p:
             writer.write_portable("p", self.p)
         else:
@@ -448,7 +448,7 @@ class APortable(Portable):
         writer.write_float_array("fs", self.floats)
         writer.write_int_array("is", self.ints)
         writer.write_long_array("ls", self.longs)
-        writer.write_utf_array("strs", self.strings)
+        writer.write_string_array("strs", self.strings)
         writer.write_portable_array("ps", self.portables)
 
         writer.write_boolean_array("booleansNull", self.booleans_none)
@@ -459,7 +459,7 @@ class APortable(Portable):
         writer.write_float_array("fsNull", self.floats_none)
         writer.write_int_array("isNull", self.ints_none)
         writer.write_long_array("lsNull", self.longs_none)
-        writer.write_utf_array("strsNull", self.strings_none)
+        writer.write_string_array("strsNull", self.strings_none)
 
         out = writer.get_raw_data_output()
 
@@ -471,7 +471,7 @@ class APortable(Portable):
         out.write_float(self.f)
         out.write_int(self.i)
         out.write_long(self.l)
-        out.write_utf(self.string)
+        out.write_string(self.string)
 
         out.write_boolean_array(self.booleans)
         out.write_byte_array(self.bytes_)
@@ -481,7 +481,7 @@ class APortable(Portable):
         out.write_float_array(self.floats)
         out.write_int_array(self.ints)
         out.write_long_array(self.longs)
-        out.write_utf_array(self.strings)
+        out.write_string_array(self.strings)
 
         out.write_boolean_array(self.booleans_none)
         out.write_byte_array(self.bytes_none)
@@ -491,7 +491,7 @@ class APortable(Portable):
         out.write_float_array(self.floats_none)
         out.write_int_array(self.ints_none)
         out.write_long_array(self.longs_none)
-        out.write_utf_array(self.strings_none)
+        out.write_string_array(self.strings_none)
 
         self.bytes_size = len(self.bytes_)
         out.write_byte(self.bytes_size)
@@ -520,7 +520,7 @@ class APortable(Portable):
         self.f = reader.read_float("f")
         self.i = reader.read_int("i")
         self.l = reader.read_long("l")
-        self.string = reader.read_utf("str")
+        self.string = reader.read_string("str")
         self.p = reader.read_portable("p")
 
         self.booleans = reader.read_boolean_array("booleans")
@@ -531,7 +531,7 @@ class APortable(Portable):
         self.floats = reader.read_float_array("fs")
         self.ints = reader.read_int_array("is")
         self.longs = reader.read_long_array("ls")
-        self.strings = reader.read_utf_array("strs")
+        self.strings = reader.read_string_array("strs")
         self.portables = reader.read_portable_array("ps")
 
         self.booleans_none = reader.read_boolean_array("booleansNull")
@@ -542,7 +542,7 @@ class APortable(Portable):
         self.floats_none = reader.read_float_array("fsNull")
         self.ints_none = reader.read_int_array("isNull")
         self.longs_none = reader.read_long_array("lsNull")
-        self.strings_none = reader.read_utf_array("strsNull")
+        self.strings_none = reader.read_string_array("strsNull")
 
         inp = reader.get_raw_data_input()
 
@@ -554,7 +554,7 @@ class APortable(Portable):
         self.f = inp.read_float()
         self.i = inp.read_int()
         self.l = inp.read_long()
-        self.string = inp.read_utf()
+        self.string = inp.read_string()
 
         self.booleans = inp.read_boolean_array()
         self.bytes_ = inp.read_byte_array()
@@ -564,7 +564,7 @@ class APortable(Portable):
         self.floats = inp.read_float_array()
         self.ints = inp.read_int_array()
         self.longs = inp.read_long_array()
-        self.strings = inp.read_utf_array()
+        self.strings = inp.read_string_array()
 
         self.booleans_none = inp.read_boolean_array()
         self.bytes_none = inp.read_byte_array()
@@ -574,7 +574,7 @@ class APortable(Portable):
         self.floats_none = inp.read_float_array()
         self.ints_none = inp.read_int_array()
         self.longs_none = inp.read_long_array()
-        self.strings_none = inp.read_utf_array()
+        self.strings_none = inp.read_string_array()
 
         self.bytes_size = inp.read_byte()
         self.bytes_fully = bytearray(self.bytes_size)

--- a/tests/serialization/custom_global_serialization_test.py
+++ b/tests/serialization/custom_global_serialization_test.py
@@ -11,8 +11,8 @@ class TestGlobalSerializer(StreamSerializer):
         super(TestGlobalSerializer, self).__init__()
 
     def read(self, inp):
-        utf = inp.read_utf()
-        obj = cPickle.loads(utf.encode())
+        string = inp.read_string()
+        obj = cPickle.loads(string.encode())
         try:
             obj.source = "GLOBAL"
         except AttributeError:
@@ -20,7 +20,7 @@ class TestGlobalSerializer(StreamSerializer):
         return obj
 
     def write(self, out, obj):
-        out.write_utf(cPickle.dumps(obj, 0).decode("utf-8"))
+        out.write_string(cPickle.dumps(obj, 0).decode("utf-8"))
 
     def get_type_id(self):
         return 10000
@@ -45,14 +45,14 @@ class CustomClass(object):
 class CustomSerializer(StreamSerializer):
     def write(self, out, obj):
         if isinstance(obj, CustomClass):
-            out.write_utf(obj.uid)
-            out.write_utf(obj.name)
-            out.write_utf(obj.text)
+            out.write_string(obj.uid)
+            out.write_string(obj.name)
+            out.write_string(obj.text)
         else:
             raise ValueError("Can only serialize CustomClass")
 
     def read(self, inp):
-        return CustomClass(inp.read_utf(), inp.read_utf(), inp.read_utf(), "CUSTOM")
+        return CustomClass(inp.read_string(), inp.read_string(), inp.read_string(), "CUSTOM")
 
     def get_type_id(self):
         return 10001
@@ -64,16 +64,16 @@ class CustomSerializer(StreamSerializer):
 class TheOtherCustomSerializer(StreamSerializer):
     def write(self, out, obj):
         if isinstance(obj, CustomClass):
-            out.write_utf(obj.text)
-            out.write_utf(obj.name)
-            out.write_utf(obj.uid)
+            out.write_string(obj.text)
+            out.write_string(obj.name)
+            out.write_string(obj.uid)
         else:
             raise ValueError("Can only serialize CustomClass")
 
     def read(self, inp):
-        text_ = inp.read_utf()
-        name_ = inp.read_utf()
-        uid = inp.read_utf()
+        text_ = inp.read_string()
+        name_ = inp.read_string()
+        uid = inp.read_string()
         return CustomClass(uid, name_, text_, "CUSTOM")
 
     def get_type_id(self):

--- a/tests/serialization/identified_test.py
+++ b/tests/serialization/identified_test.py
@@ -68,8 +68,8 @@ class SerializationV1Identified(IdentifiedDataSerializable):
         out.write_long_array(self.longs)
         out.write_float_array(self.floats)
         out.write_double_array(self.doubles)
-        out.write_utf(self.a_string)
-        out.write_utf_array(self.strings)
+        out.write_string(self.a_string)
+        out.write_string_array(self.strings)
 
     def read_data(self, inp):
         self.a_byte = inp.read_byte()
@@ -89,8 +89,8 @@ class SerializationV1Identified(IdentifiedDataSerializable):
         self.longs = inp.read_long_array()
         self.floats = inp.read_float_array()
         self.doubles = inp.read_double_array()
-        self.a_string = inp.read_utf()
-        self.strings = inp.read_utf_array()
+        self.a_string = inp.read_string()
+        self.strings = inp.read_string_array()
 
     def get_factory_id(self):
         return FACTORY_ID

--- a/tests/serialization/morphing_portable_test.py
+++ b/tests/serialization/morphing_portable_test.py
@@ -177,7 +177,7 @@ class MorphingPortableTestCase(unittest.TestCase):
             self.reader.read_long,
             self.reader.read_float,
             self.reader.read_double,
-            self.reader.read_utf_array,
+            self.reader.read_string_array,
             self.reader.read_short_array,
             self.reader.read_int_array,
             self.reader.read_long_array,
@@ -193,12 +193,12 @@ class MorphingPortableTestCase(unittest.TestCase):
             with self.assertRaises(TypeError):
                 read_fnc("9")
         with self.assertRaises(TypeError):
-            self.reader.read_utf("1")
+            self.reader.read_string("1")
 
     def test_missing_fields(self):
         functions = [
-            self.reader.read_utf,
-            self.reader.read_utf_array,
+            self.reader.read_string,
+            self.reader.read_string_array,
             self.reader.read_short_array,
             self.reader.read_int_array,
             self.reader.read_long_array,

--- a/tests/serialization/portable_test.py
+++ b/tests/serialization/portable_test.py
@@ -73,7 +73,7 @@ class SerializationV1Portable(Portable):
         out.write_long("6", self.a_long)
         out.write_float("7", self.a_float)
         out.write_double("8", self.a_double)
-        out.write_utf("9", self.a_string)
+        out.write_string("9", self.a_string)
 
         out.write_byte_array("a1", self.bytes)
         out.write_boolean_array("a2", self.booleans)
@@ -83,7 +83,7 @@ class SerializationV1Portable(Portable):
         out.write_long_array("a6", self.longs)
         out.write_float_array("a7", self.floats)
         out.write_double_array("a8", self.doubles)
-        out.write_utf_array("a9", self.strings)
+        out.write_string_array("a9", self.strings)
 
         if self.inner_portable is None:
             out.write_null_portable("p", FACTORY_ID, InnerPortable.CLASS_ID)
@@ -108,7 +108,7 @@ class SerializationV1Portable(Portable):
         self.a_long = inp.read_long("6")
         self.a_float = inp.read_float("7")
         self.a_double = inp.read_double("8")
-        self.a_string = inp.read_utf("9")
+        self.a_string = inp.read_string("9")
 
         self.bytes = inp.read_byte_array("a1")
         self.booleans = inp.read_boolean_array("a2")
@@ -118,7 +118,7 @@ class SerializationV1Portable(Portable):
         self.longs = inp.read_long_array("a6")
         self.floats = inp.read_float_array("a7")
         self.doubles = inp.read_double_array("a8")
-        self.strings = inp.read_utf_array("a9")
+        self.strings = inp.read_string_array("a9")
 
         self.inner_portable = inp.read_portable("p")
 
@@ -195,11 +195,11 @@ class InnerPortable(Portable):
         self.param_int = param_int
 
     def write_portable(self, writer):
-        writer.write_utf("param_str", self.param_str)
+        writer.write_string("param_str", self.param_str)
         writer.write_int("param_int", self.param_int)
 
     def read_portable(self, reader):
-        self.param_str = reader.read_utf("param_str")
+        self.param_str = reader.read_string("param_str")
         self.param_int = reader.read_int("param_int")
 
     def get_factory_id(self):
@@ -246,10 +246,10 @@ class Child(Portable):
         return 2
 
     def write_portable(self, writer):
-        writer.write_utf("name", self.name)
+        writer.write_string("name", self.name)
 
     def read_portable(self, reader):
-        self.name = reader.read_utf("name")
+        self.name = reader.read_string("name")
 
     def __eq__(self, other):
         return isinstance(other, self.__class__) and self.name == other.name
@@ -295,10 +295,10 @@ class MyPortable1(Portable):
         self.str_field = str_field
 
     def write_portable(self, writer):
-        writer.write_utf("str_field", self.str_field)
+        writer.write_string("str_field", self.str_field)
 
     def read_portable(self, reader):
-        self.str_field = reader.read_utf("str_field")
+        self.str_field = reader.read_string("str_field")
 
     def get_factory_id(self):
         return 1
@@ -390,7 +390,7 @@ class PortableSerializationTestCase(unittest.TestCase):
 
     def test_portable_class_def(self):
         builder_inner = ClassDefinitionBuilder(FACTORY_ID, InnerPortable.CLASS_ID)
-        builder_inner.add_utf_field("param_str")
+        builder_inner.add_string_field("param_str")
         builder_inner.add_int_field("param_int")
         class_def_inner = builder_inner.build()
 
@@ -404,7 +404,7 @@ class PortableSerializationTestCase(unittest.TestCase):
         builder.add_long_field("6")
         builder.add_float_field("7")
         builder.add_double_field("8")
-        builder.add_utf_field("9")
+        builder.add_string_field("9")
         builder.add_byte_array_field("a1")
         builder.add_boolean_array_field("a2")
         builder.add_char_array_field("a3")
@@ -413,7 +413,7 @@ class PortableSerializationTestCase(unittest.TestCase):
         builder.add_long_array_field("a6")
         builder.add_float_array_field("a7")
         builder.add_double_array_field("a8")
-        builder.add_utf_array_field("a9")
+        builder.add_string_array_field("a9")
         builder.add_portable_field("p", class_def_inner)
         builder.add_portable_array_field("ap", class_def_inner)
         class_def = builder.build()
@@ -471,7 +471,7 @@ class PortableSerializationTestCase(unittest.TestCase):
 
         config.portable_factories = {1: {1: Parent, 2: Child}}
 
-        child_class_def = ClassDefinitionBuilder(FACTORY_ID, 2).add_utf_field("name").build()
+        child_class_def = ClassDefinitionBuilder(FACTORY_ID, 2).add_string_field("name").build()
         parent_class_def = (
             ClassDefinitionBuilder(FACTORY_ID, 1)
             .add_portable_field("child", child_class_def)
@@ -490,7 +490,7 @@ class PortableSerializationTestCase(unittest.TestCase):
     def test_duplicate_class_definition(self):
         config = _Config()
 
-        class_def1 = ClassDefinitionBuilder(1, 1).add_utf_field("str_field").build()
+        class_def1 = ClassDefinitionBuilder(1, 1).add_string_field("str_field").build()
         class_def2 = ClassDefinitionBuilder(1, 1).add_int_field("int_field").build()
 
         config.class_definitions = [class_def1, class_def2]
@@ -502,7 +502,7 @@ class PortableSerializationTestCase(unittest.TestCase):
         config = _Config()
         config.portable_factories = {1: {1: MyPortable1}, 2: {1: MyPortable2}}
 
-        class_def1 = ClassDefinitionBuilder(1, 1).add_utf_field("str_field").build()
+        class_def1 = ClassDefinitionBuilder(1, 1).add_string_field("str_field").build()
         class_def2 = ClassDefinitionBuilder(2, 1).add_int_field("int_field").build()
 
         config.class_definitions = [class_def1, class_def2]

--- a/tests/soak_test/map_soak_test.py
+++ b/tests/soak_test/map_soak_test.py
@@ -47,7 +47,7 @@ class SimpleEntryProcessor(IdentifiedDataSerializable):
         pass
 
     def write_data(self, object_data_output):
-        object_data_output.write_utf(self.value)
+        object_data_output.write_string(self.value)
 
     def get_class_id(self):
         return self.CLASS_ID


### PR DESCRIPTION
As decided with the team, methods containing the word `utf` is
renamed with `string`. (`read_utf` -> `read_string` etc.).

For backwards compatibility, old methods are still there but we
have a deprecation documentation for them.

Closes #342 
Closes #367 