### PR TITLE
Add a test that verifies client can work when it is configured with different network interface than member

### DIFF
--- a/tests/integration/backward_compatible/reconnect_test.py
+++ b/tests/integration/backward_compatible/reconnect_test.py
@@ -1,6 +1,8 @@
+import sys
 import time
-from threading import Thread
+from threading import Thread, Event
 
+from hazelcast import HazelcastClient
 from hazelcast.errors import HazelcastError, TargetDisconnectedError
 from hazelcast.lifecycle import LifecycleState
 from hazelcast.util import AtomicInteger
@@ -141,3 +143,128 @@ class ReconnectTest(HazelcastTestCase):
             self.assertEqual(new_member.uuid, str(members[0].uuid))
 
         self.assertTrueEventually(assert_member_list)
+
+
+class ReconnectWithDifferentInterfacesTest(HazelcastTestCase):
+    def _create_cluster_config(self, public_address, heartbeat_seconds=300):
+        return """<?xml version="1.0" encoding="UTF-8"?>
+        <hazelcast xmlns="http://www.hazelcast.com/schema/config"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://www.hazelcast.com/schema/config
+            http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd">
+            <network>
+                <public-address>%s</public-address>
+            </network>
+            <properties>
+                <property name="hazelcast.client.max.no.heartbeat.seconds">%d</property>
+            </properties>
+        </hazelcast>""" % (
+            public_address,
+            heartbeat_seconds,
+        )
+
+    def setUp(self):
+        self.rc = self.create_rc()
+
+    def tearDown(self):
+        self.rc.exit()
+
+    def test_connection_count_after_reconnect_with_member_hostname_client_ip(self):
+        self._verify_connection_count_after_reconnect("localhost", "127.0.0.1")
+
+    def test_connection_count_after_reconnect_with_member_hostname_client_hostname(self):
+        self._verify_connection_count_after_reconnect("localhost", "localhost")
+
+    def test_connection_count_after_reconnect_with_member_ip_client_ip(self):
+        self._verify_connection_count_after_reconnect("127.0.0.1", "127.0.0.1")
+
+    def test_connection_count_after_reconnect_with_member_ip_client_hostname(self):
+        self._verify_connection_count_after_reconnect("127.0.0.1", "localhost")
+
+    def test_listeners_after_client_disconnected_with_member_hostname_client_ip(self):
+        self._verify_listeners_after_client_disconnected("localhost", "127.0.0.1")
+
+    def test_listeners_after_client_disconnected_with_member_hostname_client_hostname(self):
+        self._verify_listeners_after_client_disconnected("localhost", "localhost")
+
+    def test_listeners_after_client_disconnected_with_member_ip_client_ip(self):
+        self._verify_listeners_after_client_disconnected("127.0.0.1", "127.0.0.1")
+
+    def test_listeners_after_client_disconnected_with_member_ip_client_hostname(self):
+        self._verify_listeners_after_client_disconnected("127.0.0.1", "localhost")
+
+    def _verify_connection_count_after_reconnect(self, member_address, client_address):
+        cluster = self.create_cluster(self.rc, self._create_cluster_config(member_address))
+        member = cluster.start_member()
+
+        disconnected = Event()
+        reconnected = Event()
+
+        def listener(state):
+            if state == "DISCONNECTED":
+                disconnected.set()
+
+            if state == "CONNECTED" and disconnected.is_set():
+                reconnected.set()
+
+        client = HazelcastClient(
+            cluster_name=cluster.id,
+            cluster_members=[client_address],
+            cluster_connect_timeout=sys.maxsize,
+            lifecycle_listeners=[listener],
+        )
+
+        self.assertTrueEventually(
+            lambda: self.assertEqual(1, len(client._connection_manager.active_connections))
+        )
+
+        member.shutdown()
+
+        self.assertTrueEventually(lambda: self.assertTrue(disconnected.is_set()))
+
+        cluster.start_member()
+
+        self.assertTrueEventually(lambda: self.assertTrue(reconnected.is_set()))
+
+        self.assertEqual(1, len(client._connection_manager.active_connections))
+
+        client.shutdown()
+        self.rc.terminateCluster(cluster.id)
+
+    def _verify_listeners_after_client_disconnected(self, member_address, client_address):
+        heartbeat_seconds = 2
+        cluster = self.create_cluster(
+            self.rc, self._create_cluster_config(member_address, heartbeat_seconds)
+        )
+        member = cluster.start_member()
+
+        client = HazelcastClient(
+            cluster_name=cluster.id,
+            cluster_members=[client_address],
+            cluster_connect_timeout=sys.maxsize,
+        )
+
+        test_map = client.get_map("test").blocking()
+
+        event_count = AtomicInteger()
+
+        test_map.add_entry_listener(
+            added_func=lambda _: event_count.get_and_increment(), include_value=False
+        )
+
+        self.assertTrueEventually(
+            lambda: self.assertEqual(1, len(client._connection_manager.active_connections))
+        )
+
+        member.shutdown()
+
+        time.sleep(2 * heartbeat_seconds)
+
+        cluster.start_member()
+
+        def assertion():
+            test_map.remove(1)
+            test_map.put(1, 2)
+            self.assertNotEqual(0, event_count.get())
+
+        self.assertTrueEventually(assertion)


### PR DESCRIPTION
Based on the Java-side `ClientRegressionWithRealNetworkTest`, added tests
that verify the client can continue to work when it is configured with
different network interfaces than the member side. Note that, this
is just a test that verifies the behavior of the client is correct.

Closes #148 