### PR TITLE
Fail fast on the METADATA group name for CP data structures

### DIFF
--- a/hazelcast/cp.py
+++ b/hazelcast/cp.py
@@ -155,6 +155,7 @@ class CPSubsystem(object):
 
 
 _DEFAULT_GROUP_NAME = "default"
+_METADATA_CP_GROUP_NAME = "metadata"
 
 
 def _without_default_group_name(name):
@@ -165,7 +166,11 @@ def _without_default_group_name(name):
 
     check_true(name.find("@", idx + 1) == -1, "Custom group name must be specified at most once")
     group_name = name[idx + 1 :].strip()
-    if group_name == _DEFAULT_GROUP_NAME:
+    check_true(
+        group_name.lower() != _METADATA_CP_GROUP_NAME,
+        "CP data structures cannot run on the METADATA CP group!",
+    )
+    if group_name.lower() == _DEFAULT_GROUP_NAME:
         return name[:idx]
     return name
 

--- a/tests/unit/proxy/cp/cp_proxy_manager_test.py
+++ b/tests/unit/proxy/cp/cp_proxy_manager_test.py
@@ -6,11 +6,19 @@ from hazelcast.cp import _without_default_group_name, _get_object_name_for_proxy
 class CPProxyManagerTest(unittest.TestCase):
     def test_without_default_group_name(self):
         self.assertEqual("test", _without_default_group_name("test@default"))
+        self.assertEqual("test", _without_default_group_name("test@DEFAULT"))
         self.assertEqual("test@custom", _without_default_group_name("test@custom"))
 
     def test_without_default_group_name_with_multiple_group_names(self):
         with self.assertRaises(AssertionError):
             _without_default_group_name("test@default@@default")
+
+    def test_without_default_group_name_with_metadata_group_name(self):
+        with self.assertRaises(AssertionError):
+            _without_default_group_name("test@METADATA")
+
+        with self.assertRaises(AssertionError):
+            _without_default_group_name("test@metadata")
 
     def test_get_object_name_for_proxy(self):
         self.assertEqual("test", _get_object_name_for_proxy("test@default"))


### PR DESCRIPTION
It is not possible to run the CP data structures on the metadata
group name. We now fail-fast if someone tries to use the `METADATA`
as the CP group name. Also, the group name comparison made
case-insensitive.

Closes #374 