### PR TITLE
Make document generation job more strict

### DIFF
--- a/.github/workflows/test_runner.yml
+++ b/.github/workflows/test_runner.yml
@@ -83,4 +83,4 @@ jobs:
       - name: Generate documentation
         working-directory: docs
         run: |
-          make html
+          make html SPHINXOPTS="-W --keep-going"


### PR DESCRIPTION
Right now, the documentation generator job does not fail when there
is a warning. We wanted to fail on such warnings because the warning
shown might result in missing content on the generated docs.

We achieve this by supplying the `-W` SPHINXOPTS. Also, we provide
`--keep-going` to not just fail on the first warnings we see
and try to keep going. This way, we would see all warnings. Note that,
the exit code will still be non-zero if there are some warnings and
the job will fail.