### PR TITLE
Set the cluster connection timeout to infinite by default

### DIFF
--- a/docs/client_connection_strategy.rst
+++ b/docs/client_connection_strategy.rst
@@ -46,10 +46,10 @@ starting and reconnecting modes.
 Configuring Client Connection Retry
 -----------------------------------
 
-When the client is disconnected from the cluster, it searches for new
-connections to reconnect. You can configure the frequency of the
-reconnection attempts and client shutdown behavior using the argumentes
-below.
+When the client is disconnected from the cluster or trying to connect
+to a one for the first time, it searches for new connections. You can
+configure the frequency of the connection attempts and the client
+shutdown behavior using the arguments below.
 
 .. code:: python
 
@@ -69,13 +69,14 @@ The following are configuration element descriptions:
 - ``retry_max_backoff``: Specifies the upper limit for the backoff in
   seconds. Its default value is ``30``. It must be non-negative.
 - ``retry_multiplier``: Factor to multiply the backoff after a failed
-  retry. Its default value is ``1``. It must be greater than or equal
+  retry. Its default value is ``1.05``. It must be greater than or equal
   to ``1``.
 - ``retry_jitter``: Specifies by how much to randomize backoffs. Its
   default value is ``0``. It must be in range ``0`` to ``1``.
 - ``cluster_connect_timeout``: Timeout value in seconds for the client
   to give up to connect to the current cluster. Its default value is
-  ``120``.
+  ``-1``. For the default value, client will not stop trying to connect
+  to the target cluster. (infinite timeout)
 
 A pseudo-code is as follows:
 
@@ -86,6 +87,7 @@ A pseudo-code is as follows:
     while (try_connect(connection_timeout)) != SUCCESS) {
         if (get_current_time() - begin_time >= CLUSTER_CONNECT_TIMEOUT) {
             // Give up to connecting to the current cluster and switch to another if exists.
+            // For the default values, CLUSTER_CONNECT_TIMEOUT is infinite.
         }
         sleep(current_backoff + uniform_random(-JITTER * current_backoff, JITTER * current_backoff))
         current_backoff = min(current_backoff * MULTIPLIER, MAX_BACKOFF)

--- a/docs/client_connection_strategy.rst
+++ b/docs/client_connection_strategy.rst
@@ -74,7 +74,7 @@ The following are configuration element descriptions:
 - ``retry_jitter``: Specifies by how much to randomize backoffs. Its
   default value is ``0``. It must be in range ``0`` to ``1``.
 - ``cluster_connect_timeout``: Timeout value in seconds for the client
-  to give up to connect to the current cluster. Its default value is
+  to give up connecting to the cluster. Its default value is
   ``-1``. For the default value, client will not stop trying to connect
   to the target cluster. (infinite timeout)
 

--- a/docs/client_connection_strategy.rst
+++ b/docs/client_connection_strategy.rst
@@ -46,10 +46,9 @@ starting and reconnecting modes.
 Configuring Client Connection Retry
 -----------------------------------
 
-When the client is disconnected from the cluster or trying to connect
-to a one for the first time, it searches for new connections. You can
-configure the frequency of the connection attempts and the client
-shutdown behavior using the arguments below.
+The client searches for new connections when it is trying to connect
+to the cluster. Both the frequency of connection attempts and the
+client shutdown behavior can be configured using the arguments below.
 
 .. code:: python
 
@@ -75,8 +74,7 @@ The following are configuration element descriptions:
   default value is ``0``. It must be in range ``0`` to ``1``.
 - ``cluster_connect_timeout``: Timeout value in seconds for the client
   to give up connecting to the cluster. Its default value is
-  ``-1``. For the default value, client will not stop trying to connect
-  to the target cluster. (infinite timeout)
+  ``-1``. The client will continuously try to connect by default.
 
 A pseudo-code is as follows:
 
@@ -87,7 +85,7 @@ A pseudo-code is as follows:
     while (try_connect(connection_timeout)) != SUCCESS) {
         if (get_current_time() - begin_time >= CLUSTER_CONNECT_TIMEOUT) {
             // Give up to connecting to the current cluster and switch to another if exists.
-            // For the default values, CLUSTER_CONNECT_TIMEOUT is infinite.
+            // CLUSTER_CONNECT_TIMEOUT is infinite by default.
         }
         sleep(current_backoff + uniform_random(-JITTER * current_backoff, JITTER * current_backoff))
         current_backoff = min(current_backoff * MULTIPLIER, MAX_BACKOFF)

--- a/hazelcast/client.py
+++ b/hazelcast/client.py
@@ -1,7 +1,7 @@
 import logging
+import sys
 import threading
 
-from hazelcast import six
 from hazelcast.cluster import ClusterService, _InternalClusterService
 from hazelcast.config import _Config
 from hazelcast.connection import ConnectionManager, DefaultAddressProvider
@@ -678,7 +678,7 @@ class HazelcastClient(object):
     @staticmethod
     def _get_connection_timeout(config):
         timeout = config.connection_timeout
-        return six.MAXSIZE if timeout == 0 else timeout
+        return sys.maxsize if timeout == 0 else timeout
 
     @staticmethod
     def _init_load_balancer(config):

--- a/hazelcast/client.py
+++ b/hazelcast/client.py
@@ -123,7 +123,7 @@ class HazelcastClient(object):
             failed retry. Must be greater than or equal to ``1``. By default,
             set to ``1.05``.
         cluster_connect_timeout (float): Timeout value in seconds for the client to
-            give up a connection attempt to the cluster. Must be non-negative or
+            give up connecting to the cluster. Must be non-negative or
             equal to `-1`. By default, set to `-1`. `-1` means that the client
             will not stop trying to the target cluster. (infinite timeout)
         portable_version (int): Default value for the portable version if the

--- a/hazelcast/client.py
+++ b/hazelcast/client.py
@@ -121,10 +121,11 @@ class HazelcastClient(object):
             in range ``[0.0, 1.0]``. By default, set to ``0.0`` (no randomization).
         retry_multiplier (float): The factor with which to multiply backoff after a
             failed retry. Must be greater than or equal to ``1``. By default,
-            set to ``1.0``.
+            set to ``1.05``.
         cluster_connect_timeout (float): Timeout value in seconds for the client to
-            give up a connection attempt to the cluster. Must be non-negative.
-            By default, set to `120.0`.
+            give up a connection attempt to the cluster. Must be non-negative or
+            equal to `-1`. By default, set to `-1`. `-1` means that the client
+            will not stop trying to the target cluster. (infinite timeout)
         portable_version (int): Default value for the portable version if the
             class does not have the :func:`get_portable_version` method. Portable
             versions are used to differentiate two versions of the

--- a/hazelcast/config.py
+++ b/hazelcast/config.py
@@ -531,8 +531,8 @@ class _Config(object):
         self._retry_initial_backoff = 1.0
         self._retry_max_backoff = 30.0
         self._retry_jitter = 0.0
-        self._retry_multiplier = 1.0
-        self._cluster_connect_timeout = 120.0
+        self._retry_multiplier = 1.05
+        self._cluster_connect_timeout = -1
         self._portable_version = 0
         self._data_serializable_factories = {}
         self._portable_factories = {}
@@ -812,8 +812,8 @@ class _Config(object):
     @cluster_connect_timeout.setter
     def cluster_connect_timeout(self, value):
         if isinstance(value, number_types):
-            if value < 0:
-                raise ValueError("cluster_connect_timeout must be non-negative")
+            if value < 0 and value != -1:
+                raise ValueError("cluster_connect_timeout must be non-negative or equal to -1")
             self._cluster_connect_timeout = value
         else:
             raise TypeError("cluster_connect_timeout must be a number")

--- a/hazelcast/config.py
+++ b/hazelcast/config.py
@@ -459,6 +459,22 @@ class IndexUtil(object):
             raise ValueError("Unsupported index type %s" % index_type)
 
 
+_DEFAULT_CLUSTER_NAME = "dev"
+_DEFAULT_CONNECTION_TIMEOUT = 5.0
+_DEFAULT_RETRY_INITIAL_BACKOFF = 1.0
+_DEFAULT_RETRY_MAX_BACKOFF = 30.0
+_DEFAULT_RETRY_JITTER = 0.0
+_DEFAULT_RETRY_MULTIPLIER = 1.05
+_DEFAULT_CLUSTER_CONNECT_TIMEOUT = -1
+_DEFAULT_PORTABLE_VERSION = 0
+_DEFAULT_HEARTBEAT_INTERVAL = 5.0
+_DEFAULT_HEARTBEAT_TIMEOUT = 60.0
+_DEFAULT_INVOCATION_TIMEOUT = 120.0
+_DEFAULT_INVOCATION_RETRY_PAUSE = 1.0
+_DEFAULT_STATISTICS_PERIOD = 3.0
+_DEFAULT_OPERATION_BACKUP_TIMEOUT = 5.0
+
+
 class _Config(object):
     __slots__ = (
         "_cluster_members",
@@ -512,9 +528,9 @@ class _Config(object):
 
     def __init__(self):
         self._cluster_members = []
-        self._cluster_name = "dev"
+        self._cluster_name = _DEFAULT_CLUSTER_NAME
         self._client_name = None
-        self._connection_timeout = 5.0
+        self._connection_timeout = _DEFAULT_CONNECTION_TIMEOUT
         self._socket_options = []
         self._redo_operation = False
         self._smart_routing = True
@@ -528,12 +544,12 @@ class _Config(object):
         self._cloud_discovery_token = None
         self._async_start = False
         self._reconnect_mode = ReconnectMode.ON
-        self._retry_initial_backoff = 1.0
-        self._retry_max_backoff = 30.0
-        self._retry_jitter = 0.0
-        self._retry_multiplier = 1.05
-        self._cluster_connect_timeout = -1
-        self._portable_version = 0
+        self._retry_initial_backoff = _DEFAULT_RETRY_INITIAL_BACKOFF
+        self._retry_max_backoff = _DEFAULT_RETRY_MAX_BACKOFF
+        self._retry_jitter = _DEFAULT_RETRY_JITTER
+        self._retry_multiplier = _DEFAULT_RETRY_MULTIPLIER
+        self._cluster_connect_timeout = _DEFAULT_CLUSTER_CONNECT_TIMEOUT
+        self._portable_version = _DEFAULT_PORTABLE_VERSION
         self._data_serializable_factories = {}
         self._portable_factories = {}
         self._class_definitions = []
@@ -548,15 +564,15 @@ class _Config(object):
         self._lifecycle_listeners = []
         self._flake_id_generators = {}
         self._labels = []
-        self._heartbeat_interval = 5.0
-        self._heartbeat_timeout = 60.0
-        self._invocation_timeout = 120.0
-        self._invocation_retry_pause = 1.0
+        self._heartbeat_interval = _DEFAULT_HEARTBEAT_INTERVAL
+        self._heartbeat_timeout = _DEFAULT_HEARTBEAT_TIMEOUT
+        self._invocation_timeout = _DEFAULT_INVOCATION_TIMEOUT
+        self._invocation_retry_pause = _DEFAULT_INVOCATION_RETRY_PAUSE
         self._statistics_enabled = False
-        self._statistics_period = 3.0
+        self._statistics_period = _DEFAULT_STATISTICS_PERIOD
         self._shuffle_member_list = True
         self._backup_ack_to_client_enabled = True
-        self._operation_backup_timeout = 5.0
+        self._operation_backup_timeout = _DEFAULT_OPERATION_BACKUP_TIMEOUT
         self._fail_on_indeterminate_operation_state = False
 
     @property
@@ -812,8 +828,11 @@ class _Config(object):
     @cluster_connect_timeout.setter
     def cluster_connect_timeout(self, value):
         if isinstance(value, number_types):
-            if value < 0 and value != -1:
-                raise ValueError("cluster_connect_timeout must be non-negative or equal to -1")
+            if value < 0 and value != _DEFAULT_CLUSTER_CONNECT_TIMEOUT:
+                raise ValueError(
+                    "cluster_connect_timeout must be non-negative or equal to %s"
+                    % _DEFAULT_CLUSTER_CONNECT_TIMEOUT
+                )
             self._cluster_connect_timeout = value
         else:
             raise TypeError("cluster_connect_timeout must be a number")

--- a/hazelcast/connection.py
+++ b/hazelcast/connection.py
@@ -284,7 +284,7 @@ class ConnectionManager(object):
             # If the no timeout is specified by the
             # user, or set to -1 explicitly, set
             # the timeout to infinite.
-            cluster_connect_timeout = six.MAXSIZE
+            cluster_connect_timeout = sys.maxsize
 
         return _WaitStrategy(
             config.retry_initial_backoff,

--- a/hazelcast/cp.py
+++ b/hazelcast/cp.py
@@ -1,7 +1,7 @@
+import sys
 import time
 from threading import RLock, Lock
 
-from hazelcast import six
 from hazelcast.errors import (
     SessionExpiredError,
     CPGroupDestroyedError,
@@ -277,7 +277,7 @@ class _SessionState(object):
     def _is_expired(self, timestamp):
         expiration_time = self.creation_time + self.ttl
         if expiration_time < 0:
-            expiration_time = six.MAXSIZE
+            expiration_time = sys.maxsize
         return timestamp > expiration_time
 
     def __eq__(self, other):

--- a/hazelcast/listener.py
+++ b/hazelcast/listener.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 import threading
 from uuid import uuid4
 
@@ -100,7 +101,7 @@ class ListenerService(object):
                     continue
 
                 invocation = Invocation(
-                    deregister_request, connection=connection, timeout=six.MAXSIZE, urgent=True
+                    deregister_request, connection=connection, timeout=sys.maxsize, urgent=True
                 )
                 self._invocation_service.invoke(invocation)
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -293,7 +293,7 @@ class ConfigTest(unittest.TestCase):
 
     def test_retry_multiplier(self):
         config = self.config
-        self.assertEqual(1, config.retry_multiplier)
+        self.assertEqual(1.05, config.retry_multiplier)
 
         with self.assertRaises(ValueError):
             config.retry_multiplier = 0.5
@@ -306,10 +306,13 @@ class ConfigTest(unittest.TestCase):
 
     def test_cluster_connect_timeout(self):
         config = self.config
-        self.assertEqual(120, config.cluster_connect_timeout)
+        self.assertEqual(-1, config.cluster_connect_timeout)
+
+        config.cluster_connect_timeout = -1
+        self.assertEqual(-1, config.cluster_connect_timeout)
 
         with self.assertRaises(ValueError):
-            config.cluster_connect_timeout = -1
+            config.cluster_connect_timeout = -2
 
         with self.assertRaises(TypeError):
             config.cluster_connect_timeout = ""

--- a/tests/connection_strategy_test.py
+++ b/tests/connection_strategy_test.py
@@ -87,7 +87,6 @@ class ConnectionStrategyTest(HazelcastTestCase):
             cluster_members=["localhost:5701"],
             cluster_name=self.cluster.id,
             reconnect_mode=ReconnectMode.OFF,
-            cluster_connect_timeout=six.MAXSIZE,
             lifecycle_listeners=[event_collector],
         )
         m = self.client.get_map(random_string()).blocking()
@@ -119,7 +118,6 @@ class ConnectionStrategyTest(HazelcastTestCase):
             cluster_members=["localhost:5701"],
             cluster_name=self.cluster.id,
             reconnect_mode=ReconnectMode.ASYNC,
-            cluster_connect_timeout=six.MAXSIZE,
             lifecycle_listeners=[disconnected_collector],
         )
         m = self.client.get_map(random_string()).blocking()


### PR DESCRIPTION
We decided to set the default cluster connection timeout to
infinite to have a better user experience out-of-the-box
for most of the users/use cases. Note that, this is a breaking
change for the users who rely on the client to shutdown after
some time. Affected users might set the `cluster_connect_timeout`
to a finite value.

Also, updated the default value of the `retry_multiplier` to back off
more after the client tries to connect to the target cluster for
some time.

Closes #335 
Closes #306