### PR TITLE
Fix SOAK test script

### DIFF
--- a/tests/soak_test/map_soak_test.py
+++ b/tests/soak_test/map_soak_test.py
@@ -13,7 +13,12 @@ import random
 from hazelcast.client import HazelcastClient
 from hazelcast.serialization.api import IdentifiedDataSerializable
 from hazelcast.predicate import between
-from tests.util import get_current_timestamp
+
+if hasattr(time, "monotonic"):
+    get_current_timestamp = time.monotonic
+else:
+    get_current_timestamp = time.time
+
 
 THREAD_COUNT = 32
 ENTRY_COUNT = 10000


### PR DESCRIPTION
The Python script we are using were trying to import something
from the test package. That was not good because inside the
`__init__` file of the test package, we define a global logger
config that we want to use in tests.

But, in the SOAK test, we are using some other logger config.

To make the logger output work, import is removed and the functionnality
is directly copy-pasted, since it is something really small.