### PR TITLE
Check the enterprise key properly in the test runner

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -38,8 +38,8 @@ if __name__ == "__main__":
                     "--nologcapture",
                 ]
 
-                is_oss = "HAZELCAST_ENTERPRISE_KEY" not in os.environ
-                if is_oss:
+                enterprise_key = os.environ.get("HAZELCAST_ENTERPRISE_KEY", None)
+                if not enterprise_key:
                     args.extend(["-A", "not enterprise"])
 
                 return_code = nose.run_exit(argv=args)


### PR DESCRIPTION
In the test runner, we just check if there is an entry named
`HAZELCAST_ENTERPRISE_KEY` in the environment variables. For our
codecov runner, for PRs, it is in fact there but set to an empty value.

Hence, it was passing the check mistakenly. Now, we don't start
the enterprise tests, if there is an empty enterprise key.