### PR TITLE
Link to the Features section in the documentation index

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -110,8 +110,7 @@ Features
    **Unisocket** and **Smart** operation modes
 -  Ability to listen to client lifecycle, cluster state, and distributed
    data structure events
--  and `many
-   more <https://hazelcast.org/imdg/clients-languages/python/#client-features>`__
+-  and :ref:`many more<features:features>`
 
 
 .. toctree::


### PR DESCRIPTION
As requested, we now link to the Features section of the documentation
in the index, instead of the hazelcast.org link.