### PR TITLE
Update Hazelcast version used in tests

### DIFF
--- a/start_rc.py
+++ b/start_rc.py
@@ -3,7 +3,7 @@ import subprocess
 import sys
 from os.path import isfile
 
-SERVER_VERSION = "4.1"
+SERVER_VERSION = "4.1.4-SNAPSHOT"
 RC_VERSION = "0.8-SNAPSHOT"
 
 RELEASE_REPO = "http://repo1.maven.apache.org/maven2"

--- a/start_rc.py
+++ b/start_rc.py
@@ -47,6 +47,7 @@ def download_if_necessary(repo, artifact_id, version, is_test_artifact=False):
         "mvn",
         "-q",
         "dependency:get",
+        "-Dtransitive=false",
         "-DrepoUrl=" + repo,
         "-Dartifact=" + artifact,
         "-Ddest=" + dest_file_name,


### PR DESCRIPTION
Updated the version to 4.1.4-SNAPSHOT to use the renewed
certificates.