### PR TITLE
Pretty print cluster connect timeout in logs

### DIFF
--- a/hazelcast/connection.py
+++ b/hazelcast/connection.py
@@ -2,7 +2,6 @@ import io
 import logging
 import random
 import struct
-import sys
 import threading
 import time
 import uuid
@@ -33,6 +32,8 @@ from hazelcast.util import AtomicInteger, calculate_version, UNKNOWN_VERSION
 
 _logger = logging.getLogger(__name__)
 
+_INF = float("inf")
+
 
 class _WaitStrategy(object):
     def __init__(self, initial_backoff, max_backoff, multiplier, cluster_connect_timeout, jitter):
@@ -45,7 +46,7 @@ class _WaitStrategy(object):
         self._cluster_connect_attempt_begin = None
         self._current_backoff = None
 
-        if cluster_connect_timeout == sys.maxsize:
+        if cluster_connect_timeout == _INF:
             self._cluster_connect_timeout_text = "INFINITE"
         else:
             self._cluster_connect_timeout_text = "%ds" % self._cluster_connect_timeout
@@ -320,7 +321,7 @@ class ConnectionManager(object):
             # If the no timeout is specified by the
             # user, or set to -1 explicitly, set
             # the timeout to infinite.
-            cluster_connect_timeout = sys.maxsize
+            cluster_connect_timeout = _INF
 
         return _WaitStrategy(
             config.retry_initial_backoff,

--- a/hazelcast/connection.py
+++ b/hazelcast/connection.py
@@ -49,7 +49,7 @@ class _WaitStrategy(object):
         if cluster_connect_timeout == _INF:
             self._cluster_connect_timeout_text = "INFINITE"
         else:
-            self._cluster_connect_timeout_text = "%ds" % self._cluster_connect_timeout
+            self._cluster_connect_timeout_text = "%.2fs" % self._cluster_connect_timeout
 
     def reset(self):
         self._attempt = 0
@@ -75,7 +75,7 @@ class _WaitStrategy(object):
         sleep_time = min(sleep_time, self._cluster_connect_timeout - time_passed)
         _logger.warning(
             "Unable to get live cluster connection, retry in %.2fs, attempt: %d, "
-            "cluster connect timeout: %s, max backoff: %ds",
+            "cluster connect timeout: %s, max backoff: %.2fs",
             sleep_time,
             self._attempt,
             self._cluster_connect_timeout_text,

--- a/hazelcast/connection.py
+++ b/hazelcast/connection.py
@@ -45,6 +45,11 @@ class _WaitStrategy(object):
         self._cluster_connect_attempt_begin = None
         self._current_backoff = None
 
+        if cluster_connect_timeout == sys.maxsize:
+            self._cluster_connect_timeout_text = "INFINITE"
+        else:
+            self._cluster_connect_timeout_text = "%ds" % self._cluster_connect_timeout
+
     def reset(self):
         self._attempt = 0
         self._cluster_connect_attempt_begin = time.time()
@@ -55,9 +60,9 @@ class _WaitStrategy(object):
         time_passed = time.time() - self._cluster_connect_attempt_begin
         if time_passed > self._cluster_connect_timeout:
             _logger.warning(
-                "Unable to get live cluster connection, cluster connect timeout (%ds) is reached. "
+                "Unable to get live cluster connection, cluster connect timeout (%s) is reached. "
                 "Attempt %d.",
-                self._cluster_connect_timeout,
+                self._cluster_connect_timeout_text,
                 self._attempt,
             )
             return False
@@ -69,10 +74,10 @@ class _WaitStrategy(object):
         sleep_time = min(sleep_time, self._cluster_connect_timeout - time_passed)
         _logger.warning(
             "Unable to get live cluster connection, retry in %.2fs, attempt: %d, "
-            "cluster connect timeout: %ds, max backoff: %ds",
+            "cluster connect timeout: %s, max backoff: %ds",
             sleep_time,
             self._attempt,
-            self._cluster_connect_timeout,
+            self._cluster_connect_timeout_text,
             self._max_backoff,
         )
         time.sleep(sleep_time)


### PR DESCRIPTION
Before this change, we were logging the cluster connect timeout
as it is. Its default value is equal to `sys.maxsize`, so the
logs were like

```
... cluster connect timeout: 92233720368547758067s ...
```

We now output `INFINITE` for the default value.

```
... cluster connect timeout: INFINITE
```

If the user provides a different value, it will be printed
as it is now.

Closes #404 