### PR TITLE
Do not check backup timeout for resolved invocations

### DIFF
--- a/hazelcast/invocation.py
+++ b/hazelcast/invocation.py
@@ -350,6 +350,7 @@ class InvocationService(object):
                 if not connection.live:
                     error = TargetDisconnectedError(connection.close_reason)
                     self._notify_error(invocation, error)
+                    continue
 
                 if self._backup_ack_to_client_enabled:
                     self._detect_and_handle_backup_timeout(invocation, now)


### PR DESCRIPTION
In the clean resources timer, if we detect that the connection that
the invocation is sent is not alive, we resolve it with
TargetDisconnectedError. For those invocations, there is no need
to check the backup timeout.

Closes #325