### PR TITLE
[API-701] v5 SQL: Use different logic for getting query connections

### DIFF
--- a/hazelcast/connection.py
+++ b/hazelcast/connection.py
@@ -317,20 +317,6 @@ class ConnectionManager(object):
         else:
             raise IOError("No connection found to cluster")
 
-    def _get_connection_from_load_balancer(self, should_get_data_member):
-        load_balancer = self._load_balancer
-        member = None
-        if should_get_data_member:
-            if load_balancer.can_get_next_data_member():
-                member = load_balancer.next_data_member()
-        else:
-            member = load_balancer.next()
-
-        if not member:
-            return None
-
-        return self.get_connection(member.uuid)
-
     def _get_or_connect_to_address(self, address):
         for connection in list(six.itervalues(self.active_connections)):
             if connection.remote_address == address:

--- a/hazelcast/connection.py
+++ b/hazelcast/connection.py
@@ -172,7 +172,7 @@ class ConnectionManager(object):
                     return connection
 
         # Otherwise iterate over connections and return the first one
-        for member_uuid, connection in list(six.iteritems(self.active_connections)):
+        for connection in list(six.itervalues(self.active_connections)):
             return connection
 
         # Failed to get a connection
@@ -190,7 +190,7 @@ class ConnectionManager(object):
             - ``None``, if there is no connection.
 
         Returns:
-            Connection: Random connection.
+            Connection: A random connection for SQL.
         """
         if self._smart_routing_enabled:
             # There might be a race - the chosen member might be just connected or disconnected.

--- a/hazelcast/connection.py
+++ b/hazelcast/connection.py
@@ -32,11 +32,17 @@ from hazelcast.protocol.codec import (
     client_authentication_custom_codec,
     client_ping_codec,
 )
-from hazelcast.util import AtomicInteger, calculate_version, UNKNOWN_VERSION
+from hazelcast.util import (
+    AtomicInteger,
+    calculate_version,
+    UNKNOWN_VERSION,
+    member_of_larger_same_version_group,
+)
 
 _logger = logging.getLogger(__name__)
 
 _INF = float("inf")
+_SQL_CONNECTION_RANDOM_ATTEMPTS = 10
 
 
 class _WaitStrategy(object):
@@ -156,25 +162,65 @@ class ConnectionManager(object):
     def get_connection(self, member_uuid):
         return self.active_connections.get(member_uuid, None)
 
-    def get_random_connection(self, should_get_data_member=False):
+    def get_random_connection(self):
+        # Try getting the connection from the load balancer, if smart routing is enabled
         if self._smart_routing_enabled:
-            connection = self._get_connection_from_load_balancer(should_get_data_member)
-            if connection:
-                return connection
+            member = self._load_balancer.next()
+            if member:
+                connection = self.get_connection(member.uuid)
+                if connection:
+                    return connection
 
-        # We should not get to this point under normal circumstances
-        # for the smart client. For uni-socket client, there would be
-        # a single connection in the dict. Therefore, copying the list
-        # should be acceptable.
+        # Otherwise iterate over connections and return the first one
         for member_uuid, connection in list(six.iteritems(self.active_connections)):
-            if should_get_data_member:
-                member = self._cluster_service.get_member(member_uuid)
-                if not member or member.lite_member:
-                    continue
+            return connection
+
+        # Failed to get a connection
+        return None
+
+    def get_random_connection_for_sql(self):
+        """Returns a random connection for SQL.
+
+        The connection is tried to be selected in the following order.
+
+            - Random connection to a data member from the larger same-version
+              group.
+            - Random connection to a data member.
+            - Any random connection
+            - ``None``, if there is no connection.
+
+        Returns:
+            Connection: Random connection.
+        """
+        if self._smart_routing_enabled:
+            # There might be a race - the chosen member might be just connected or disconnected.
+            # Try a couple of times, the member_of_larger_same_version_group returns a random
+            # connection, we might be lucky...
+            for _ in range(_SQL_CONNECTION_RANDOM_ATTEMPTS):
+                members = self._cluster_service.get_members()
+                member = member_of_larger_same_version_group(members)
+                if not member:
+                    break
+
+                connection = self.get_connection(member.uuid)
+                if connection:
+                    return connection
+
+        # Otherwise iterate over connections and return the first one
+        # that's not to a lite member.
+        first_connection = None
+        for member_uuid, connection in list(six.iteritems(self.active_connections)):
+            if not first_connection:
+                first_connection = connection
+
+            member = self._cluster_service.get_member(member_uuid)
+            if not member or member.lite_member:
+                continue
 
             return connection
 
-        return None
+        # Failed to get a connection to a data member.
+        return first_connection
 
     def start(self, load_balancer):
         if self.live:

--- a/hazelcast/sql.py
+++ b/hazelcast/sql.py
@@ -1428,14 +1428,11 @@ class _InternalSqlService(object):
 
     def _get_query_connection(self):
         try:
-            # Get a random Data member (non-lite member)
             connection = self._connection_manager.get_random_connection_for_sql()
         except Exception as e:
             raise self.re_raise(e, None)
 
         if not connection:
-            # Either the client is not connected to the cluster, or
-            # there are no data members in the cluster.
             raise HazelcastSqlError(
                 self.get_client_id(),
                 _SqlErrorCode.CONNECTION_PROBLEM,

--- a/hazelcast/util.py
+++ b/hazelcast/util.py
@@ -504,6 +504,7 @@ def member_of_larger_same_version_group(members):
                 "More than 2 distinct member versions found: %s, %s, %s" % (version0, version1, v)
             )
 
+    # no data members
     if count0 == 0:
         return None
 
@@ -514,6 +515,7 @@ def member_of_larger_same_version_group(members):
         count = count0
         version = version1
 
+    # return a random member from the larger group
     random_member_idx = random.randrange(0, count)
     for member in members:
         if not member.lite_member and _is_same_version(version, member.version):

--- a/hazelcast/util.py
+++ b/hazelcast/util.py
@@ -454,3 +454,69 @@ def try_to_get_error_message(error):
     elif len(error.args) > 0:
         return error.args[0]
     return None
+
+
+def _is_same_version(v1, v2):
+    # Ignores the patch version
+    return v1.major == v2.major and v1.minor == v2.minor
+
+
+def _is_newer_version(v1, v2):
+    # Ignores the patch version
+    return v1.major > v2.major or (v1.major == v2.major and v1.minor > v2.minor)
+
+
+def member_of_larger_same_version_group(members):
+    """Finds a larger same-version group of data members from a collection of
+    members and return a random member from the group.
+
+    If the same-version groups have the same size, return a member from the
+    newer group.
+
+    Args:
+        members (list[hazelcast.core.MemberInfo]): List of all members.
+
+    Returns:
+        hazelcast.core.MemberInfo: The chosen member or ``None``, if no data
+        member is found.
+    """
+    # The members should have at most 2 different version (ignoring the patch
+    # version).
+
+    version0 = None
+    version1 = None
+    count0 = 0
+    count1 = 0
+
+    for member in members:
+        if member.lite_member:
+            continue
+
+        v = member.version
+        if not version0 or _is_same_version(version0, v):
+            version0 = v
+            count0 += 1
+        elif not version1 or _is_same_version(version1, v):
+            version1 = v
+            count1 += 1
+        else:
+            raise ValueError(
+                "More than 2 distinct member versions found: %s, %s, %s" % (version0, version1, v)
+            )
+
+    if count0 == 0:
+        return None
+
+    if count0 > count1 or count0 == count1 and _is_newer_version(version0, version1):
+        count = count0
+        version = version0
+    else:
+        count = count0
+        version = version1
+
+    random_member_idx = random.randrange(0, count)
+    for member in members:
+        if not member.lite_member and _is_same_version(version, member.version):
+            random_member_idx -= 1
+            if random_member_idx < 0:
+                return member

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 -r requirements-test.txt
-black==20.8b1; python_version >= "3.6"
+black==21.7b0; python_version >= "3.6"
 Sphinx==3.4.2; python_version >= "3.5"
 sphinx-rtd-theme==0.5.1; python_version >= "3.5"

--- a/tests/integration/backward_compatible/authentication_tests/authentication_test.py
+++ b/tests/integration/backward_compatible/authentication_tests/authentication_test.py
@@ -3,7 +3,7 @@ import unittest
 
 from hazelcast.errors import HazelcastError
 from tests.base import HazelcastTestCase
-from tests.util import get_abs_path, set_attr, is_client_version_older_than
+from tests.util import get_abs_path, set_attr, compare_client_version
 from hazelcast.client import HazelcastClient
 
 try:
@@ -14,7 +14,7 @@ except ImportError:
 
 @set_attr(enterprise=True)
 @unittest.skipIf(
-    is_client_version_older_than("4.2.1"), "Tests the features added in 4.2.1 version of the client"
+    compare_client_version("4.2.1") < 0, "Tests the features added in 4.2.1 version of the client"
 )
 class AuthenticationTest(HazelcastTestCase):
     current_directory = os.path.dirname(__file__)

--- a/tests/integration/backward_compatible/cluster_test.py
+++ b/tests/integration/backward_compatible/cluster_test.py
@@ -4,7 +4,7 @@ import tempfile
 from hazelcast import HazelcastClient, six
 from hazelcast.util import RandomLB, RoundRobinLB
 from tests.base import HazelcastTestCase
-from tests.util import set_attr, random_string, event_collector, mark_client_version_at_least
+from tests.util import set_attr, random_string, event_collector, skip_if_client_version_older_than
 
 
 class ClusterTest(HazelcastTestCase):
@@ -228,7 +228,7 @@ class HotRestartEventTest(HazelcastTestCase):
         self.assertEqual(member.uuid, str(members[0].uuid))
 
     def test_when_member_started_with_the_same_address(self):
-        mark_client_version_at_least(self, "4.2")
+        skip_if_client_version_older_than(self, "4.2")
 
         old_member = self.cluster.start_member()
         self.client = HazelcastClient(cluster_name=self.cluster.id)

--- a/tests/integration/backward_compatible/proxy/cp/atomic_long_test.py
+++ b/tests/integration/backward_compatible/proxy/cp/atomic_long_test.py
@@ -1,7 +1,7 @@
 from hazelcast.errors import DistributedObjectDestroyedError
 from hazelcast.serialization.api import IdentifiedDataSerializable
 from tests.integration.backward_compatible.proxy.cp import CPTestCase
-from tests.util import mark_server_version_at_least
+from tests.util import skip_if_server_version_older_than
 
 
 class Multiplication(IdentifiedDataSerializable):
@@ -108,28 +108,28 @@ class AtomicLongTest(CPTestCase):
 
     def test_alter(self):
         # the class is defined in the 4.1 JAR
-        mark_server_version_at_least(self, self.client, "4.1")
+        skip_if_server_version_older_than(self, self.client, "4.1")
         self.atomic_long.set(2)
         self.assertIsNone(self.atomic_long.alter(Multiplication(5)))
         self.assertEqual(10, self.atomic_long.get())
 
     def test_alter_and_get(self):
         # the class is defined in the 4.1 JAR
-        mark_server_version_at_least(self, self.client, "4.1")
+        skip_if_server_version_older_than(self, self.client, "4.1")
         self.atomic_long.set(-3)
         self.assertEqual(-9, self.atomic_long.alter_and_get(Multiplication(3)))
         self.assertEqual(-9, self.atomic_long.get())
 
     def test_get_and_alter(self):
         # the class is defined in the 4.1 JAR
-        mark_server_version_at_least(self, self.client, "4.1")
+        skip_if_server_version_older_than(self, self.client, "4.1")
         self.atomic_long.set(123)
         self.assertEqual(123, self.atomic_long.get_and_alter(Multiplication(-1)))
         self.assertEqual(-123, self.atomic_long.get())
 
     def test_apply(self):
         # the class is defined in the 4.1 JAR
-        mark_server_version_at_least(self, self.client, "4.1")
+        skip_if_server_version_older_than(self, self.client, "4.1")
         self.atomic_long.set(42)
         self.assertEqual(84, self.atomic_long.apply(Multiplication(2)))
         self.assertEqual(42, self.atomic_long.get())

--- a/tests/integration/backward_compatible/proxy/cp/atomic_reference_test.py
+++ b/tests/integration/backward_compatible/proxy/cp/atomic_reference_test.py
@@ -3,7 +3,7 @@ from hazelcast.serialization.api import IdentifiedDataSerializable
 
 from tests.integration.backward_compatible.util import write_string_to_output
 from tests.integration.backward_compatible.proxy.cp import CPTestCase
-from tests.util import mark_server_version_at_least
+from tests.util import skip_if_server_version_older_than
 
 
 class AppendString(IdentifiedDataSerializable):
@@ -110,35 +110,35 @@ class AtomicReferenceTest(CPTestCase):
 
     def test_alter(self):
         # the class is defined in the 4.1 JAR
-        mark_server_version_at_least(self, self.client, "4.1")
+        skip_if_server_version_older_than(self, self.client, "4.1")
         self.ref.set("hey")
         self.assertIsNone(self.ref.alter(AppendString("123")))
         self.assertEqual("hey123", self.ref.get())
 
     def test_alter_with_incompatible_types(self):
         # the class is defined in the 4.1 JAR
-        mark_server_version_at_least(self, self.client, "4.1")
+        skip_if_server_version_older_than(self, self.client, "4.1")
         self.ref.set(42)
         with self.assertRaises(ClassCastError):
             self.ref.alter(AppendString("."))
 
     def test_alter_and_get(self):
         # the class is defined in the 4.1 JAR
-        mark_server_version_at_least(self, self.client, "4.1")
+        skip_if_server_version_older_than(self, self.client, "4.1")
         self.ref.set("123")
         self.assertEqual("123...", self.ref.alter_and_get(AppendString("...")))
         self.assertEqual("123...", self.ref.get())
 
     def test_get_and_alter(self):
         # the class is defined in the 4.1 JAR
-        mark_server_version_at_least(self, self.client, "4.1")
+        skip_if_server_version_older_than(self, self.client, "4.1")
         self.ref.set("hell")
         self.assertEqual("hell", self.ref.get_and_alter(AppendString("o")))
         self.assertEqual("hello", self.ref.get())
 
     def test_apply(self):
         # the class is defined in the 4.1 JAR
-        mark_server_version_at_least(self, self.client, "4.1")
+        skip_if_server_version_older_than(self, self.client, "4.1")
         self.ref.set("hell")
         self.assertEqual("hello", self.ref.apply(AppendString("o")))
         self.assertEqual("hell", self.ref.get())

--- a/tests/integration/backward_compatible/proxy/map_test.py
+++ b/tests/integration/backward_compatible/proxy/map_test.py
@@ -56,7 +56,7 @@ from tests.util import (
     get_current_timestamp,
     compare_client_version,
     compare_server_version,
-    mark_client_version_at_least,
+    skip_if_client_version_older_than,
     random_string,
 )
 
@@ -444,7 +444,7 @@ class MapTest(SingleMemberTestCase):
     def test_put_get_large_payload(self):
         # The fix for reading large payloads is introduced in 4.2.1
         # See https://github.com/hazelcast/hazelcast-python-client/pull/436
-        mark_client_version_at_least(self, "4.2.1")
+        skip_if_client_version_older_than(self, "4.2.1")
 
         payload = bytearray(os.urandom(16 * 1024 * 1024))
         start = get_current_timestamp()

--- a/tests/integration/backward_compatible/proxy/map_test.py
+++ b/tests/integration/backward_compatible/proxy/map_test.py
@@ -54,8 +54,8 @@ from tests.util import (
     event_collector,
     fill_map,
     get_current_timestamp,
-    is_client_version_older_than,
-    is_server_version_older_than,
+    compare_client_version,
+    compare_server_version,
     mark_client_version_at_least,
     random_string,
 )
@@ -364,7 +364,7 @@ class MapTest(SingleMemberTestCase):
         self.assertIsNotNone(entry_view.cost)
         self.assertIsNotNone(entry_view.creation_time)
         self.assertIsNotNone(entry_view.expiration_time)
-        if is_server_version_older_than(self.client, "4.2"):
+        if compare_server_version(self.client, "4.2") < 0:
             self.assertEqual(entry_view.hits, 2)
         else:
             # 4.2+ servers do not collect per entry stats by default
@@ -780,7 +780,7 @@ class MapMaxIdleTest(SingleMemberTestCase):
 
 
 @unittest.skipIf(
-    is_client_version_older_than("4.2.1"), "Tests the features added in 4.2.1 version of the client"
+    compare_client_version("4.2.1") < 0, "Tests the features added in 4.2.1 version of the client"
 )
 class MapAggregatorsIntTest(SingleMemberTestCase):
     @classmethod
@@ -883,7 +883,7 @@ class MapAggregatorsIntTest(SingleMemberTestCase):
 
 
 @unittest.skipIf(
-    is_client_version_older_than("4.2.1"), "Tests the features added in 4.2.1 version of the client"
+    compare_client_version("4.2.1") < 0, "Tests the features added in 4.2.1 version of the client"
 )
 class MapAggregatorsLongTest(SingleMemberTestCase):
     @classmethod
@@ -925,7 +925,7 @@ class MapAggregatorsLongTest(SingleMemberTestCase):
 
 
 @unittest.skipIf(
-    is_client_version_older_than("4.2.1"), "Tests the features added in 4.2.1 version of the client"
+    compare_client_version("4.2.1") < 0, "Tests the features added in 4.2.1 version of the client"
 )
 class MapAggregatorsDoubleTest(SingleMemberTestCase):
     @classmethod
@@ -1026,7 +1026,7 @@ class MapAggregatorsDoubleTest(SingleMemberTestCase):
 
 
 @unittest.skipIf(
-    is_client_version_older_than("4.2.1"), "Tests the features added in 4.2.1 version of the client"
+    compare_client_version("4.2.1") < 0, "Tests the features added in 4.2.1 version of the client"
 )
 class MapProjectionsTest(SingleMemberTestCase):
     @classmethod

--- a/tests/integration/backward_compatible/proxy/reliable_topic_test.py
+++ b/tests/integration/backward_compatible/proxy/reliable_topic_test.py
@@ -18,7 +18,7 @@ from tests.util import (
     random_string,
     event_collector,
     get_current_timestamp,
-    mark_client_version_at_least,
+    skip_if_client_version_older_than,
 )
 
 CAPACITY = 10
@@ -494,7 +494,7 @@ class ReliableTopicTest(SingleMemberTestCase):
         self.assertTrueEventually(assertion)
 
     def test_client_receives_when_server_publish_messages(self):
-        mark_client_version_at_least(self, "4.2.1")
+        skip_if_client_version_older_than(self, "4.2.1")
 
         topic_name = random_string()
         topic = self.get_topic(topic_name)

--- a/tests/integration/backward_compatible/proxy/reliable_topic_test.py
+++ b/tests/integration/backward_compatible/proxy/reliable_topic_test.py
@@ -14,7 +14,7 @@ except ImportError:
 
 from tests.base import SingleMemberTestCase
 from tests.util import (
-    is_client_version_older_than,
+    compare_client_version,
     random_string,
     event_collector,
     get_current_timestamp,
@@ -25,7 +25,7 @@ CAPACITY = 10
 
 
 @unittest.skipIf(
-    is_client_version_older_than("4.1"), "Tests the features added in 4.1 version of the client"
+    compare_client_version("4.1") < 0, "Tests the features added in 4.1 version of the client"
 )
 class ReliableTopicTest(SingleMemberTestCase):
     @classmethod
@@ -38,7 +38,7 @@ class ReliableTopicTest(SingleMemberTestCase):
     @classmethod
     def configure_client(cls, config):
         config["cluster_name"] = cls.cluster.id
-        if not is_client_version_older_than("4.1"):
+        if not compare_client_version("4.1") < 0:
             # Add these config elements only to the 4.1+ clients
             # since the older versions do not know anything
             # about them.

--- a/tests/integration/backward_compatible/proxy/ringbuffer_test.py
+++ b/tests/integration/backward_compatible/proxy/ringbuffer_test.py
@@ -5,7 +5,7 @@ import unittest
 from hazelcast.proxy.ringbuffer import OVERFLOW_POLICY_FAIL, MAX_BATCH_SIZE
 from hazelcast.serialization.api import IdentifiedDataSerializable
 from tests.base import SingleMemberTestCase
-from tests.util import random_string, is_client_version_older_than, get_current_timestamp
+from tests.util import random_string, compare_client_version
 from hazelcast.six.moves import range
 
 CAPACITY = 10
@@ -120,7 +120,7 @@ class RingBufferTest(SingleMemberTestCase):
 
 
 @unittest.skipIf(
-    is_client_version_older_than("4.1"), "Tests the features added in 4.1 version of the client"
+    compare_client_version("4.1") < 0, "Tests the features added in 4.1 version of the client"
 )
 class RingbufferReadManyTest(SingleMemberTestCase):
     @classmethod

--- a/tests/integration/backward_compatible/sql_test.py
+++ b/tests/integration/backward_compatible/sql_test.py
@@ -777,7 +777,7 @@ class JetSqlTest(SqlTestBase):
         TYPE IMap
         OPTIONS (
             'keyFormat' = 'int',
-            'valueFormat' = 'json'
+            'valueFormat' = 'json-flat'
         )
         """
             % self.map_name

--- a/tests/integration/backward_compatible/sql_test.py
+++ b/tests/integration/backward_compatible/sql_test.py
@@ -60,9 +60,7 @@ class SqlTestBase(HazelcastTestCase):
         cls.is_v5_or_newer_server = compare_server_version_with_rc(cls.rc, "5.0") >= 0
 
         # enable Jet if the server is 5.0+
-        cluster_config = (
-            SERVER_CONFIG % JET_ENABLED_CONFIG if cls.is_v5_or_newer_server else SERVER_CONFIG % ""
-        )
+        cluster_config = SERVER_CONFIG % (JET_ENABLED_CONFIG if cls.is_v5_or_newer_server else "")
         cls.cluster = cls.create_cluster(cls.rc, cluster_config)
         cls.member = cls.cluster.start_member()
         cls.client = HazelcastClient(
@@ -82,11 +80,11 @@ class SqlTestBase(HazelcastTestCase):
 
         # Skip tests if major versions of the client/server do not match.
         is_v5_or_newer_client = compare_client_version("5.0") >= 0
-        if is_v5_or_newer_client ^ self.is_v5_or_newer_server:
+        if is_v5_or_newer_client != self.is_v5_or_newer_server:
             self.skipTest("Major versions of the client and the server do not match.")
 
     def _mark_minimum_server_version(self):
-        mark_server_version_at_least(self, self.client, "5.0")
+        mark_server_version_at_least(self, self.client, "4.2")
 
     def tearDown(self):
         self.map.clear()
@@ -677,7 +675,8 @@ class SqlServiceV4LiteMemberClusterTest(SingleMemberTestCase):
 class SqlServiceV5LiteMemberClusterTest(SingleMemberTestCase):
     @classmethod
     def configure_cluster(cls):
-        return LITE_MEMBER_CONFIG % ""
+        is_v5_or_newer_server = compare_server_version_with_rc(cls.rc, "5.0") >= 0
+        return LITE_MEMBER_CONFIG % (JET_ENABLED_CONFIG if is_v5_or_newer_server else "")
 
     @classmethod
     def configure_client(cls, config):

--- a/tests/integration/backward_compatible/sql_test.py
+++ b/tests/integration/backward_compatible/sql_test.py
@@ -13,9 +13,10 @@ from tests.hzrc.ttypes import Lang
 from mock import patch
 
 from tests.util import (
-    is_client_version_older_than,
+    compare_server_version_with_rc,
+    compare_client_version,
     mark_server_version_at_least,
-    is_server_version_older_than,
+    mark_server_version_at_most,
 )
 
 try:
@@ -49,32 +50,14 @@ class SqlTestBase(HazelcastTestCase):
 
     rc = None
     cluster = None
-    is_v5_or_newer_server = True
+    is_v5_or_newer_server = None
     client = None
 
     @classmethod
     def setUpClass(cls):
         cls.rc = cls.create_rc()
 
-        # We don't know the member version before starting a member.
-        # That's why, we are creating (and shutting down) a dummy
-        # cluster to determine the member version.
-        dummy_cluster = None
-        dummy_client = None
-
-        try:
-            dummy_cluster = cls.create_cluster(cls.rc)
-            dummy_cluster.start_member()
-            dummy_client = HazelcastClient(cluster_name=dummy_cluster.id)
-
-            if is_server_version_older_than(dummy_client, "5.0"):
-                cls.is_v5_or_newer_server = False
-        finally:
-            if dummy_client:
-                dummy_client.shutdown()
-
-            if dummy_cluster:
-                cls.rc.terminateCluster(dummy_cluster.id)
+        cls.is_v5_or_newer_server = compare_server_version_with_rc(cls.rc, "5.0") >= 0
 
         # enable Jet if the server is 5.0+
         cluster_config = (
@@ -95,21 +78,12 @@ class SqlTestBase(HazelcastTestCase):
     def setUp(self):
         self.map_name = random_string()
         self.map = self.client.get_map(self.map_name).blocking()
-        self._mark_minimum_server_version()
+        mark_server_version_at_least(self, self.client, "4.2")
 
         # Skip tests if major versions of the client/server do not match.
-
-        if (  # 4.x client with 5.x server
-            is_client_version_older_than("5.0")
-            and not is_server_version_older_than(self.client, "5.0")
-        ) or (  # 5.x client with 4.x server
-            not is_client_version_older_than("5.0")
-            and is_server_version_older_than(self.client, "5.0")
-        ):
+        is_v5_or_newer_client = compare_client_version("5.0") >= 0
+        if is_v5_or_newer_client ^ self.is_v5_or_newer_server:
             self.skipTest("Major versions of the client and the server do not match.")
-
-    def _mark_minimum_server_version(self):
-        mark_server_version_at_least(self, self.client, "4.2")
 
     def tearDown(self):
         self.map.clear()
@@ -120,7 +94,7 @@ class SqlTestBase(HazelcastTestCase):
 
 
 @unittest.skipIf(
-    is_client_version_older_than("4.2"), "Tests the features added in 4.2 version of the client"
+    compare_client_version("4.2") < 0, "Tests the features added in 4.2 version of the client"
 )
 class SqlServiceTest(SqlTestBase):
     def test_execute(self):
@@ -278,7 +252,7 @@ class SqlServiceTest(SqlTestBase):
 
 
 @unittest.skipIf(
-    is_client_version_older_than("4.2"), "Tests the features added in 4.2 version of the client"
+    compare_client_version("4.2") < 0, "Tests the features added in 4.2 version of the client"
 )
 class SqlResultTest(SqlTestBase):
     def test_blocking_iterator(self):
@@ -469,7 +443,7 @@ class SqlResultTest(SqlTestBase):
 
 
 @unittest.skipIf(
-    is_client_version_older_than("4.2"), "Tests the features added in 4.2 version of the client"
+    compare_client_version("4.2") < 0, "Tests the features added in 4.2 version of the client"
 )
 class SqlColumnTypesReadTest(SqlTestBase):
     def test_varchar(self):
@@ -655,18 +629,19 @@ LITE_MEMBER_CONFIG = """
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
            http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd">
-    <lite-member enabled="true" />
+    <lite-member enabled="true" />%s
 </hazelcast>
 """
 
 
 @unittest.skipIf(
-    is_client_version_older_than("4.2"), "Tests the features added in 4.2 version of the client"
+    compare_client_version("4.2") < 0 or compare_client_version("5.0") >= 0,
+    "Tests the behaviour of the v4 client, with the features added in 4.2",
 )
-class SqlServiceLiteMemberClusterTest(SingleMemberTestCase):
+class SqlServiceV4LiteMemberClusterTest(SingleMemberTestCase):
     @classmethod
     def configure_cluster(cls):
-        return LITE_MEMBER_CONFIG
+        return LITE_MEMBER_CONFIG % ""
 
     @classmethod
     def configure_client(cls, config):
@@ -675,6 +650,7 @@ class SqlServiceLiteMemberClusterTest(SingleMemberTestCase):
 
     def setUp(self):
         mark_server_version_at_least(self, self.client, "4.2")
+        mark_server_version_at_most(self, self.client, "5.0")
 
     def test_execute(self):
         with self.assertRaises(HazelcastSqlError) as cm:
@@ -693,7 +669,89 @@ class SqlServiceLiteMemberClusterTest(SingleMemberTestCase):
 
 
 @unittest.skipIf(
-    is_client_version_older_than("5.0"), "Tests the features added in 5.0 version of the client"
+    compare_client_version("5.0") < 0, "Tests the features added in 5.0 version of the client"
+)
+class SqlServiceV5LiteMemberClusterTest(SingleMemberTestCase):
+    @classmethod
+    def configure_cluster(cls):
+        return LITE_MEMBER_CONFIG % ""
+
+    @classmethod
+    def configure_client(cls, config):
+        config["cluster_name"] = cls.cluster.id
+        return config
+
+    def setUp(self):
+        mark_server_version_at_least(self, self.client, "5.0")
+
+    def test_execute(self):
+        with self.assertRaises(HazelcastSqlError) as cm:
+            with self.client.sql.execute("SOME QUERY") as result:
+                result.update_count().result()
+
+        # Make sure that exception is originating from the server
+        self.assertEqual(self.member.uuid, str(cm.exception.originating_member_uuid))
+
+    def test_execute_statement(self):
+        statement = SqlStatement("SOME QUERY")
+        with self.assertRaises(HazelcastSqlError) as cm:
+            with self.client.sql.execute_statement(statement) as result:
+                result.update_count().result()
+
+        # Make sure that exception is originating from the server
+        self.assertEqual(self.member.uuid, str(cm.exception.originating_member_uuid))
+
+
+@unittest.skipIf(
+    compare_client_version("5.0") < 0, "Tests the features added in 5.0 version of the client"
+)
+class SqlServiceV5MixedClusterTest(HazelcastTestCase):
+    rc = None
+    cluster = None
+    is_v5_or_newer_server = None
+    client = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.rc = cls.create_rc()
+        cls.is_v5_or_newer_server = compare_server_version_with_rc(cls.rc, "5.0") >= 0
+
+        cluster_config = (
+            LITE_MEMBER_CONFIG % JET_ENABLED_CONFIG
+            if cls.is_v5_or_newer_server
+            else LITE_MEMBER_CONFIG % ""
+        )
+        cls.cluster = cls.create_cluster(cls.rc, cluster_config)
+        cls.cluster.start_member()
+        cls.cluster.start_member()
+
+        script = """instance_0.getCluster().promoteLocalLiteMember();"""
+        cls.rc.executeOnController(cls.cluster.id, script, Lang.JAVASCRIPT)
+
+        cls.client = HazelcastClient(cluster_name=cls.cluster.id)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.client.shutdown()
+        cls.rc.terminateCluster(cls.cluster.id)
+        cls.rc.exit()
+
+    def setUp(self):
+        mark_server_version_at_least(self, self.client, "5.0")
+
+    def test_mixed_cluster(self):
+        map_name = random_string()
+        m = self.client.get_map(map_name).blocking()
+        m.put(1, 1)
+        with self.client.sql.execute("SELECT this FROM %s" % map_name) as result:
+            rows = [row.get_object("this") for row in result]
+
+        self.assertEqual(1, len(rows))
+        self.assertEqual(1, rows[0])
+
+
+@unittest.skipIf(
+    compare_client_version("5.0") < 0, "Tests the features added in 5.0 version of the client"
 )
 class JetSqlTest(SqlTestBase):
     def _mark_minimum_server_version(self):

--- a/tests/integration/backward_compatible/sql_test.py
+++ b/tests/integration/backward_compatible/sql_test.py
@@ -78,12 +78,15 @@ class SqlTestBase(HazelcastTestCase):
     def setUp(self):
         self.map_name = random_string()
         self.map = self.client.get_map(self.map_name).blocking()
-        mark_server_version_at_least(self, self.client, "4.2")
+        self._mark_minimum_server_version()
 
         # Skip tests if major versions of the client/server do not match.
         is_v5_or_newer_client = compare_client_version("5.0") >= 0
         if is_v5_or_newer_client ^ self.is_v5_or_newer_server:
             self.skipTest("Major versions of the client and the server do not match.")
+
+    def _mark_minimum_server_version(self):
+        mark_server_version_at_least(self, self.client, "5.0")
 
     def tearDown(self):
         self.map.clear()

--- a/tests/integration/backward_compatible/statistics_test.py
+++ b/tests/integration/backward_compatible/statistics_test.py
@@ -9,7 +9,7 @@ from hazelcast.serialization import BE_INT, INT_SIZE_IN_BYTES
 from hazelcast.statistics import Statistics
 from tests.base import HazelcastTestCase
 from tests.hzrc.ttypes import Lang
-from tests.util import get_current_timestamp, random_string, mark_client_version_at_least
+from tests.util import get_current_timestamp, random_string, skip_if_client_version_older_than
 
 
 class StatisticsTest(HazelcastTestCase):
@@ -186,7 +186,7 @@ class StatisticsTest(HazelcastTestCase):
         client.shutdown()
 
     def test_metrics_blob(self):
-        mark_client_version_at_least(self, "4.2.1")
+        skip_if_client_version_older_than(self, "4.2.1")
 
         map_name = random_string()
         client = HazelcastClient(

--- a/tests/unit/sql_test.py
+++ b/tests/unit/sql_test.py
@@ -32,7 +32,7 @@ class SqlMockTest(unittest.TestCase):
         self.connection = MagicMock()
 
         connection_manager = MagicMock(client_uuid=uuid.uuid4())
-        connection_manager.get_random_connection = MagicMock(return_value=self.connection)
+        connection_manager.get_random_connection_for_sql = MagicMock(return_value=self.connection)
 
         serialization_service = MagicMock()
         serialization_service.to_object.side_effect = lambda arg: arg

--- a/tests/util.py
+++ b/tests/util.py
@@ -6,9 +6,9 @@ from hazelcast import __version__
 from hazelcast.config import SSLProtocol
 from hazelcast.util import calculate_version
 
-# time.monotonic() is more consistent since it uses cpu clock rather than system clock. Use it if available.
 from tests.hzrc.ttypes import Lang
 
+# time.monotonic() is more consistent since it uses cpu clock rather than system clock. Use it if available.
 if hasattr(time, "monotonic"):
     get_current_timestamp = time.monotonic
 else:

--- a/tests/util.py
+++ b/tests/util.py
@@ -92,12 +92,12 @@ def set_attr(*args, **kwargs):
     return wrap_ob
 
 
-def mark_server_version_at_least(test, client, version):
+def skip_if_server_version_older_than(test, client, version):
     if compare_server_version(client, version) < 0:
         test.skipTest("Expected a newer server")
 
 
-def mark_server_version_at_most(test, client, version):
+def skip_if_server_version_newer_than_or_equal(test, client, version):
     if compare_server_version(client, version) >= 0:
         test.skipTest("Expected an older server")
 
@@ -127,12 +127,12 @@ def compare_server_version_with_rc(rc, version):
     return server_version - version
 
 
-def mark_client_version_at_least(test, version):
+def skip_if_client_version_older_than(test, version):
     if compare_client_version(version) < 0:
         test.skipTest("Expected a newer client")
 
 
-def mark_client_version_at_most(test, version):
+def skip_if_client_version_newer_than_or_equal(test, version):
     if compare_client_version(version) >= 0:
         test.skipTest("Expected an older client")
 


### PR DESCRIPTION
In v5, the logic behind selecting a query connection is changed
a little bit.

Formerly, we were relying on the load balancers to fetch the next
data member. Now, we are selecting a random connection from the
largest same-version (ignoring the patch version) member group.
This way, SQL will be available on the client-side during rolling
upgrade scenarios.
