### PR TITLE
Fix the SQL column type documentation

### DIFF
--- a/docs/using_python_client_with_hazelcast_imdg.rst
+++ b/docs/using_python_client_with_hazelcast_imdg.rst
@@ -1533,6 +1533,7 @@ formats.
 - ``TIME`` with the ``HH:MM:SS[.ffffff]`` format.
 - ``TIMESTAMP`` with the ``YYYY-MM-DDTHH:MM:SS[.ffffff]`` format.
 - ``TIMESTAMP_WITH_TIME_ZONE`` with the ``YYYY-MM-DDTHH:MM:SS.ffffff+HH:MM[:SS]``
+  format.
 - ``DECIMAL`` with the floating point number format.
 
 If you want to use these types in queries, you have to send them as strings

--- a/hazelcast/sql.py
+++ b/hazelcast/sql.py
@@ -338,7 +338,7 @@ class SqlColumnType(object):
 
     DECIMAL = 6
     """
-    Represented by ``decimal.Decimal``.
+    Represented by ``str``.
     """
 
     REAL = 7
@@ -353,22 +353,23 @@ class SqlColumnType(object):
 
     DATE = 9
     """
-    Represented by ``datetime.date``.
+    Represented by ``str`` with the ``YYYY-MM-DD`` format.
     """
 
     TIME = 10
     """
-    Represented by ``datetime.time``.
+    Represented by ``str`` with the ``HH:MM:SS[.ffffff]`` format.
     """
 
     TIMESTAMP = 11
     """
-    Represented by ``datetime.datetime``.
+    Represented by ``str`` with the ``YYYY-MM-DDTHH:MM:SS[.ffffff]`` format.
     """
 
     TIMESTAMP_WITH_TIME_ZONE = 12
     """
-    Represented by ``datetime.datetime`` with ``datetime.tzinfo``.
+    Represented by ``str`` with the ``YYYY-MM-DDTHH:MM:SS.ffffff+HH:MM[:SS]`` 
+    format.
     """
 
     OBJECT = 13


### PR DESCRIPTION
The SQL column type documentation was not up-to-date with the
latest decisions about using `str`. Updated them and put the
format of the `str` to make them easier to use.