### PR TITLE
Update the TIMESTAMP_WITH_TIMEZONE documentation

### DIFF
--- a/docs/using_python_client_with_hazelcast_imdg.rst
+++ b/docs/using_python_client_with_hazelcast_imdg.rst
@@ -1532,8 +1532,8 @@ formats.
 - ``DATE`` with the ``YYYY-MM-DD`` format.
 - ``TIME`` with the ``HH:MM:SS[.ffffff]`` format.
 - ``TIMESTAMP`` with the ``YYYY-MM-DDTHH:MM:SS[.ffffff]`` format.
-- ``TIMESTAMP_WITH_TIME_ZONE`` with the ``YYYY-MM-DDTHH:MM:SS.ffffff+HH:MM[:SS]``
-  format.
+- ``TIMESTAMP_WITH_TIME_ZONE`` with the
+  ``YYYY-MM-DDTHH:MM:SS[.ffffff](+|-)HH:MM[:SS]`` format.
 - ``DECIMAL`` with the floating point number format.
 
 If you want to use these types in queries, you have to send them as strings

--- a/hazelcast/sql.py
+++ b/hazelcast/sql.py
@@ -368,8 +368,8 @@ class SqlColumnType(object):
 
     TIMESTAMP_WITH_TIME_ZONE = 12
     """
-    Represented by ``str`` with the ``YYYY-MM-DDTHH:MM:SS.ffffff+HH:MM[:SS]`` 
-    format.
+    Represented by ``str`` with the 
+    ``YYYY-MM-DDTHH:MM:SS[.ffffff](+|-)HH:MM[:SS]`` format.
     """
 
     OBJECT = 13


### PR DESCRIPTION
Updated the documentation to reflect the format of this type
more accurately.

- Made the microsecond part optional, since it won't be displayed
if it is equal to zero.
- Made the timezone offset sign one-of `+` or `-`.