### PR TITLE
Add tests that verify near cache works even if the cluster connecti…

### DIFF
--- a/hazelcast/near_cache.py
+++ b/hazelcast/near_cache.py
@@ -84,6 +84,7 @@ class NearCache(dict):
         eviction_sampling_count=None,
         eviction_sampling_pool_size=None,
     ):
+        super(NearCache, self).__init__()
         self.name = name
         self.serialization_service = serialization_service
         self.in_memory_format = in_memory_format

--- a/tests/integration/backward_compatible/client_test.py
+++ b/tests/integration/backward_compatible/client_test.py
@@ -33,7 +33,6 @@ class ClientTest(HazelcastTestCase):
             events = []
 
             def event_collector(e):
-                print(e)
                 if e == LifecycleState.DISCONNECTED:
                     events.append(e)
 


### PR DESCRIPTION
…on is down

Similar to the Java client, added simple tests that verify the map with
near cache continues to work for the entries that exist in the cache
even if the cluster connection is down.

Closes #309 