### PR TITLE
Use time.monotonic() instead of time.time() for profiling 

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -60,9 +60,9 @@ class HazelcastTestCase(unittest.TestCase):
         self.clients = []
 
     def assertTrueEventually(self, assertion, timeout=30):
-        timeout_time = time.time() + timeout
+        timeout_time = time.monotonic() + timeout
         exc_info = None
-        while time.time() < timeout_time:
+        while time.monotonic() < timeout_time:
             try:
                 assertion()
                 return

--- a/tests/base.py
+++ b/tests/base.py
@@ -6,6 +6,7 @@ from threading import Thread
 
 from hazelcast import six
 from tests.hzrc.client import HzRemoteController
+from tests.util import get_current_timestamp
 import hazelcast
 from hazelcast.core import Address
 
@@ -60,9 +61,9 @@ class HazelcastTestCase(unittest.TestCase):
         self.clients = []
 
     def assertTrueEventually(self, assertion, timeout=30):
-        timeout_time = time.monotonic() + timeout
+        timeout_time = get_current_timestamp() + timeout
         exc_info = None
-        while time.monotonic() < timeout_time:
+        while get_current_timestamp() < timeout_time:
             try:
                 assertion()
                 return

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -53,9 +53,9 @@ class ClientTest(HazelcastTestCase):
         topic.add_listener(message_listener)
 
         topic2 = client2.get_topic(key)
-        begin = time.time()
+        begin = time.monotonic()
 
-        while (time.time() - begin) < 2 * client_heartbeat_seconds:
+        while (time.monotonic() - begin) < 2 * client_heartbeat_seconds:
             topic2.publish("message")
             time.sleep(0.5)
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -4,6 +4,7 @@ from tests.base import HazelcastTestCase
 from hazelcast.client import HazelcastClient
 from hazelcast.lifecycle import LifecycleState
 from tests.hzrc.ttypes import Lang
+from tests.util import get_current_timestamp
 
 
 class ClientTest(HazelcastTestCase):
@@ -53,9 +54,9 @@ class ClientTest(HazelcastTestCase):
         topic.add_listener(message_listener)
 
         topic2 = client2.get_topic(key)
-        begin = time.monotonic()
+        begin = get_current_timestamp()
 
-        while (time.monotonic() - begin) < 2 * client_heartbeat_seconds:
+        while (get_current_timestamp() - begin) < 2 * client_heartbeat_seconds:
             topic2.publish("message")
             time.sleep(0.5)
 

--- a/tests/proxy/cp/count_down_latch_test.py
+++ b/tests/proxy/cp/count_down_latch_test.py
@@ -9,7 +9,7 @@ from hazelcast.future import ImmediateExceptionFuture
 from hazelcast.proxy.cp.count_down_latch import CountDownLatch
 from hazelcast.util import AtomicInteger
 from tests.proxy.cp import CPTestCase
-from tests.util import random_string
+from tests.util import random_string, get_current_timestamp
 
 inf = 2 ** 31 - 1
 
@@ -49,9 +49,9 @@ class CountDownLatchTest(CPTestCase):
 
     def test_await_latch_with_timeout(self):
         latch = self._get_latch(1)
-        start = time.monotonic()
+        start = get_current_timestamp()
         self.assertFalse(latch.await_latch(0.1))
-        time_passed = time.monotonic() - start
+        time_passed = get_current_timestamp() - start
         self.assertTrue(time_passed > 0.1)
 
     def test_await_latch_multiple_waiters(self):

--- a/tests/proxy/cp/count_down_latch_test.py
+++ b/tests/proxy/cp/count_down_latch_test.py
@@ -49,9 +49,9 @@ class CountDownLatchTest(CPTestCase):
 
     def test_await_latch_with_timeout(self):
         latch = self._get_latch(1)
-        start = time.time()
+        start = time.monotonic()
         self.assertFalse(latch.await_latch(0.1))
-        time_passed = time.time() - start
+        time_passed = time.monotonic() - start
         self.assertTrue(time_passed > 0.1)
 
     def test_await_latch_multiple_waiters(self):

--- a/tests/proxy/cp/semaphore_test.py
+++ b/tests/proxy/cp/semaphore_test.py
@@ -129,11 +129,11 @@ class SemaphoreTest(CPTestCase):
         t = threading.Thread(target=run)
         t.start()
         event.wait()
-        start = time.time()
+        start = time.monotonic()
         f = semaphore._wrapped.acquire()
         event2.set()
         f.result()
-        self.assertGreaterEqual(time.time() - start, 1)
+        self.assertGreaterEqual(time.monotonic() - start, 1)
         t.join()
 
     @parameterized.expand(SEMAPHORE_TYPES)
@@ -152,14 +152,14 @@ class SemaphoreTest(CPTestCase):
         t = threading.Thread(target=run)
         t.start()
         event.wait()
-        start = time.time()
+        start = time.monotonic()
         f = semaphore._wrapped.acquire()
         event2.set()
 
         with self.assertRaises(DistributedObjectDestroyedError):
             f.result()
 
-        self.assertGreaterEqual(time.time() - start, 1)
+        self.assertGreaterEqual(time.monotonic() - start, 1)
         t.join()
 
     @parameterized.expand(SEMAPHORE_TYPES)
@@ -284,9 +284,9 @@ class SemaphoreTest(CPTestCase):
     @parameterized.expand(SEMAPHORE_TYPES)
     def test_try_acquire_when_not_enough_permits_with_timeout(self, semaphore_type):
         semaphore = self.get_semaphore(semaphore_type, 1)
-        start = time.time()
+        start = time.monotonic()
         self.assertFalse(semaphore.try_acquire(2, 1))
-        self.assertGreaterEqual(time.time() - start, 1)
+        self.assertGreaterEqual(time.monotonic() - start, 1)
         self.assertEqual(1, semaphore.available_permits())
 
     def get_semaphore(self, semaphore_type, initialize_with=None):

--- a/tests/proxy/cp/semaphore_test.py
+++ b/tests/proxy/cp/semaphore_test.py
@@ -19,7 +19,7 @@ from hazelcast.protocol import RaftGroupId
 from hazelcast.proxy.cp.semaphore import SessionlessSemaphore, SessionAwareSemaphore
 from hazelcast.util import AtomicInteger
 from tests.proxy.cp import CPTestCase
-from tests.util import random_string
+from tests.util import random_string, get_current_timestamp
 
 SEMAPHORE_TYPES = [
     "sessionless",
@@ -129,11 +129,11 @@ class SemaphoreTest(CPTestCase):
         t = threading.Thread(target=run)
         t.start()
         event.wait()
-        start = time.monotonic()
+        start = get_current_timestamp()
         f = semaphore._wrapped.acquire()
         event2.set()
         f.result()
-        self.assertGreaterEqual(time.monotonic() - start, 1)
+        self.assertGreaterEqual(get_current_timestamp() - start, 1)
         t.join()
 
     @parameterized.expand(SEMAPHORE_TYPES)
@@ -152,14 +152,14 @@ class SemaphoreTest(CPTestCase):
         t = threading.Thread(target=run)
         t.start()
         event.wait()
-        start = time.monotonic()
+        start = get_current_timestamp()
         f = semaphore._wrapped.acquire()
         event2.set()
 
         with self.assertRaises(DistributedObjectDestroyedError):
             f.result()
 
-        self.assertGreaterEqual(time.monotonic() - start, 1)
+        self.assertGreaterEqual(get_current_timestamp() - start, 1)
         t.join()
 
     @parameterized.expand(SEMAPHORE_TYPES)
@@ -284,9 +284,9 @@ class SemaphoreTest(CPTestCase):
     @parameterized.expand(SEMAPHORE_TYPES)
     def test_try_acquire_when_not_enough_permits_with_timeout(self, semaphore_type):
         semaphore = self.get_semaphore(semaphore_type, 1)
-        start = time.monotonic()
+        start = get_current_timestamp()
         self.assertFalse(semaphore.try_acquire(2, 1))
-        self.assertGreaterEqual(time.monotonic() - start, 1)
+        self.assertGreaterEqual(get_current_timestamp() - start, 1)
         self.assertEqual(1, semaphore.available_permits())
 
     def get_semaphore(self, semaphore_type, initialize_with=None):

--- a/tests/reactor_test.py
+++ b/tests/reactor_test.py
@@ -341,12 +341,12 @@ class AsyncoreConnectionTest(HazelcastTestCase):
     def test_constructor_with_unreachable_addresses(self):
         addr = Address("192.168.0.1", 5701)
         config = _Config()
-        start = time.time()
+        start = time.monotonic()
         conn = AsyncoreConnection(MagicMock(map=dict()), MagicMock(), None, addr, config, None)
         try:
             # Server is unreachable, but this call should return
             # before connection timeout
-            self.assertLess(time.time() - start, config.connection_timeout)
+            self.assertLess(time.monotonic() - start, config.connection_timeout)
         finally:
             conn.close(None, None)
 

--- a/tests/reactor_test.py
+++ b/tests/reactor_test.py
@@ -20,6 +20,7 @@ from hazelcast.reactor import (
 )
 from hazelcast.util import AtomicInteger
 from tests.base import HazelcastTestCase
+from tests.util import get_current_timestamp
 
 
 class ReactorTest(HazelcastTestCase):
@@ -341,12 +342,12 @@ class AsyncoreConnectionTest(HazelcastTestCase):
     def test_constructor_with_unreachable_addresses(self):
         addr = Address("192.168.0.1", 5701)
         config = _Config()
-        start = time.monotonic()
+        start = get_current_timestamp()
         conn = AsyncoreConnection(MagicMock(map=dict()), MagicMock(), None, addr, config, None)
         try:
             # Server is unreachable, but this call should return
             # before connection timeout
-            self.assertLess(time.monotonic() - start, config.connection_timeout)
+            self.assertLess(get_current_timestamp() - start, config.connection_timeout)
         finally:
             conn.close(None, None)
 

--- a/tests/soak_test/map_soak_test.py
+++ b/tests/soak_test/map_soak_test.py
@@ -13,6 +13,7 @@ import random
 from hazelcast.client import HazelcastClient
 from hazelcast.serialization.api import IdentifiedDataSerializable
 from hazelcast.predicate import between
+from tests.util import get_current_timestamp
 
 THREAD_COUNT = 32
 ENTRY_COUNT = 10000
@@ -111,8 +112,8 @@ def start():
     test_failed = [False]
 
     def run(stats):
-        end_time = time.monotonic() + hour_limit * 60 * 60
-        while time.monotonic() < end_time:
+        end_time = get_current_timestamp() + hour_limit * 60 * 60
+        while get_current_timestamp() < end_time:
             if test_failed[0]:
                 return  # Some other thread failed, no need to continue the test
 
@@ -148,8 +149,8 @@ def start():
         thread.start()
 
     def display_statistics():
-        end_time = time.monotonic() + hour_limit * 60 * 60
-        while time.monotonic() < end_time:
+        end_time = get_current_timestamp() + hour_limit * 60 * 60
+        while get_current_timestamp() < end_time:
             time.sleep(STATS_DISPLAY_SECONDS)
             if test_failed[0]:
                 # Some thread failed. No need to continue.

--- a/tests/soak_test/map_soak_test.py
+++ b/tests/soak_test/map_soak_test.py
@@ -111,8 +111,8 @@ def start():
     test_failed = [False]
 
     def run(stats):
-        end_time = time.time() + hour_limit * 60 * 60
-        while time.time() < end_time:
+        end_time = time.monotonic() + hour_limit * 60 * 60
+        while time.monotonic() < end_time:
             if test_failed[0]:
                 return  # Some other thread failed, no need to continue the test
 
@@ -148,8 +148,8 @@ def start():
         thread.start()
 
     def display_statistics():
-        end_time = time.time() + hour_limit * 60 * 60
-        while time.time() < end_time:
+        end_time = time.monotonic() + hour_limit * 60 * 60
+        while time.monotonic() < end_time:
             time.sleep(STATS_DISPLAY_SECONDS)
             if test_failed[0]:
                 # Some thread failed. No need to continue.

--- a/tests/statistics_test.py
+++ b/tests/statistics_test.py
@@ -205,9 +205,9 @@ class StatisticsTest(HazelcastTestCase):
             raise AssertionError
 
     def _wait_for_statistics_collection(self, client_uuid, timeout=30):
-        timeout_time = time.time() + timeout
+        timeout_time = time.monotonic() + timeout
         response = self._get_client_stats_from_server(client_uuid)
-        while time.time() < timeout_time:
+        while time.monotonic() < timeout_time:
             try:
                 self._verify_response_not_empty(response)
                 return response

--- a/tests/statistics_test.py
+++ b/tests/statistics_test.py
@@ -6,7 +6,7 @@ from hazelcast.core import CLIENT_TYPE
 from hazelcast.statistics import Statistics
 from tests.base import HazelcastTestCase
 from tests.hzrc.ttypes import Lang
-from tests.util import random_string
+from tests.util import random_string, get_current_timestamp
 
 
 class StatisticsTest(HazelcastTestCase):
@@ -205,9 +205,9 @@ class StatisticsTest(HazelcastTestCase):
             raise AssertionError
 
     def _wait_for_statistics_collection(self, client_uuid, timeout=30):
-        timeout_time = time.monotonic() + timeout
+        timeout_time = get_current_timestamp() + timeout
         response = self._get_client_stats_from_server(client_uuid)
-        while time.monotonic() < timeout_time:
+        while get_current_timestamp() < timeout_time:
             try:
                 self._verify_response_not_empty(response)
                 return response

--- a/tests/util.py
+++ b/tests/util.py
@@ -34,14 +34,14 @@ def fill_map(map, size=10, key_prefix="key", value_prefix="val"):
 
 
 def get_ssl_config(
-        cluster_name,
-        enable_ssl=False,
-        cafile=None,
-        certfile=None,
-        keyfile=None,
-        password=None,
-        protocol=SSLProtocol.TLSv1_2,
-        ciphers=None,
+    cluster_name,
+    enable_ssl=False,
+    cafile=None,
+    certfile=None,
+    keyfile=None,
+    password=None,
+    protocol=SSLProtocol.TLSv1_2,
+    ciphers=None,
 ):
     config = {
         "cluster_name": cluster_name,

--- a/tests/util.py
+++ b/tests/util.py
@@ -3,27 +3,12 @@ import time
 
 from uuid import uuid4
 from hazelcast.config import SSLProtocol
-from hazelcast.six import PY3
 
-
-def get_current_timestamp():
-    """
-    Get current timestamp.
-    time.monotonic() is more consistent since it uses cpu clock rather than system clock.
-
-    python versions 3.3 and up supports time.monotonic(). Before python version 3.5 and on gnu/hurd
-    monotonic() is not available. Since we support support python3.4 and up, there is a check
-    for the monotonic attribute availability, just for gnu/hurd.
-
-    Returns:
-        If time.time() used, this function returns is number of seconds since 1970,
-        if time.monotonic() is used, it still returns fractional seconds but its value alone
-        is not meaningful, but it can still can be used take time difference for profiling.
-    """
-    if PY3 and hasattr(time, "monotonic"):
-        return time.monotonic()
-    else:
-        return time.time()
+# time.monotonic() is more consistent since it uses cpu clock rather than system clock. Use it if available.
+if hasattr(time, "monotonic"):
+    get_current_timestamp = time.monotonic
+else:
+    get_current_timestamp = time.time
 
 
 def random_string():

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,13 +1,13 @@
 import os
 import time
-import sys
 
 from uuid import uuid4
 from hazelcast.config import SSLProtocol
+from hazelcast.six import PY3
 
 
 def get_current_timestamp():
-    if sys.version_info >= (3, 3):
+    if PY3:
         return time.monotonic()
     else:
         return time.time()

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,8 +1,16 @@
 import os
 import time
+import sys
 
 from uuid import uuid4
 from hazelcast.config import SSLProtocol
+
+
+def get_current_timestamp():
+    if sys.version_info >= (3, 5):
+        return time.monotonic()
+    else:
+        return time.time()
 
 
 def random_string():

--- a/tests/util.py
+++ b/tests/util.py
@@ -7,7 +7,19 @@ from hazelcast.six import PY3
 
 
 def get_current_timestamp():
-    if PY3:
+    """
+    Get current timestamp.
+    time.monotonic() is more resilient since it uses cpu clock rather than system clock changes
+    python 3.3 and up supports time.monotonic(). Before python 3.5 and on gnu/hurd monotonic() is
+    not available. Since we support support python3.4 and up regarding python3, there is a check
+    for the monotonic() availability.
+
+    Returns:
+        If time.time() used, this function returns is number of seconds since 1970,
+        if time.monotonic() is used, it still returns fractional seconds but its value alone
+        is not meaningful, but it can still can be used take time difference for profiling.
+    """
+    if PY3 and hasattr(time, "monotonic"):
         return time.monotonic()
     else:
         return time.time()
@@ -36,14 +48,14 @@ def fill_map(map, size=10, key_prefix="key", value_prefix="val"):
 
 
 def get_ssl_config(
-    cluster_name,
-    enable_ssl=False,
-    cafile=None,
-    certfile=None,
-    keyfile=None,
-    password=None,
-    protocol=SSLProtocol.TLSv1_2,
-    ciphers=None,
+        cluster_name,
+        enable_ssl=False,
+        cafile=None,
+        certfile=None,
+        keyfile=None,
+        password=None,
+        protocol=SSLProtocol.TLSv1_2,
+        ciphers=None,
 ):
     config = {
         "cluster_name": cluster_name,

--- a/tests/util.py
+++ b/tests/util.py
@@ -9,10 +9,11 @@ from hazelcast.six import PY3
 def get_current_timestamp():
     """
     Get current timestamp.
-    time.monotonic() is more resilient since it uses cpu clock rather than system clock changes
-    python 3.3 and up supports time.monotonic(). Before python 3.5 and on gnu/hurd monotonic() is
-    not available. Since we support support python3.4 and up regarding python3, there is a check
-    for the monotonic() availability.
+    time.monotonic() is more consistent since it uses cpu clock rather than system clock.
+
+    python versions 3.3 and up supports time.monotonic(). Before python version 3.5 and on gnu/hurd
+    monotonic() is not available. Since we support support python3.4 and up, there is a check
+    for the monotonic attribute availability, just for gnu/hurd.
 
     Returns:
         If time.time() used, this function returns is number of seconds since 1970,

--- a/tests/util.py
+++ b/tests/util.py
@@ -7,7 +7,7 @@ from hazelcast.config import SSLProtocol
 
 
 def get_current_timestamp():
-    if sys.version_info >= (3, 5):
+    if sys.version_info >= (3, 3):
         return time.monotonic()
     else:
         return time.time()


### PR DESCRIPTION
* [time.time()](https://docs.python.org/3/library/time.html#time.time) returns the time based on system clock, which can go back for several reasons such as 
    * synchronization from a web server
    * leap seconds
* Thus, using time.time() for profiling is not the correct option. The difference might even be negative due to reasons above.
* Instead of using time.time(), [time.monotonic()](https://docs.python.org/3/library/time.html#time.monotonic) should be used as it is based on cpu clock and always increases.