### PR TITLE
Make public attributes of the client properties and document them

### DIFF
--- a/hazelcast/partition.py
+++ b/hazelcast/partition.py
@@ -20,7 +20,8 @@ class _PartitionTable(object):
 
 class PartitionService(object):
     """
-    Allows to retrieve information about the partition count, the partition owner or the partitionId of a key.
+    Allows to retrieve information about the partition count, the partition owner
+    or the partition id of a key.
     """
 
     __slots__ = ("_service", "_serialization_service")


### PR DESCRIPTION
We were not documenting the public attributes of the client. Now,
we are doing it with their types, which has more documentation.

Also, made them read-only properties.