### PR TITLE
Add reliable topic configs only for 4.1+ clients

### DIFF
--- a/tests/integration/backward_compatible/proxy/reliable_topic_test.py
+++ b/tests/integration/backward_compatible/proxy/reliable_topic_test.py
@@ -29,20 +29,24 @@ class ReliableTopicTest(SingleMemberTestCase):
     @classmethod
     def configure_client(cls, config):
         config["cluster_name"] = cls.cluster.id
-        config["reliable_topics"] = {
-            "discard": {
-                "overload_policy": TopicOverloadPolicy.DISCARD_NEWEST,
-            },
-            "overwrite": {
-                "overload_policy": TopicOverloadPolicy.DISCARD_OLDEST,
-            },
-            "block": {
-                "overload_policy": TopicOverloadPolicy.BLOCK,
-            },
-            "error": {
-                "overload_policy": TopicOverloadPolicy.ERROR,
-            },
-        }
+        if not is_client_version_older_than("4.1"):
+            # Add these config elements only to the 4.1+ clients
+            # since the older versions do not know anything
+            # about them.
+            config["reliable_topics"] = {
+                "discard": {
+                    "overload_policy": TopicOverloadPolicy.DISCARD_NEWEST,
+                },
+                "overwrite": {
+                    "overload_policy": TopicOverloadPolicy.DISCARD_OLDEST,
+                },
+                "block": {
+                    "overload_policy": TopicOverloadPolicy.BLOCK,
+                },
+                "error": {
+                    "overload_policy": TopicOverloadPolicy.ERROR,
+                },
+            }
         return config
 
     def setUp(self):


### PR DESCRIPTION
In the `ReliableTopicTest`, we should only add the reliable
topic config elements for 4.1+ clients.

Note that, this change is required because the unittest will skip
tests after running the setUpClass method.