### PR TITLE
Do not use deprecated abstract classes from collections

### DIFF
--- a/hazelcast/util.py
+++ b/hazelcast/util.py
@@ -1,7 +1,12 @@
 import random
 import threading
 import time
-from collections import Sequence, Iterable
+
+try:
+    from collections.abc import Sequence, Iterable
+except ImportError:
+    # Compatibility for Python2
+    from collections import Sequence, Iterable
 
 from hazelcast import six
 


### PR DESCRIPTION
Abstract classes Sequence and Iterable are meant to be imported
from `collections.abc` instead of `collections` starting from
Python 3.3. Since the minimum supported Python version for the
client is 3.4, we can safely try to import it from the new location
and fallback to the old location if the import fails. It will only
fail for Python 2.7 in which it is fine to import those abstract
classes from `collections`.

Closes #384 