### PR TITLE
Fix frame reader

### DIFF
--- a/tests/integration/backward_compatible/proxy/map_test.py
+++ b/tests/integration/backward_compatible/proxy/map_test.py
@@ -11,7 +11,13 @@ from tests.integration.backward_compatible.util import (
     write_string_to_output,
     read_string_from_input,
 )
-from tests.util import random_string, event_collector, fill_map, is_server_version_older_than
+from tests.util import (
+    random_string,
+    event_collector,
+    fill_map,
+    is_server_version_older_than,
+    get_current_timestamp,
+)
 from hazelcast import six
 from hazelcast.six.moves import range
 
@@ -395,6 +401,13 @@ class MapTest(SingleMemberTestCase):
     def test_put_get(self):
         self.assertIsNone(self.map.put("key", "value"))
         self.assertEqual(self.map.get("key"), "value")
+
+    def test_put_get_large_payload(self):
+        payload = bytearray(os.urandom(16 * 1024 * 1024))
+        start = get_current_timestamp()
+        self.assertIsNone(self.map.put("key", payload))
+        self.assertEqual(self.map.get("key"), payload)
+        self.assertLessEqual(get_current_timestamp() - start, 5)
 
     def test_put_get2(self):
         val = "x" * 5000


### PR DESCRIPTION
In the frame reader, we were storing the frame size including the
header (frame size + flags which is 6 bytes). Also, after reading
the frame size from the header, we were incrementing the bytes_read.

That approach works for small frames, that we can read with one go,
but was not working for frames that are large. For the same frame,
the next time we call read_frame, the length of the reader (the data
we haven't read from the buffer) was equal to frame size, but the
variable frame_size was equal to `frame_size + HEADER_SIZE`. So,
we were not reading the data that was actually there due to some
faulty length check.

We were able to read the data that is in the buffer after some long
time, when the response for the client ping request comes as it
was incrementing the length of the reader enough to pass the length
check.

To fix that, now, the frame_size field holds the frame size excluding
the header size.

closes #434 