### PR TITLE
Backward compatibility related test fixes

### DIFF
--- a/tests/integration/backward_compatible/connection_strategy_test.py
+++ b/tests/integration/backward_compatible/connection_strategy_test.py
@@ -126,13 +126,15 @@ class ConnectionStrategyTest(HazelcastTestCase):
 
         self.rc.shutdownMember(self.cluster.id, member.uuid)
         self.assertTrueEventually(lambda: self.assertEqual(1, len(disconnected_collector.events)))
+
         with self.assertRaises(ClientOfflineError):
             m.put(1, 1)
 
-        self.rc.startMember(self.cluster.id)
-
         connected_collector = collector(LifecycleState.CONNECTED)
         self.client.lifecycle_service.add_listener(connected_collector)
+
+        self.rc.startMember(self.cluster.id)
+
         self.assertTrueEventually(lambda: self.assertEqual(1, len(connected_collector.events)))
 
         m.put(1, 1)

--- a/tests/integration/backward_compatible/proxy/reliable_topic_test.py
+++ b/tests/integration/backward_compatible/proxy/reliable_topic_test.py
@@ -1,9 +1,15 @@
 import os
 import unittest
 
-from hazelcast.config import TopicOverloadPolicy
-from hazelcast.errors import TopicOverloadError
-from hazelcast.proxy.reliable_topic import ReliableMessageListener
+try:
+    from hazelcast.config import TopicOverloadPolicy
+    from hazelcast.errors import TopicOverloadError
+    from hazelcast.proxy.reliable_topic import ReliableMessageListener
+except ImportError:
+    # For backward compatibility. If we cannot import those, we won't
+    # be even referencing them in tests.
+    pass
+
 from tests.base import SingleMemberTestCase
 from tests.util import (
     is_client_version_older_than,


### PR DESCRIPTION
There were two problems identified in the backward compatibility
tests.

- The `reliable_topic_test` was added to the client in v4.1 and marked
correctly. However, there were no guards on the imports. So, it failed
against client v4.0. We added import guards for problematic ones.

- In `test_async_reconnect_mode`, we added the listener after restarting
the member. In some situations, we might connect member back, even
before adding the listener, and miss the event. Now, the listener is
added before restarting the member.