### PR TITLE
Improve test runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+venv/
+.venv/
 build/
 develop-eggs/
 dist/

--- a/run_tests.py
+++ b/run_tests.py
@@ -36,6 +36,7 @@ if __name__ == "__main__":
                     "--cover-package=hazelcast",
                     "--cover-inclusive",
                     "--nologcapture",
+                    "tests",
                 ]
 
                 enterprise_key = os.environ.get("HAZELCAST_ENTERPRISE_KEY", None)


### PR DESCRIPTION
When there are some scripts in the main directory, the test runner
might get stuck on executing it and fail to start tests.

To improve the local development experience, I added the directory
of the tests to the test runner so that it only tries to run
tests from there.

Also, added some common virtual environment directories to the .gitignore.

Closes #443 