### PR TITLE
[API-700] v5 SQL: Initial PR

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,9 +72,9 @@ author = u"Hazelcast Inc. Developers"
 # built documents.
 #
 # The short X.Y version.
-version = "4.2.1"
+version = "5.0"
 # The full version, including alpha/beta/rc tags.
-release = "4.2.1"
+release = "5.0"
 
 autodoc_member_order = "bysource"
 autoclass_content = "both"

--- a/docs/using_python_client_with_hazelcast_imdg.rst
+++ b/docs/using_python_client_with_hazelcast_imdg.rst
@@ -1507,49 +1507,24 @@ Data Types
 The SQL service supports a set of SQL data types. Every data type is mapped to
 a Python type that represents the type’s value.
 
-======================== ===============
+======================== ========================================
 Type Name                Python Type
-======================== ===============
+======================== ========================================
 BOOLEAN                  bool
 VARCHAR                  str
 TINYINT                  int
 SMALLINT                 int
 INTEGER                  int
 BIGINT                   int
-DECIMAL                  str
+DECIMAL                  decimal.Decimal
 REAL                     float
 DOUBLE                   float
-DATE                     str
-TIME                     str
-TIMESTAMP                str
-TIMESTAMP_WITH_TIME_ZONE str
+DATE                     datetime.date
+TIME                     datetime.time
+TIMESTAMP                datetime.datetime
+TIMESTAMP_WITH_TIME_ZONE datetime.datetime (with non-None tzinfo)
 OBJECT                   Any Python type
-======================== ===============
-
-Note that, the following types are returned as strings, with the following
-formats.
-
-- ``DATE`` with the ``YYYY-MM-DD`` format.
-- ``TIME`` with the ``HH:MM:SS[.ffffff]`` format.
-- ``TIMESTAMP`` with the ``YYYY-MM-DDTHH:MM:SS[.ffffff]`` format.
-- ``TIMESTAMP_WITH_TIME_ZONE`` with the
-  ``YYYY-MM-DDTHH:MM:SS[.ffffff](+|-)HH:MM[:SS]`` format.
-- ``DECIMAL`` with the floating point number format.
-
-If you want to use these types in queries, you have to send them as strings
-and add explicit ``CAST`` to queries.
-
-``CAST`` operator has the following syntax:
-
-.. code:: sql
-
-    CAST(? AS TYPE)
-
-An example usage is shown below:
-
-.. code:: python
-
-    client.sql.execute("SELECT * FROM map WHERE date < CAST(? AS DATE)", "2021-06-02")
+======================== ========================================
 
 SELECT
 ~~~~~~

--- a/hazelcast/__init__.py
+++ b/hazelcast/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.2.1"
+__version__ = "5.0"
 
 # Set the default handler to "hazelcast" loggers
 # to avoid "No handlers could be found" warnings.

--- a/hazelcast/sql.py
+++ b/hazelcast/sql.py
@@ -129,9 +129,7 @@ class SqlService(object):
 
         When an SQL statement is submitted to a member, it is parsed and
         optimized by the ``hazelcast-sql`` module. The ``hazelcast-sql`` must
-        be in the classpath, otherwise an exception will be thrown. If you're
-        using the ``hazelcast-all`` or ``hazelcast-enterprise-all`` packages, the
-        ``hazelcast-sql`` module is included in them by default. If not, i.e., you
+        be in the classpath, otherwise an exception will be thrown. If you
         are using ``hazelcast`` or ``hazelcast-enterprise``, then you need to have
         ``hazelcast-sql`` in the classpath. If you are using the Docker image,
         the SQL module is included by default.
@@ -338,7 +336,7 @@ class SqlColumnType(object):
 
     DECIMAL = 6
     """
-    Represented by ``str``.
+    Represented by ``decimal.Decimal``.
     """
 
     REAL = 7
@@ -353,23 +351,22 @@ class SqlColumnType(object):
 
     DATE = 9
     """
-    Represented by ``str`` with the ``YYYY-MM-DD`` format.
+    Represented by ``datetime.date``.
     """
 
     TIME = 10
     """
-    Represented by ``str`` with the ``HH:MM:SS[.ffffff]`` format.
+    Represented by ``datetime.time``.
     """
 
     TIMESTAMP = 11
     """
-    Represented by ``str`` with the ``YYYY-MM-DDTHH:MM:SS[.ffffff]`` format.
+    Represented by ``datetime.datetime`` with ``None`` ``tzinfo``.
     """
 
     TIMESTAMP_WITH_TIME_ZONE = 12
     """
-    Represented by ``str`` with the 
-    ``YYYY-MM-DDTHH:MM:SS[.ffffff](+|-)HH:MM[:SS]`` format.
+    Represented by ``datetime.datetime`` with ``non-None`` ``tzinfo``.
     """
 
     OBJECT = 13

--- a/start_rc.py
+++ b/start_rc.py
@@ -3,7 +3,7 @@ import subprocess
 import sys
 from os.path import isfile
 
-SERVER_VERSION = "4.2.1"
+SERVER_VERSION = "5.0-SNAPSHOT"
 RC_VERSION = "0.8-SNAPSHOT"
 
 RELEASE_REPO = "http://repo1.maven.apache.org/maven2"
@@ -65,14 +65,14 @@ def start_rc(stdout=None, stderr=None):
 
     rc = download_if_necessary(RC_REPO, "hazelcast-remote-controller", RC_VERSION)
     tests = download_if_necessary(REPO, "hazelcast", SERVER_VERSION, True)
+    sql = download_if_necessary(REPO, "hazelcast-sql", SERVER_VERSION)
 
-    artifacts.append(rc)
-    artifacts.append(tests)
+    artifacts.extend([rc, tests, sql])
 
     enterprise_key = os.environ.get("HAZELCAST_ENTERPRISE_KEY", None)
 
     if enterprise_key:
-        server = download_if_necessary(ENTERPRISE_REPO, "hazelcast-enterprise-all", SERVER_VERSION)
+        server = download_if_necessary(ENTERPRISE_REPO, "hazelcast-enterprise", SERVER_VERSION)
         ep_tests = download_if_necessary(
             ENTERPRISE_REPO, "hazelcast-enterprise", SERVER_VERSION, True
         )
@@ -80,7 +80,7 @@ def start_rc(stdout=None, stderr=None):
         artifacts.append(server)
         artifacts.append(ep_tests)
     else:
-        server = download_if_necessary(REPO, "hazelcast-all", SERVER_VERSION)
+        server = download_if_necessary(REPO, "hazelcast", SERVER_VERSION)
         artifacts.append(server)
 
     class_path = CLASS_PATH_SEPARATOR.join(artifacts)

--- a/tests/base.py
+++ b/tests/base.py
@@ -119,6 +119,7 @@ class SingleMemberTestCase(HazelcastTestCase):
 
     rc = None
     cluster = None
+    member = None
     client = None
 
     @classmethod
@@ -126,7 +127,6 @@ class SingleMemberTestCase(HazelcastTestCase):
         cls.rc = cls.create_rc()
         cls.cluster = cls.create_cluster(cls.rc, cls.configure_cluster())
         cls.member = cls.cluster.start_member()
-
         cls.client = hazelcast.HazelcastClient(**cls.configure_client(dict()))
 
     @classmethod

--- a/tests/base.py
+++ b/tests/base.py
@@ -118,6 +118,7 @@ class SingleMemberTestCase(HazelcastTestCase):
     """
 
     rc = None
+    cluster = None
     client = None
 
     @classmethod

--- a/tests/integration/backward_compatible/sql_test.py
+++ b/tests/integration/backward_compatible/sql_test.py
@@ -231,13 +231,7 @@ class SqlServiceTest(SqlTestBase):
             # -1 comes from the fact that, we don't fetch the first page.
             expected = math.ceil(float(entry_count) / statement.cursor_buffer_size) - 1
             actual = patched.call_count
-
-            # In 5.0+, some pages other than the last page might also be
-            # not full.
-            if self.is_v5_or_newer_server:
-                self.assertGreaterEqual(actual, expected)
-            else:
-                self.assertEqual(expected, actual)
+            self.assertEqual(expected, actual)
 
     def test_execute_statement_with_copy(self):
         self._populate_map()

--- a/tests/integration/backward_compatible/sql_test.py
+++ b/tests/integration/backward_compatible/sql_test.py
@@ -1,20 +1,26 @@
+import datetime
 import decimal
 import math
 import random
 import string
 import unittest
 
-from hazelcast import six
+from hazelcast import six, HazelcastClient
 from hazelcast.future import ImmediateFuture
 from hazelcast.serialization.api import Portable
-from tests.base import SingleMemberTestCase
+from tests.base import SingleMemberTestCase, HazelcastTestCase
 from tests.hzrc.ttypes import Lang
 from mock import patch
 
-from tests.util import is_client_version_older_than, mark_server_version_at_least
+from tests.util import (
+    is_client_version_older_than,
+    mark_server_version_at_least,
+    is_server_version_older_than,
+)
 
 try:
     from hazelcast.sql import HazelcastSqlError, SqlStatement, SqlExpectedResultType, SqlColumnType
+    from hazelcast.util import timezone
 except ImportError:
     # For backward compatibility. If we cannot import those, we won't
     # be even referencing them in tests.
@@ -30,25 +36,79 @@ SERVER_CONFIG = """
             <portable-factory factory-id="666">com.hazelcast.client.test.PortableFactory
             </portable-factory>
         </portable-factories>
-    </serialization>
+    </serialization>%s
 </hazelcast>
 """
 
+JET_ENABLED_CONFIG = """
+    <jet enabled="true" />
+"""
 
-class SqlTestBase(SingleMemberTestCase):
-    @classmethod
-    def configure_cluster(cls):
-        return SERVER_CONFIG
+
+class SqlTestBase(HazelcastTestCase):
+
+    rc = None
+    cluster = None
+    is_v5_or_newer_server = True
+    client = None
 
     @classmethod
-    def configure_client(cls, config):
-        config["cluster_name"] = cls.cluster.id
-        config["portable_factories"] = {666: {6: Student}}
-        return config
+    def setUpClass(cls):
+        cls.rc = cls.create_rc()
+
+        # We don't know the member version before starting a member.
+        # That's why, we are creating (and shutting down) a dummy
+        # cluster to determine the member version.
+        dummy_cluster = None
+        dummy_client = None
+
+        try:
+            dummy_cluster = cls.create_cluster(cls.rc)
+            dummy_cluster.start_member()
+            dummy_client = HazelcastClient(cluster_name=dummy_cluster.id)
+
+            if is_server_version_older_than(dummy_client, "5.0"):
+                cls.is_v5_or_newer_server = False
+        finally:
+            if dummy_client:
+                dummy_client.shutdown()
+
+            if dummy_cluster:
+                cls.rc.terminateCluster(dummy_cluster.id)
+
+        # enable Jet if the server is 5.0+
+        cluster_config = (
+            SERVER_CONFIG % JET_ENABLED_CONFIG if cls.is_v5_or_newer_server else SERVER_CONFIG % ""
+        )
+        cls.cluster = cls.create_cluster(cls.rc, cluster_config)
+        cls.member = cls.cluster.start_member()
+        cls.client = HazelcastClient(
+            cluster_name=cls.cluster.id, portable_factories={666: {6: Student}}
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.client.shutdown()
+        cls.rc.terminateCluster(cls.cluster.id)
+        cls.rc.exit()
 
     def setUp(self):
         self.map_name = random_string()
         self.map = self.client.get_map(self.map_name).blocking()
+        self._mark_minimum_server_version()
+
+        # Skip tests if major versions of the client/server do not match.
+
+        if (  # 4.x client with 5.x server
+            is_client_version_older_than("5.0")
+            and not is_server_version_older_than(self.client, "5.0")
+        ) or (  # 5.x client with 4.x server
+            not is_client_version_older_than("5.0")
+            and is_server_version_older_than(self.client, "5.0")
+        ):
+            self.skipTest("Major versions of the client and the server do not match.")
+
+    def _mark_minimum_server_version(self):
         mark_server_version_at_least(self, self.client, "4.2")
 
     def tearDown(self):
@@ -168,10 +228,16 @@ class SqlServiceTest(SqlTestBase):
             six.assertCountEqual(
                 self, [i for i in range(entry_count)], [row.get_object("age") for row in result]
             )
-            # -1 comes from the fact that, we don't fetch the first page
-            self.assertEqual(
-                math.ceil(float(entry_count) / statement.cursor_buffer_size) - 1, patched.call_count
-            )
+            # -1 comes from the fact that, we don't fetch the first page.
+            expected = math.ceil(float(entry_count) / statement.cursor_buffer_size) - 1
+            actual = patched.call_count
+
+            # In 5.0+, some pages other than the last page might also be
+            # not full.
+            if self.is_v5_or_newer_server:
+                self.assertGreaterEqual(actual, expected)
+            else:
+                self.assertEqual(expected, actual)
 
     def test_execute_statement_with_copy(self):
         self._populate_map()
@@ -452,6 +518,9 @@ class SqlColumnTypesReadTest(SqlTestBase):
 
     def test_date(self):
         def value_factory(key):
+            if self.is_v5_or_newer_server:
+                return datetime.date(key + 2000, key + 1, key + 1)
+
             return "%d-%02d-%02d" % (key + 2000, key + 1, key + 1)
 
         self._populate_map_via_rc("java.time.LocalDate.of(key + 2000, key + 1, key + 1)")
@@ -459,6 +528,9 @@ class SqlColumnTypesReadTest(SqlTestBase):
 
     def test_time(self):
         def value_factory(key):
+            if self.is_v5_or_newer_server:
+                return datetime.time(key, key, key, key)
+
             time = "%02d:%02d:%02d" % (key, key, key)
             if key != 0:
                 time += ".%06d" % key
@@ -469,6 +541,9 @@ class SqlColumnTypesReadTest(SqlTestBase):
 
     def test_timestamp(self):
         def value_factory(key):
+            if self.is_v5_or_newer_server:
+                return datetime.datetime(key + 2000, key + 1, key + 1, key, key, key, key)
+
             timestamp = "%d-%02d-%02dT%02d:%02d:%02d" % (
                 key + 2000,
                 key + 1,
@@ -489,6 +564,18 @@ class SqlColumnTypesReadTest(SqlTestBase):
 
     def test_timestamp_with_time_zone(self):
         def value_factory(key):
+            if self.is_v5_or_newer_server:
+                return datetime.datetime(
+                    key + 2000,
+                    key + 1,
+                    key + 1,
+                    key,
+                    key,
+                    key,
+                    key,
+                    timezone(datetime.timedelta(hours=key)),
+                )
+
             timestamp = "%d-%02d-%02dT%02d:%02d:%02d" % (
                 key + 2000,
                 key + 1,
@@ -510,7 +597,11 @@ class SqlColumnTypesReadTest(SqlTestBase):
 
     def test_decimal(self):
         def value_factory(key):
-            return str(decimal.Decimal((0, (key,), -1 * key)))
+            d = decimal.Decimal((0, (key,), -1 * key))
+            if self.is_v5_or_newer_server:
+                return d
+
+            return str(d)
 
         self._populate_map_via_rc("java.math.BigDecimal.valueOf(key, key)")
         self._validate_rows(SqlColumnType.DECIMAL, value_factory)
@@ -605,6 +696,56 @@ class SqlServiceLiteMemberClusterTest(SingleMemberTestCase):
 
         # Make sure that exception is originating from the client
         self.assertNotEqual(self.member.uuid, str(cm.exception.originating_member_uuid))
+
+
+@unittest.skipIf(
+    is_client_version_older_than("5.0"), "Tests the features added in 5.0 version of the client"
+)
+class JetSqlTest(SqlTestBase):
+    def _mark_minimum_server_version(self):
+        mark_server_version_at_least(self, self.client, "5.0")
+
+    def test_streaming_sql_query(self):
+        with self.client.sql.execute("SELECT * FROM TABLE(generate_stream(100))") as result:
+            for idx, row in enumerate(result):
+                self.assertEqual(idx, row.get_object("v"))
+                if idx == 200:
+                    break
+
+    def test_federated_query(self):
+        query = (
+            """
+        CREATE MAPPING %s (
+            __key INT,
+            name VARCHAR,
+            age INT
+        )
+        TYPE IMap
+        OPTIONS (
+            'keyFormat' = 'int',
+            'valueFormat' = 'json'
+        )
+        """
+            % self.map_name
+        )
+
+        with self.client.sql.execute(query) as result:
+            self.assertEqual(0, result.update_count().result())
+
+        insert_into_query = (
+            """
+        INSERT INTO %s (__key, name, age) 
+        VALUES (1, 'John', 42)
+        """
+            % self.map_name
+        )
+
+        with self.client.sql.execute(insert_into_query) as result:
+            self.assertEqual(0, result.update_count().result())
+
+        self.assertEqual(1, self.map.size())
+        entry = self.map.get(1)
+        self.assertEqual({"name": "John", "age": 42}, entry.loads())
 
 
 class Student(Portable):


### PR DESCRIPTION
This is an initial PR for the v5 SQL. It consists minimal changes
required to test the v5 SQL. Follow up PRs will come after that.

Here are the list of changes made:

- Set client version to 5.0
- Update remote controller scripts so that it uses hazelcast+hazelcast-sql
JARs instead of hazelcast-all, since hazelcast-all is not produced anymore.
Also, update some documentation about it.
- Use ints to represent years in DATE column type
- Use built-in types for DATE, TIME, TIMESTAMP, TIMESTAMP WITH TIMEZONE, and DECIMAL
which are datetime.date, datetime.time, datetime.datetime,
datetime.datetime(with non-None tzinfo), and decimal.Decimal.
- Update SQL tests and add some Jet tests
- Fix distributed objects tests by filtering internal objects out.