### PR TITLE
Update Hazelcast version used in tests

### DIFF
--- a/start_rc.py
+++ b/start_rc.py
@@ -3,7 +3,7 @@ import subprocess
 import sys
 from os.path import isfile
 
-SERVER_VERSION = "4.2.1-SNAPSHOT"
+SERVER_VERSION = "4.2.1"
 RC_VERSION = "0.8-SNAPSHOT"
 
 RELEASE_REPO = "http://repo1.maven.apache.org/maven2"


### PR DESCRIPTION
Sets the Hazelcast version to 4.2.1 instead of 4.2.1-SNAPSHOT as
the 4.2.1 is released.