### PR TITLE
Fix authentication mechanism

### DIFF
--- a/hazelcast/future.py
+++ b/hazelcast/future.py
@@ -38,7 +38,7 @@ class Future(object):
         """Sets the exception for this Future in case of errors.
 
         Args:
-            exception (Exception): Exception to be threw in case of error.
+            exception (BaseException): Exception to be threw in case of error.
             traceback (function): Function to be called on traceback.
         """
         if not isinstance(exception, BaseException):


### PR DESCRIPTION
As of now, during the authentication process, we, more or less, do the
following:

- Send an authentication request
- Put a future that will be resolved after the authentication request completes
to the pending connections that performs client-side authentication logic
(ConnectionManager#on_auth)
- Return the future

The problem is that, through unlucky timing, we might perform the
authentication logic before putting the future to the pending connections
map. Such as,

- Clients initiates get_or_connect in the main thread during startup
- We send the authentication request in the main thread
- Before we return the invocation future, and add a callback to it,
Python schedules the reactor thread, we write the request to wire,
and get back the response.
- Python schedules the main thread again, it is now trying to add
a callback to a completed future. Since it is completed, it executes
the authentication logic immediately. One of the steps of the client
side authentication logic is to remove the connection from the pending
connections map. Since the future is not put into the map yet, nothing
is removed.
- We then add this future to the pending connections map, but since
it is already completed, no one is going to remove it from the
pending connections map.
- During the shutdown, we see an unexpected entry in the pending
connections map and fail.

To solve this, we put a future directly into the pending connections
and perform the logic afterward.

Closes #378 