### PR TITLE
[API-337] Monkey patch client shutdown on tests for older client versions

### DIFF
--- a/hazelcast/__init__.py
+++ b/hazelcast/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.0"
+__version__ = "4.1"
 
 # Set the default handler to "hazelcast" loggers
 # to avoid "No handlers could be found" warnings.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,10 @@
 import logging
 import subprocess
 
+from hazelcast import __version__, HazelcastClient
+
+from hazelcast.util import calculate_version
+
 try:
     output = subprocess.check_output(["git", "show", "-s", '--format="%h"']).decode()
     commit_id = output.strip().replace('"', "").replace("'", "")
@@ -14,3 +18,34 @@ logging.basicConfig(
     datefmt="%H:%M:%S,",
 )
 logging.getLogger().setLevel(logging.INFO)
+
+if calculate_version(__version__) < calculate_version("4.1"):
+    # For the 4.0 version of the client, there is a known
+    # bug that might affect client shutdown in some scheduling
+    # scenarios. See
+    # https://github.com/hazelcast/hazelcast-python-client/issues/378
+    # and linked PRs for details. In short, shutdown might fail
+    # on connection_manager shutdown, due to unexpected pending
+    # connections. What we do here is that, we try to shutdown
+    # as usual, if it fails, we try to shutdown leftovers and
+    # return without raising.
+
+    original_shutdown = HazelcastClient.shutdown
+
+    def patched_shutdown(self):
+        try:
+            # business as usual
+            original_shutdown(self)
+        except RuntimeError:
+            # ConnectionManager shutdown failed.
+
+            # We need to explicitly shutdown invocation
+            # service due to infinitely running cleanup
+            # timer.
+            self._invocation_service.shutdown()
+
+            # Shutdown reactor thread so that it won't
+            # affect other tests
+            self._reactor.shutdown()
+
+    HazelcastClient.shutdown = patched_shutdown


### PR DESCRIPTION
Due to a bug on the older client releases, the backward compatibility
tests sometimes fail on the client.shutdown() call. The reasoning
is explained in the https://github.com/hazelcast/hazelcast-python-client/issues/378
and linked PRs.

To solve this problem, we monkey patch the shutdown method, try to
call it, if it fails with an expected exception, cleanup the
leftovers and return without an error.

Shutdown calls generally happen on the teardown methods of the
tests so that we do not leak any clients to other tests. This
change should not cause any problems in actual tests.

This change should not cause any change in the current codebase
since we increased the client version to the next version in this PR (to 4.1)