### PR TITLE
Fix Github Actions runners

### DIFF
--- a/.github/workflows/nightly_runner.yml
+++ b/.github/workflows/nightly_runner.yml
@@ -4,7 +4,7 @@ on:
     - cron: '0 2 * * *'
 jobs:
   run-tests:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os == "ubuntu-latest" && matrix.python-version == "3.4" && "ubuntu-18.04" || matrix.os }}
     name: Run tests with Python ${{ matrix.python-version }} on ${{ matrix.os }}
     strategy:
       matrix:
@@ -25,7 +25,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
           pip install -r requirements-test.txt
       - name: Run tests
         env:

--- a/.github/workflows/test_runner.yml
+++ b/.github/workflows/test_runner.yml
@@ -31,7 +31,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
           pip install -r requirements-test.txt
       - name: Run tests
         env:
@@ -61,7 +60,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
       - name: Run black
         run: |
@@ -78,7 +76,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
       - name: Generate documentation
         working-directory: docs

--- a/tests/integration/backward_compatible/proxy/cp/count_down_latch_test.py
+++ b/tests/integration/backward_compatible/proxy/cp/count_down_latch_test.py
@@ -44,11 +44,15 @@ class CountDownLatchTest(CPTestCase):
         self.assertFalse(latch.await_latch(0))
 
     def test_await_latch_with_timeout(self):
+        timeout = 0.1
         latch = self.get_latch(1)
         start = get_current_timestamp()
-        self.assertFalse(latch.await_latch(0.1))
+        self.assertFalse(latch.await_latch(timeout))
         time_passed = get_current_timestamp() - start
-        self.assertTrue(time_passed > 0.1)
+        self.assertTrue(
+            time_passed >= timeout,
+            "Time passed is less than %s, which is %s" % (timeout, time_passed),
+        )
 
     def test_await_latch_multiple_waiters(self):
         latch = self.get_latch(1)

--- a/tests/util.py
+++ b/tests/util.py
@@ -8,7 +8,7 @@ from hazelcast.util import calculate_version
 
 from tests.hzrc.ttypes import Lang
 
-# time.monotonic() is more consistent since it uses cpu clock rather than system clock. Use it if available.
+# time.monotonic() cannot go backwards. Use it if available.
 if hasattr(time, "monotonic"):
     get_current_timestamp = time.monotonic
 else:


### PR DESCRIPTION
In the nightly tests, there were some failures.

- In Windows runners, `test_await_latch_with_timeout` was failing
randomly. My assumption is that, due to low time resolution, sometimes
we were getting equal values instead of larger values. I changed
the condition from `>` to `>=`. Also, I changed the failure message
so that, the next time it fails we will see the exact values.

- Removed `python -m pip install --upgrade pip` statements as the Python
runners already have the latest pip available to them. If we try to
upgrade pip to the latest version, for some older Python versions
it fails because those Python versions reached their EOL and pip
no longer tries to maintain compatibility for them.

- Modified the nightly runner so that, when the os is `ubuntu-latest`
and the Python version is `3.4`, we will use `ubuntu-18.04`, as there
is no Python 3.4 binary available in `ubuntu-latest`. Hopefully, we
will drop the support for ancient Python versions, but till that
day, this workaround should work.