### PR TITLE
[API-466] Fire membership events when HotRestart is enabled

### DIFF
--- a/hazelcast/connection.py
+++ b/hazelcast/connection.py
@@ -584,7 +584,7 @@ class ConnectionManager(object):
 
     def _on_cluster_restart(self):
         self._near_cache_manager.clear_near_caches()
-        self._cluster_service.clear_member_list_version()
+        self._cluster_service.clear_member_list()
 
     def _check_partition_count(self, partition_count):
         if not self._partition_service.check_and_set_partition_count(partition_count):

--- a/hazelcast/listener.py
+++ b/hazelcast/listener.py
@@ -218,7 +218,6 @@ class ClusterViewListenerService(object):
         if self._listener_added_connection:
             return
 
-        self._cluster_service.clear_member_list_version()
         self._listener_added_connection = connection
         request = client_add_cluster_view_listener_codec.encode_request()
         invocation = Invocation(

--- a/tests/util.py
+++ b/tests/util.py
@@ -102,6 +102,11 @@ def is_server_version_older_than(client, expected_version):
     return server_version < expected_version
 
 
+def mark_client_version_at_least(test, expected_version):
+    if is_client_version_older_than(expected_version):
+        test.skipTest("Expected a newer client")
+
+
 def is_client_version_older_than(expected_version):
     version = calculate_version(__version__)
     expected_version = calculate_version(expected_version)


### PR DESCRIPTION
With this change, we now clear the memberlist when the cluster changes,
instead of just clearing the memberlist version so that, we can
fire events when a member with HotRestart enabled restarts with
the same UUID. Added a test that verifies this behavior.

Also, removed an unnecessary usage of the `clear_member_list_version`
method.

closes #371 