### PR TITLE
Make Address readable via IdentifiedDataSerializer

### DIFF
--- a/hazelcast/serialization/objects.py
+++ b/hazelcast/serialization/objects.py
@@ -47,7 +47,7 @@ class ReliableTopicMessage(IdentifiedDataSerializable):
 # Inherits from the Address, as we cannot implement
 # IDS in the core module due to cyclic import problems.
 # This was needed to construct the ReliableTopic messages
-# sent from the server as they have an non-None address
+# sent from the server as they have a non-None address
 # field.
 class IdentifiedAddress(Address, IdentifiedDataSerializable):
 

--- a/hazelcast/serialization/objects.py
+++ b/hazelcast/serialization/objects.py
@@ -1,4 +1,4 @@
-from hazelcast.core import MapEntry
+from hazelcast.core import Address, MapEntry
 from hazelcast.serialization.api import IdentifiedDataSerializable
 from hazelcast.serialization.data import Data
 from hazelcast.util import to_millis
@@ -44,15 +44,34 @@ class ReliableTopicMessage(IdentifiedDataSerializable):
         return self.CLASS_ID
 
 
-def _read_data_from(inp):
-    array = inp.read_byte_array()
-    if array is None:
-        return None
-    return Data(array)
+# Inherits from the Address, as we cannot implement
+# IDS in the core module due to cyclic import problems.
+# This was needed to construct the ReliableTopic messages
+# sent from the server as they have an non-None address
+# field.
+class IdentifiedAddress(Address, IdentifiedDataSerializable):
 
+    FACTORY_ID = 0
+    CLASS_ID = 1
 
-def _write_data_to(out, data):
-    out.write_byte_array(data.to_bytes())
+    def __init__(self, host=None, port=None):
+        super(IdentifiedAddress, self).__init__(host, port)
+
+    def write_data(self, object_data_output):
+        # skip writing it as we don't need it
+        pass
+
+    def read_data(self, object_data_input):
+        self.port = object_data_input.read_int()
+        # skip type as it is unused in the Python client
+        object_data_input.read_byte()
+        self.host = object_data_input.read_string()
+
+    def get_factory_id(self):
+        return self.FACTORY_ID
+
+    def get_class_id(self):
+        return self.CLASS_ID
 
 
 # Values are canonicalized in the server-side. No need to
@@ -94,3 +113,14 @@ class IdentifiedMapEntry(MapEntry, IdentifiedDataSerializable):
 
     def get_class_id(self):
         return self.CLASS_ID
+
+
+def _read_data_from(inp):
+    array = inp.read_byte_array()
+    if array is None:
+        return None
+    return Data(array)
+
+
+def _write_data_to(out, data):
+    out.write_byte_array(data.to_bytes())

--- a/hazelcast/serialization/service.py
+++ b/hazelcast/serialization/service.py
@@ -1,16 +1,17 @@
 import uuid
 
+from hazelcast import six
 from hazelcast.serialization.base import BaseSerializationService
 from hazelcast.serialization.objects import (
-    ReliableTopicMessage,
     CanonicalizingHashSet,
+    IdentifiedAddress,
     IdentifiedMapEntry,
+    ReliableTopicMessage,
 )
 from hazelcast.serialization.portable.classdef import FieldType
 from hazelcast.serialization.portable.context import PortableContext
 from hazelcast.serialization.portable.serializer import PortableSerializer
 from hazelcast.serialization.serializer import *
-from hazelcast import six
 
 DEFAULT_OUT_BUFFER_SIZE = 4 * 1024
 
@@ -69,6 +70,9 @@ class SerializationServiceV1(BaseSerializationService):
             },
             IdentifiedMapEntry.FACTORY_ID: {
                 IdentifiedMapEntry.CLASS_ID: IdentifiedMapEntry,
+            },
+            IdentifiedAddress.FACTORY_ID: {
+                IdentifiedAddress.CLASS_ID: IdentifiedAddress,
             },
         }
 


### PR DESCRIPTION
Formerly, we didn't implement IDS for Address as it was not needed
in the Python client but with the implementation of ReliableTopic,
it was possible to get Address instances via fields the messages
sent by the server.

To fix this, we introduce another class that inherits from the Address
and return it when someone tries to read such field. We take such measures
to deal with the cyclic import errors. If we were to implement IDS for
Address in the core module, and try to register it in the serialization
module, we would have a cyclic import.

Note that, this is basically a workaround but it is enough for our needs.
We need a proper refactoring of our modules to get rid of such problems
and maybe we can do that in 5.0.