### PR TITLE
Fix nightly runners

### DIFF
--- a/.github/workflows/nightly_runner.yml
+++ b/.github/workflows/nightly_runner.yml
@@ -1,10 +1,11 @@
 name: Runs the tests nightly
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 2 * * *'
 jobs:
   run-tests:
-    runs-on: ${{ matrix.os == "ubuntu-latest" && matrix.python-version == "3.4" && "ubuntu-18.04" || matrix.os }}
+    runs-on: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.4' && 'ubuntu-18.04' || matrix.os }}
     name: Run tests with Python ${{ matrix.python-version }} on ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
This time, nightly runners complained with the following error:

```
The workflow is not valid. .github/workflows/nightly_runner.yml (Line: 7, Col: 14): Unexpected symbol: '"ubuntu-latest"'. Located at position 14 within expression: matrix.os == "ubuntu-latest" && matrix.python-version == "3.4" && "ubuntu-18.04" || matrix.os
```

Looking at the https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions,
they use single quotes inside of the expressions for strings.
Hence, this time, I did the same.

Also, I put `workflow_dispatch` option to `on` section so that
I can manually start the tests. This way, we don't have to wait
until the next morning to see the effects of the changes we made.