### PR TITLE
Fix `test_lifecycle_listener_receives_disconnected_event`

### DIFF
--- a/tests/integration/backward_compatible/lifecycle_test.py
+++ b/tests/integration/backward_compatible/lifecycle_test.py
@@ -67,7 +67,12 @@ class LifecycleTest(HazelcastTestCase):
         )
         client.lifecycle_service.add_listener(collector)
         member.shutdown()
-        self.assertEqual(collector.events, [LifecycleState.DISCONNECTED])
+
+        def assertion():
+            self.assertEqual(collector.events, [LifecycleState.DISCONNECTED])
+
+        self.assertTrueEventually(assertion)
+
         client.shutdown()
 
     def test_remove_lifecycle_listener(self):


### PR DESCRIPTION
This test failed in Github Actions runners. The reason of the failure
is that, we try to check the received events right after shutting down
the member. It might be the case that, the member is shutdown, but
it is not visible to the client yet.

To tackle that, we now use `assertTrueEventually` to verify that
we receive the event.