### PR TITLE
Projections follow up

### DIFF
--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -13,6 +13,7 @@ API Documentation
     lifecycle
     partition
     predicate
+    projection
     proxy/modules
     security
     serialization

--- a/docs/api/projection.rst
+++ b/docs/api/projection.rst
@@ -1,0 +1,4 @@
+Projection
+==========
+
+.. automodule:: hazelcast.projection

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -30,6 +30,7 @@ features:
 - Built-in Predicates
 - Listener with Predicate
 - Fast Aggregations
+- Projections
 - Near Cache Support
 - Programmatic Configuration
 - SSL Support (requires Enterprise server)

--- a/docs/using_python_client_with_hazelcast_imdg.rst
+++ b/docs/using_python_client_with_hazelcast_imdg.rst
@@ -2166,31 +2166,30 @@ See the following example.
     import hazelcast
 
     from hazelcast.core import HazelcastJsonValue
-    from hazelcast.predicate import greater_or_equal
+    from hazelcast.predicate import greater
     from hazelcast.projection import single_attribute, multi_attribute
 
     client = hazelcast.HazelcastClient()
     employees = client.get_map("employees").blocking()
 
-    employees.put(1, HazelcastJsonValue('{"Age": 23, "Height": 180, "Weight": 60}'))
-    employees.put(2, HazelcastJsonValue('{"Age": 21, "Height": 170, "Weight": 70}'))
+    employees.put(1, HazelcastJsonValue({"age": 25, "height": 180, "weight": 60}))
+    employees.put(2, HazelcastJsonValue({"age": 21, "height": 170, "weight": 70}))
+    employees.put(3, HazelcastJsonValue({"age": 40, "height": 175, "weight": 75}))
 
-    employee_ages = employees.project(single_attribute("Age"))
-    # Prints:
-    # The ages of employees are [21, 23]
-    print("The ages of employees are %s" % employee_ages)
+    ages = employees.project(single_attribute("age"))
 
-    # Run Single Attribute With Predicate
-    employee_ages = employees.project(single_attribute("Age"), greater_or_equal("Age", 23))
-    # Prints:
-    # The employee age is 23
-    print("The employee age is: %s" % employee_ages[0])
+    # Prints: "Ages of the employees are [21, 25, 40]"
+    print("Ages of the employees are %s" % ages)
 
-    # Run Multi Attribute Projection
-    employee_multi_attribute = employees.project(multi_attribute("Age", "Height"))
-    # Prints:
-    # Employee 1 age and height: [21, 170] Employee 2 age and height: [23, 180]
-    print("Employee 1 age and height: %s Employee 2 age and height: %s" % (employee_multi_attribute[0], employee_multi_attribute[1]))
+    filtered_ages = employees.project(single_attribute("age"), greater("age", 23))
+
+    # Prints: "Ages of the filtered employees are [25, 40]"
+    print("Ages of the filtered employees are %s" % filtered_ages)
+
+    attributes = employees.project(multi_attribute("age", "height"))
+
+    # Prints: "Ages and heights of the employees are [[21, 170], [25, 180], [40, 175]]"
+    print("Ages and heights of the employees are %s" % attributes)
 
 
 Performance

--- a/examples/projections/projections_example.py
+++ b/examples/projections/projections_example.py
@@ -1,0 +1,29 @@
+import hazelcast
+
+from hazelcast.core import HazelcastJsonValue
+from hazelcast.predicate import less_or_equal
+from hazelcast.projection import single_attribute, multi_attribute
+
+client = hazelcast.HazelcastClient()
+
+people = client.get_map("people").blocking()
+
+people.put_all(
+    {
+        1: HazelcastJsonValue({"name": "Philip", "age": 46}),
+        2: HazelcastJsonValue({"name": "Elizabeth", "age": 44}),
+        3: HazelcastJsonValue({"name": "Henry", "age": 13}),
+        4: HazelcastJsonValue({"name": "Paige", "age": 15}),
+    }
+)
+
+names = people.project(single_attribute("name"))
+print("Names of the people are %s." % names)
+
+children_names = people.project(single_attribute("name"), less_or_equal("age", 18))
+print("Names of the children are %s." % children_names)
+
+names_and_ages = people.project(multi_attribute("name", "age"))
+print("Names and ages of the people are %s." % names_and_ages)
+
+client.shutdown()

--- a/hazelcast/core.py
+++ b/hazelcast/core.py
@@ -388,8 +388,10 @@ class MapEntry(object):
 
     @property
     def key(self):
+        """Key of the entry."""
         return self._key
 
     @property
     def value(self):
+        """Value of the entry."""
         return self._value

--- a/hazelcast/projection.py
+++ b/hazelcast/projection.py
@@ -48,7 +48,7 @@ class _SingleAttributeProjection(_AbstractProjection):
 
 
 class _MultiAttributeProjection(_AbstractProjection):
-    def __init__(self, *attribute_paths):
+    def __init__(self, attribute_paths):
         if not attribute_paths:
             raise ValueError("Specify at least one attribute path")
 
@@ -81,7 +81,7 @@ def single_attribute(attribute_path):
 
     Returns:
         Projection[any]: A projection that extracts the value of the given
-            attribute path.
+        attribute path.
     """
     return _SingleAttributeProjection(attribute_path)
 
@@ -95,9 +95,9 @@ def multi_attribute(*attribute_paths):
 
     Returns:
         Projection[list]: A projection that extracts the values of the given
-            attribute paths.
+        attribute paths.
     """
-    return _MultiAttributeProjection(*attribute_paths)
+    return _MultiAttributeProjection(attribute_paths)
 
 
 def identity():
@@ -105,6 +105,6 @@ def identity():
 
     Returns:
         Projection[hazelcast.core.MapEntry]: A projection that does no
-            transformation.
+        transformation.
     """
     return _IdentityProjection()

--- a/hazelcast/projection.py
+++ b/hazelcast/projection.py
@@ -28,6 +28,7 @@ class _AbstractProjection(Projection, IdentifiedDataSerializable):
 
 
 def _validate_attribute_path(attribute_path):
+    # type: (str) -> None
     if not attribute_path:
         raise ValueError("attribute_path must not be None or empty")
 
@@ -37,6 +38,7 @@ def _validate_attribute_path(attribute_path):
 
 class _SingleAttributeProjection(_AbstractProjection):
     def __init__(self, attribute_path):
+        # type: (str) -> None
         _validate_attribute_path(attribute_path)
         self._attribute_path = attribute_path
 
@@ -49,6 +51,7 @@ class _SingleAttributeProjection(_AbstractProjection):
 
 class _MultiAttributeProjection(_AbstractProjection):
     def __init__(self, attribute_paths):
+        # type: (list[str]) -> None
         if not attribute_paths:
             raise ValueError("Specify at least one attribute path")
 
@@ -73,6 +76,7 @@ class _IdentityProjection(_AbstractProjection):
 
 
 def single_attribute(attribute_path):
+    # type: (str) -> Projection
     """Creates a projection that extracts the value of
     the given attribute path.
 
@@ -87,6 +91,7 @@ def single_attribute(attribute_path):
 
 
 def multi_attribute(*attribute_paths):
+    # type: (str) -> Projection
     """Creates a projection that extracts the values of
     one or more attribute paths.
 
@@ -97,10 +102,11 @@ def multi_attribute(*attribute_paths):
         Projection[list]: A projection that extracts the values of the given
         attribute paths.
     """
-    return _MultiAttributeProjection(attribute_paths)
+    return _MultiAttributeProjection(list(attribute_paths))
 
 
 def identity():
+    # type: () -> Projection
     """Creates a projection that does no transformation.
 
     Returns:

--- a/tests/unit/projection_test.py
+++ b/tests/unit/projection_test.py
@@ -1,0 +1,25 @@
+import unittest
+
+from hazelcast.projection import single_attribute, multi_attribute
+
+
+class ProjectionsInvalidInputTest(unittest.TestCase):
+    def test_single_attribute_with_any_operator(self):
+        with self.assertRaises(ValueError):
+            single_attribute("foo[any]")
+
+    def test_single_attribute_with_empty_path(self):
+        with self.assertRaises(ValueError):
+            single_attribute("")
+
+    def test_multi_attribute_with_no_paths(self):
+        with self.assertRaises(ValueError):
+            multi_attribute()
+
+    def test_multi_attribute_with_any_operator(self):
+        with self.assertRaises(ValueError):
+            multi_attribute("valid", "invalid[any]")
+
+    def test_multi_attribute_with_empty_path(self):
+        with self.assertRaises(ValueError):
+            multi_attribute("valid", "")


### PR DESCRIPTION
This is a follow up PR after merging the Projections PR. This is
a combination of lots of small things.

- Add documentation to properties of `MapEntry` so that they are
displayed
- Move map#project so that we maintain alphabetical order
- Add some corner case tests for projections and aggregations
- Used asserCountEqual on projection tests so that the tests will
be more durable, even if we add more items to map
- Add missing API documentation for projections
- Fix API documentation of projections around the return value documentations
- Add unit tests for the invalid projection inputs
- Make the projections code snippet simpler
- Add a code sample for projections