### PR TITLE
Mark the client version as 4.2.1 for the next development cycle

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,9 +72,9 @@ author = u"Hazelcast Inc. Developers"
 # built documents.
 #
 # The short X.Y version.
-version = "4.2"
+version = "4.2.1"
 # The full version, including alpha/beta/rc tags.
-release = "4.2"
+release = "4.2.1"
 
 autodoc_member_order = "bysource"
 autoclass_content = "both"

--- a/hazelcast/__init__.py
+++ b/hazelcast/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.2"
+__version__ = "4.2.1"
 
 # Set the default handler to "hazelcast" loggers
 # to avoid "No handlers could be found" warnings.

--- a/tests/integration/backward_compatible/proxy/map_test.py
+++ b/tests/integration/backward_compatible/proxy/map_test.py
@@ -17,6 +17,7 @@ from tests.util import (
     fill_map,
     is_server_version_older_than,
     get_current_timestamp,
+    mark_client_version_at_least,
 )
 from hazelcast import six
 from hazelcast.six.moves import range
@@ -403,6 +404,10 @@ class MapTest(SingleMemberTestCase):
         self.assertEqual(self.map.get("key"), "value")
 
     def test_put_get_large_payload(self):
+        # The fix for reading large payloads is introduced in 4.2.1
+        # See https://github.com/hazelcast/hazelcast-python-client/pull/436
+        mark_client_version_at_least(self, "4.2.1")
+
         payload = bytearray(os.urandom(16 * 1024 * 1024))
         start = get_current_timestamp()
         self.assertIsNone(self.map.put("key", payload))


### PR DESCRIPTION
Set the client version to 4.2.1 and mark the minimum client version
of the newly added test as 4.2.1.