### PR TITLE
[API-464] Show the context manager support for transactions in code samples and…

### DIFF
--- a/docs/using_python_client_with_hazelcast_imdg.rst
+++ b/docs/using_python_client_with_hazelcast_imdg.rst
@@ -456,14 +456,14 @@ in the Hazelcast IMDG Reference Manual.
     # Get transactional distributed data structures
     txn_map = transaction.get_map("transactional-map")
     txn_queue = transaction.get_queue("transactional-queue")
-    txt_set = transaction.get_set("transactional-set")
+    txn_set = transaction.get_set("transactional-set")
     try:
         obj = txn_queue.poll()
 
         # Process obj
 
         txn_map.put("1", "value1")
-        txt_set.add("value")
+        txn_set.add("value")
 
         # Do other things
 
@@ -488,6 +488,31 @@ the level of a single partition. If you are in a transaction, you can
 read the data in your transaction and the data that is already
 committed. If you are not in a transaction, you can only read the
 committed data.
+
+One can also use context managers to simplify the usage of the
+transactional data structures. The example above can be simplified
+as below.
+
+.. code:: python
+
+    # Create a Transaction object and begin the transaction
+    with client.new_transaction(timeout=10) as transaction:
+        # Get transactional distributed data structures
+        txn_map = transaction.get_map("transactional-map")
+        txn_queue = transaction.get_queue("transactional-queue")
+        txn_set = transaction.get_set("transactional-set")
+
+        obj = txn_queue.poll()
+
+        # Process obj
+
+        txn_map.put("1", "value1")
+        txn_set.add("value")
+
+        # Do other things
+
+        # If everything goes well, the transaction will be
+        # committed, if not, it will be rolled back automatically.
 
 Using PN Counter
 ~~~~~~~~~~~~~~~~

--- a/examples/transactions/transaction_basic_example.py
+++ b/examples/transactions/transaction_basic_example.py
@@ -2,17 +2,11 @@ import hazelcast
 import time
 
 client = hazelcast.HazelcastClient()
-transaction = client.new_transaction(timeout=10)
-try:
-    transaction.begin()
-    transactional_map = transaction.get_map("transaction-map")
-    print("Map: {}".format(transactional_map))
+
+with client.new_transaction(timeout=10) as transaction:
+    transactional_map = transaction.get_map("transactional-map")
+    print("Created map:", transactional_map)
 
     transactional_map.put("1", "1")
     time.sleep(0.1)
     transactional_map.put("2", "2")
-
-    transaction.commit()
-except Exception as ex:
-    transaction.rollback()
-    print("Transaction failed! {}".format(ex.args))


### PR DESCRIPTION
… documentation

We do have a context manager support for transactions but we were
not showing it in our code samples or documentation. As a result
of that, users were unaware of this feature. We even had a call
with one user who implemented a simple context manager for
Hazelcast transactions himself.

So, with this PR, we are now showing that we have support for it
in our code samples and documentation.

closes #401 