### PR TITLE
Do not overwrite invocation timeout in the constructor

### DIFF
--- a/hazelcast/invocation.py
+++ b/hazelcast/invocation.py
@@ -62,7 +62,6 @@ class Invocation(object):
         self.urgent = urgent
         self.timeout = timeout
         self.future = Future()
-        self.timeout = None
         self.sent_connection = None
         self.response_handler = response_handler
         self.backup_acks_received = 0

--- a/tests/invocation_test.py
+++ b/tests/invocation_test.py
@@ -149,6 +149,10 @@ class InvocationTest(unittest.TestCase):
             invocation.set_exception.call_args[0][0], IndeterminateOperationStateError
         )
 
+    def test_constructor_with_timeout(self):
+        invocation = Invocation(None, timeout=42)
+        self.assertEqual(42, invocation.timeout)
+
     def _start_service(self, config=_Config()):
         c = MagicMock()
         invocation_service = InvocationService(c, config, c._reactor)


### PR DESCRIPTION
We were mistakenly overwriting the invocation timeout to None
even if it is explicitly set to something else.

We are now respecting the given timeout value in the invocation
constructor.