### PR TITLE
Make the HazelcastInstanceNotActiveError non-retryable

### DIFF
--- a/hazelcast/errors.py
+++ b/hazelcast/errors.py
@@ -82,7 +82,6 @@ class ExecutionError(HazelcastError):
     pass
 
 
-@retryable
 class HazelcastInstanceNotActiveError(HazelcastError):
     pass
 


### PR DESCRIPTION
HazelcastInstanceNotActiveError was mistakenly decorated as retryable
but in fact it is not. See https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstanceNotActiveException.java