### PR TITLE
[API-582] Implement external smart client discovery

### DIFF
--- a/docs/setting_up_client_network.rst
+++ b/docs/setting_up_client_network.rst
@@ -152,7 +152,7 @@ their own public external IP addresses, they pass this information to the
 client. As a result, the client can use public addresses for communication.
 
 In order to use this feature, make sure your cluster members are accessible
-from the network the client resides in, then set ``use_public_addresses``
+from the network the client resides in, then set ``use_public_ip``
 configuration option to ``True`` while constructing the client. You should also
 specify the public address of at least one member in the configuration:
 
@@ -160,7 +160,7 @@ specify the public address of at least one member in the configuration:
 
     client = hazelcast.HazelcastClient(
         cluster_members=["myserver.publicaddress.com:5701"],
-        use_public_address=True,
+        use_public_ip=True,
     )
 
 This solution works everywhere without further configuration (Kubernetes, AWS,

--- a/docs/setting_up_client_network.rst
+++ b/docs/setting_up_client_network.rst
@@ -129,6 +129,44 @@ your client and cluster members as described in the
 :ref:`securing_client_connection:tls/ssl for hazelcast python clients`
 section.
 
+External Smart Client Discovery
+-------------------------------
+
+.. warning::
+
+    This feature requires Hazelcast IMDG 4.2 or higher version.
+
+The client sends requests directly to cluster members in the smart client mode
+(default) in order to reduce hops to accomplish operations. Because of that,
+the client should know the addresses of members in the cluster.
+
+In cloud-like environments, or Kubernetes, there are usually two network
+interfaces: the private and public network interfaces. When the client is in
+the same network as the members, it uses their private network addresses.
+Otherwise, if the client and the Hazelcast cluster are on different networks,
+the client cannot connect to members using their private network addresses.
+Hazelcast 4.2 introduced External Smart Client Discovery to solve that issue.
+The client needs to communicate with all cluster members via their public IP
+addresses in this case. Whenever Hazelcast cluster members are able to resolve
+their own public external IP addresses, they pass this information to the
+client. As a result, the client can use public addresses for communication.
+
+In order to use this feature, make sure your cluster members are accessible
+from the network the client resides in, then set ``use_public_addresses``
+configuration option to ``True`` while constructing the client. You should also
+specify the public address of at least one member in the configuration:
+
+.. code:: python
+
+    client = hazelcast.HazelcastClient(
+        cluster_members=["myserver.publicaddress.com:5701"],
+        use_public_address=True,
+    )
+
+This solution works everywhere without further configuration (Kubernetes, AWS,
+GCP, Azure, etc.) as long as the corresponding plugin is enabled in Hazelcast
+server configuration.
+
 Configuring Backup Acknowledgment
 ---------------------------------
 

--- a/examples/external-smart-client-discovery/external_smart_client_discovery_example.py
+++ b/examples/external-smart-client-discovery/external_smart_client_discovery_example.py
@@ -1,0 +1,19 @@
+import hazelcast
+
+
+# Client will try to connect to cluster using the provided
+# public address and it will connect to the other cluster members
+# using their public addresses, if available.
+client = hazelcast.HazelcastClient(
+    cluster_members=["myserver.publicaddress.com:5701"],
+    use_public_addresses=True,
+)
+
+m = client.get_map("my-map").blocking()
+
+m.set(1, 100)
+value = m.get(1)
+
+print("Value for the key `1` is %s." % value)
+
+client.shutdown()

--- a/examples/external-smart-client-discovery/external_smart_client_discovery_example.py
+++ b/examples/external-smart-client-discovery/external_smart_client_discovery_example.py
@@ -5,7 +5,7 @@ import hazelcast
 # using their public addresses, if available.
 client = hazelcast.HazelcastClient(
     cluster_members=["myserver.publicaddress.com:5701"],
-    use_public_addresses=True,
+    use_public_ip=True,
 )
 
 m = client.get_map("my-map").blocking()

--- a/examples/external-smart-client-discovery/external_smart_client_discovery_example.py
+++ b/examples/external-smart-client-discovery/external_smart_client_discovery_example.py
@@ -1,7 +1,6 @@
 import hazelcast
 
-
-# Client will try to connect to cluster using the provided
+# Client will try to connect to the cluster using the provided
 # public address and it will connect to the other cluster members
 # using their public addresses, if available.
 client = hazelcast.HazelcastClient(

--- a/hazelcast/client.py
+++ b/hazelcast/client.py
@@ -293,7 +293,7 @@ class HazelcastClient(object):
 
             - Member throws an exception.
             - Connection between the client and member is closed.
-            - Client's heartbeat requests are timed out.
+            - The client's heartbeat requests are timed out.
 
             Time passed since invocation started is compared with this property.
             If the time is already passed, then the exception is delegated to the user.
@@ -304,13 +304,14 @@ class HazelcastClient(object):
 
         invocation_retry_pause (float): Pause time between each retry cycle of an
             invocation in seconds. By default, set to ``1.0``.
-        statistics_enabled (bool): When set to ``True``, client statistics collection
-            is enabled. By default, set to ``False``.
+        statistics_enabled (bool): When set to ``True``, the client statistics
+            collection is enabled. By default, set to ``False``.
         statistics_period (float): The period in seconds the statistics run.
-        shuffle_member_list (bool): Client shuffles the given member list to prevent
-            all clients to connect to the same node when this property is set to
-            ``True``. When it is set to ``False``, the client tries to connect to
-            the nodes in the given order. By default, set to ``True``.
+        shuffle_member_list (bool): The Client shuffles the given member list
+            to prevent all clients to connect to the same node when this
+            property is set to ``True``. When it is set to ``False``, the
+            client tries to connect to the nodes in the given order. By
+            default, set to ``True``.
         backup_ack_to_client_enabled (bool): Enables the client to get backup
             acknowledgements directly from the member that backups are applied,
             which reduces number of hops and increases performance for smart clients.

--- a/hazelcast/client.py
+++ b/hazelcast/client.py
@@ -332,8 +332,8 @@ class HazelcastClient(object):
         token_provider (hazelcast.security.TokenProvider): Token provider for
             custom authentication (Enterprise feature). Note that token_provider
             setting has priority over credentials settings.
-        use_public_addresses (bool): When set to ``True``, the client uses the
-            public addresses reported by members while connecting to them, if
+        use_public_ip (bool): When set to ``True``, the client uses the public
+            IP addresses reported by members while connecting to them, if
             available. By default, set to ``False``.
     """
 

--- a/hazelcast/client.py
+++ b/hazelcast/client.py
@@ -51,16 +51,16 @@ class HazelcastClient(object):
     distributed data structures on the Hazelcast clusters.
 
     Keyword Args:
-        cluster_members (`list[str]`): Candidate address list that client
-            will use to establish initial connection.
-            By default, set to ``["127.0.0.1"]``.
+        cluster_members (`list[str]`): Candidate address list that the client
+            will use to establish initial connection. By default, set to
+            ``["127.0.0.1"]``.
         cluster_name (str): Name of the cluster to connect to. The name is
             sent as part of the the client authentication message and may
             be verified on the member. By default, set to ``dev``.
         client_name (str): Name of the client instance. By default,
             set to ``hz.client_${CLIENT_ID}``, where ``CLIENT_ID`` starts
             from ``0`` and it is incremented by ``1`` for each new client.
-        connection_timeout (float): Socket timeout value in seconds for
+        connection_timeout (float): Socket timeout value in seconds for the
             client to connect member nodes. Setting this to ``0`` makes
             the connection blocking. By default, set to ``5.0``.
         socket_options (`list[tuple]`): List of socket option tuples. The
@@ -103,13 +103,13 @@ class HazelcastClient(object):
             separating them with a colon.
         cloud_discovery_token (str): Discovery token of the Hazelcast Cloud cluster.
             When this value is set, Hazelcast Cloud discovery is enabled.
-        async_start (bool): Enables non-blocking start mode of :class:`HazelcastClient`.
+        async_start (bool): Enables non-blocking start mode of the client.
             When set to ``True``, the client creation will not wait to connect to
             cluster. The client instance will throw exceptions until it connects to
-            cluster and becomes ready. If set to ``False``, :class:`HazelcastClient`
+            cluster and becomes ready. If set to ``False``, the client
             will block until a cluster connection established and it is ready to use
             the client instance. By default, set to ``False``.
-        reconnect_mode (int|str): Defines how a client reconnects to cluster after a
+        reconnect_mode (int|str): Defines how the client reconnects to cluster after a
             disconnect. By default, set to ``ON``. See the
             :class:`hazelcast.config.ReconnectMode` for possible values.
         retry_initial_backoff (float): Wait period in seconds after the first failure
@@ -241,7 +241,7 @@ class HazelcastClient(object):
               By default, set to ``16``.
 
         load_balancer (hazelcast.util.LoadBalancer): Load balancer implementation
-            for the client
+            for the client.
         membership_listeners (`list[tuple[function, function]]`): List of membership
             listener tuples. Tuples must be of size ``2``. The first element will
             be the function to be called when a member is added, and the second
@@ -311,7 +311,7 @@ class HazelcastClient(object):
             all clients to connect to the same node when this property is set to
             ``True``. When it is set to ``False``, the client tries to connect to
             the nodes in the given order. By default, set to ``True``.
-        backup_ack_to_client_enabled (bool): Enables client to get backup
+        backup_ack_to_client_enabled (bool): Enables the client to get backup
             acknowledgements directly from the member that backups are applied,
             which reduces number of hops and increases performance for smart clients.
             This option has no effect for unisocket clients. By default, set
@@ -332,7 +332,7 @@ class HazelcastClient(object):
         token_provider (hazelcast.security.TokenProvider): Token provider for
             custom authentication (Enterprise feature). Note that token_provider
             setting has priority over credentials settings.
-        use_public_addresses (bool): When set to ``True``, client uses the
+        use_public_addresses (bool): When set to ``True``, the client uses the
             public addresses reported by members while connecting to them, if
             available. By default, set to ``False``.
     """

--- a/hazelcast/client.py
+++ b/hazelcast/client.py
@@ -332,6 +332,9 @@ class HazelcastClient(object):
         token_provider (hazelcast.security.TokenProvider): Token provider for
             custom authentication (Enterprise feature). Note that token_provider
             setting has priority over credentials settings.
+        use_public_addresses (bool): When set to ``True``, client uses the
+            public addresses reported by members while connecting to them, if
+            available. By default, set to ``False``.
     """
 
     _CLIENT_ID = AtomicInteger()

--- a/hazelcast/cluster.py
+++ b/hazelcast/cluster.py
@@ -4,6 +4,7 @@ import uuid
 from collections import OrderedDict
 
 from hazelcast import six
+from hazelcast.core import EndpointQualifier, ProtocolType
 from hazelcast.errors import TargetDisconnectedError, IllegalStateError
 from hazelcast.util import check_not_none
 
@@ -47,6 +48,8 @@ class ClientInfo(object):
 
 _EMPTY_SNAPSHOT = _MemberListSnapshot(-1, OrderedDict())
 _INITIAL_MEMBERS_TIMEOUT_SECONDS = 120
+_CLIENT_ENDPOINT_QUALIFIER = EndpointQualifier(ProtocolType.CLIENT, None)
+_MEMBER_ENDPOINT_QUALIFIER = EndpointQualifier(ProtocolType.MEMBER, None)
 
 
 class ClusterService(object):
@@ -284,6 +287,17 @@ class _InternalClusterService(object):
     def _create_snapshot(version, member_infos):
         new_members = OrderedDict()
         for member_info in member_infos:
+            address_map = member_info.address_map
+            if address_map:
+                address = address_map.get(
+                    _CLIENT_ENDPOINT_QUALIFIER,
+                    address_map.get(_MEMBER_ENDPOINT_QUALIFIER, member_info.address),
+                )
+                member_info.address = address
+            else:
+                # It might be None on 4.0 servers.
+                member_info.address_map = {}
+
             new_members[member_info.uuid] = member_info
         return _MemberListSnapshot(version, new_members)
 

--- a/hazelcast/cluster.py
+++ b/hazelcast/cluster.py
@@ -291,12 +291,14 @@ class _InternalClusterService(object):
             if address_map:
                 address = address_map.get(
                     _CLIENT_ENDPOINT_QUALIFIER,
-                    address_map.get(_MEMBER_ENDPOINT_QUALIFIER, member_info.address),
+                    address_map.get(_MEMBER_ENDPOINT_QUALIFIER, None),
                 )
                 member_info.address = address
             else:
                 # It might be None on 4.0 servers.
-                member_info.address_map = {}
+                member_info.address_map = {
+                    _MEMBER_ENDPOINT_QUALIFIER: member_info.address,
+                }
 
             new_members[member_info.uuid] = member_info
         return _MemberListSnapshot(version, new_members)

--- a/hazelcast/config.py
+++ b/hazelcast/config.py
@@ -576,6 +576,7 @@ class _Config(object):
         "_creds_username",
         "_creds_password",
         "_token_provider",
+        "_use_public_addresses",
     )
 
     def __init__(self):
@@ -630,6 +631,7 @@ class _Config(object):
         self._creds_username = None
         self._creds_password = None
         self._token_provider = None
+        self._use_public_addresses = False
 
     @property
     def cluster_members(self):
@@ -1334,6 +1336,19 @@ class _Config(object):
         if token_fun is None or not isinstance(token_fun, types.MethodType):
             raise TypeError("token_provider must be an object with a token method")
         self._token_provider = token_provider
+
+    @property
+    def use_public_addresses(self):
+        # type: () -> bool
+        return self._use_public_addresses
+
+    @use_public_addresses.setter
+    def use_public_addresses(self, value):
+        # type: (bool) -> None
+        if isinstance(value, bool):
+            self._use_public_addresses = value
+        else:
+            raise TypeError("use_public_addresses must be a boolean")
 
     @classmethod
     def from_dict(cls, d):

--- a/hazelcast/config.py
+++ b/hazelcast/config.py
@@ -576,7 +576,7 @@ class _Config(object):
         "_creds_username",
         "_creds_password",
         "_token_provider",
-        "_use_public_addresses",
+        "_use_public_ip",
     )
 
     def __init__(self):
@@ -631,7 +631,7 @@ class _Config(object):
         self._creds_username = None
         self._creds_password = None
         self._token_provider = None
-        self._use_public_addresses = False
+        self._use_public_ip = False
 
     @property
     def cluster_members(self):
@@ -1338,17 +1338,17 @@ class _Config(object):
         self._token_provider = token_provider
 
     @property
-    def use_public_addresses(self):
+    def use_public_ip(self):
         # type: () -> bool
-        return self._use_public_addresses
+        return self._use_public_ip
 
-    @use_public_addresses.setter
-    def use_public_addresses(self, value):
+    @use_public_ip.setter
+    def use_public_ip(self, value):
         # type: (bool) -> None
         if isinstance(value, bool):
-            self._use_public_addresses = value
+            self._use_public_ip = value
         else:
-            raise TypeError("use_public_addresses must be a boolean")
+            raise TypeError("use_public_ip must be a boolean")
 
     @classmethod
     def from_dict(cls, d):

--- a/hazelcast/connection.py
+++ b/hazelcast/connection.py
@@ -154,8 +154,8 @@ class ConnectionManager(object):
         self._labels = frozenset(config.labels)
         self._cluster_id = None
         self._load_balancer = None
-        self._use_public_addresses = (
-            isinstance(address_provider, DefaultAddressProvider) and config.use_public_addresses
+        self._use_public_ip = (
+            isinstance(address_provider, DefaultAddressProvider) and config.use_public_ip
         )
 
     def add_listener(self, on_connection_opened=None, on_connection_closed=None):
@@ -372,7 +372,7 @@ class ConnectionManager(object):
         return translated
 
     def _translate_member_address(self, member):
-        if self._use_public_addresses:
+        if self._use_public_ip:
             public_address = member.address_map.get(_CLIENT_PUBLIC_ENDPOINT_QUALIFIER, None)
             if public_address:
                 return public_address

--- a/hazelcast/core.py
+++ b/hazelcast/core.py
@@ -10,7 +10,8 @@ SERIALIZATION_VERSION = 1
 
 class MemberInfo(object):
     """
-    Represents a member in the cluster with its address, uuid, lite member status, attributes and version.
+    Represents a member in the cluster with its address, uuid, lite member
+    status, attributes, version, and address map.
     """
 
     __slots__ = ("address", "uuid", "attributes", "lite_member", "version", "address_map")
@@ -112,8 +113,8 @@ class ProtocolType(object):
     A member typically responds to several types of protocols for
     member-to-member, client-member protocol, WAN communication etc. The
     default configuration uses a single server socket to listen for all kinds
-    of protocol types configured, Advanced Network Config of the server allows
-    configuration of multiple server sockets.
+    of protocol types configured, while Advanced Network Config of the server
+    allows configuration of multiple server sockets.
     """
 
     # We had to put dummy documentations for the constants

--- a/hazelcast/protocol/__init__.py
+++ b/hazelcast/protocol/__init__.py
@@ -45,13 +45,6 @@ class StackTraceElement(object):
         return not self.__eq__(other)
 
 
-class EndpointQualifier(object):
-    __slots__ = ()
-
-    def __init__(self, _, __):
-        pass
-
-
 class RaftGroupId(object):
     __slots__ = ("name", "seed", "id")
 

--- a/hazelcast/protocol/codec/custom/endpoint_qualifier_codec.py
+++ b/hazelcast/protocol/codec/custom/endpoint_qualifier_codec.py
@@ -1,7 +1,7 @@
 from hazelcast.protocol.builtin import FixSizedTypesCodec, CodecUtil
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import END_FRAME_BUF, END_FINAL_FRAME_BUF, SIZE_OF_FRAME_LENGTH_AND_FLAGS, create_initial_buffer_custom
-from hazelcast.protocol import EndpointQualifier
+from hazelcast.core import EndpointQualifier
 from hazelcast.protocol.builtin import StringCodec
 
 _TYPE_ENCODE_OFFSET = 2 * SIZE_OF_FRAME_LENGTH_AND_FLAGS

--- a/hazelcast/proxy/reliable_topic.py
+++ b/hazelcast/proxy/reliable_topic.py
@@ -240,7 +240,13 @@ class _MessageRunner(object):
                     member = None
                     if message.publisher_address:
                         member = MemberInfo(
-                            message.publisher_address, None, None, False, _UNKNOWN_MEMBER_VERSION
+                            message.publisher_address,
+                            None,
+                            None,
+                            False,
+                            _UNKNOWN_MEMBER_VERSION,
+                            None,
+                            {},
                         )
 
                     topic_message = TopicMessage(

--- a/hazelcast/proxy/reliable_topic.py
+++ b/hazelcast/proxy/reliable_topic.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 
 from hazelcast import six
 from hazelcast.config import _ReliableTopicConfig, TopicOverloadPolicy
-from hazelcast.core import MemberInfo, MemberVersion
+from hazelcast.core import MemberInfo, MemberVersion, EndpointQualifier, ProtocolType
 from hazelcast.errors import (
     OperationTimeoutError,
     IllegalArgumentError,
@@ -26,6 +26,7 @@ _MAX_BACKOFF = 2.0
 _RINGBUFFER_PREFIX = "_hz_rb_"
 
 _UNKNOWN_MEMBER_VERSION = MemberVersion(0, 0, 0)
+_MEMBER_ENDPOINT_QUALIFIER = EndpointQualifier(ProtocolType.MEMBER, None)
 
 _logger = logging.getLogger(__name__)
 
@@ -246,7 +247,9 @@ class _MessageRunner(object):
                             False,
                             _UNKNOWN_MEMBER_VERSION,
                             None,
-                            {},
+                            {
+                                _MEMBER_ENDPOINT_QUALIFIER: message.publisher_address,
+                            },
                         )
 
                     topic_message = TopicMessage(

--- a/tests/integration/connection_manager_translate_test.py
+++ b/tests/integration/connection_manager_translate_test.py
@@ -60,7 +60,6 @@ class ConnectionManagerTranslateTest(HazelcastTestCase):
         ):
             self.client = HazelcastClient(
                 cluster_name=self.cluster.id,
-                cluster_connect_timeout=1.0,
             )
             # If the translate is used for this, it would return
             # the unreachable address and the connection attempt
@@ -73,7 +72,6 @@ class ConnectionManagerTranslateTest(HazelcastTestCase):
     def test_translate_is_used_when_member_has_public_client_address(self):
         self.client = HazelcastClient(
             cluster_name=self.cluster.id,
-            cluster_connect_timeout=1.0,
             use_public_ip=True,
         )
 
@@ -97,7 +95,6 @@ class ConnectionManagerTranslateTest(HazelcastTestCase):
     ):
         self.client = HazelcastClient(
             cluster_name=self.cluster.id,
-            cluster_connect_timeout=1.0,
             connection_timeout=1.0,
             use_public_ip=False,
         )

--- a/tests/integration/connection_manager_translate_test.py
+++ b/tests/integration/connection_manager_translate_test.py
@@ -29,10 +29,10 @@ class ConnectionManagerTranslateTest(HazelcastTestCase):
         cls.rc.terminateCluster(cls.cluster.id)
         cls.rc.exit()
 
-    def setUp(self) -> None:
+    def setUp(self):
         self.client = None
 
-    def tearDown(self) -> None:
+    def tearDown(self):
         if self.client:
             self.client.shutdown()
 

--- a/tests/integration/connection_manager_translate_test.py
+++ b/tests/integration/connection_manager_translate_test.py
@@ -1,0 +1,137 @@
+import uuid
+
+from mock import patch
+
+from hazelcast import HazelcastClient
+from hazelcast.core import Address, MemberInfo, MemberVersion, EndpointQualifier, ProtocolType
+from hazelcast.errors import IllegalStateError, TargetDisconnectedError
+from tests.base import HazelcastTestCase
+
+_UNREACHABLE_ADDRESS = Address("192.168.0.1", 5701)
+_MEMBER_VERSION = MemberVersion(5, 0, 0)
+_CLIENT_PUBLIC_ENDPOINT_QUALIFIER = EndpointQualifier(ProtocolType.CLIENT, "public")
+
+
+class ConnectionManagerTranslateTest(HazelcastTestCase):
+
+    rc = None
+    cluster = None
+    member = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.rc = cls.create_rc()
+        cls.cluster = cls.create_cluster(cls.rc, None)
+        cls.member = cls.cluster.start_member()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.rc.terminateCluster(cls.cluster.id)
+        cls.rc.exit()
+
+    def setUp(self) -> None:
+        self.client = None
+
+    def tearDown(self) -> None:
+        if self.client:
+            self.client.shutdown()
+
+    def test_translate_is_used(self):
+        # It shouldn't be able to connect to cluster using unreachable
+        # public address.
+        with self.assertRaises(IllegalStateError):
+            with patch.object(
+                HazelcastClient,
+                "_create_address_provider",
+                return_value=TestAddressProvider(True, self.member.address),
+            ):
+                self.client = HazelcastClient(
+                    cluster_name=self.cluster.id,
+                    cluster_connect_timeout=1.0,
+                    connection_timeout=1.0,
+                )
+
+    def test_translate_is_not_used_when_getting_existing_connection(self):
+        provider = TestAddressProvider(False, self.member.address)
+        with patch.object(
+            HazelcastClient,
+            "_create_address_provider",
+            return_value=provider,
+        ):
+            self.client = HazelcastClient(
+                cluster_name=self.cluster.id,
+                cluster_connect_timeout=1.0,
+            )
+            # If the translate is used for this, it would return
+            # the unreachable address and the connection attempt
+            # would fail.
+            provider.should_translate = True
+            conn_manager = self.client._connection_manager
+            conn = conn_manager._get_or_connect_to_address(self.member.address).result()
+            self.assertIsNotNone(conn)
+
+    def test_translate_is_used_when_member_has_public_client_address(self):
+        self.client = HazelcastClient(
+            cluster_name=self.cluster.id,
+            cluster_connect_timeout=1.0,
+            use_public_addresses=True,
+        )
+
+        member = MemberInfo(
+            _UNREACHABLE_ADDRESS,
+            uuid.uuid4(),
+            [],
+            False,
+            _MEMBER_VERSION,
+            None,
+            {
+                _CLIENT_PUBLIC_ENDPOINT_QUALIFIER: self.member.address,
+            },
+        )
+        conn_manager = self.client._connection_manager
+        conn = conn_manager._get_or_connect_to_member(member).result()
+        self.assertIsNotNone(conn)
+
+    def test_translate_is_not_used_when_member_has_public_client_address_but_option_is_disabled(
+        self,
+    ):
+        self.client = HazelcastClient(
+            cluster_name=self.cluster.id,
+            cluster_connect_timeout=1.0,
+            connection_timeout=1.0,
+            use_public_addresses=False,
+        )
+
+        member = MemberInfo(
+            _UNREACHABLE_ADDRESS,
+            uuid.uuid4(),
+            [],
+            False,
+            _MEMBER_VERSION,
+            None,
+            {
+                _CLIENT_PUBLIC_ENDPOINT_QUALIFIER: self.member.address,
+            },
+        )
+        conn_manager = self.client._connection_manager
+
+        with self.assertRaises(TargetDisconnectedError):
+            conn_manager._get_or_connect_to_member(member).result()
+
+
+class TestAddressProvider(object):
+    def __init__(self, should_translate, member_address):
+        self.should_translate = should_translate
+        self.member_address = member_address
+
+    def load_addresses(self):
+        return [self.member_address], []
+
+    def translate(self, address):
+        if not self.should_translate:
+            return address
+
+        if address == self.member_address:
+            return _UNREACHABLE_ADDRESS
+
+        return None

--- a/tests/integration/connection_manager_translate_test.py
+++ b/tests/integration/connection_manager_translate_test.py
@@ -74,7 +74,7 @@ class ConnectionManagerTranslateTest(HazelcastTestCase):
         self.client = HazelcastClient(
             cluster_name=self.cluster.id,
             cluster_connect_timeout=1.0,
-            use_public_addresses=True,
+            use_public_ip=True,
         )
 
         member = MemberInfo(
@@ -99,7 +99,7 @@ class ConnectionManagerTranslateTest(HazelcastTestCase):
             cluster_name=self.cluster.id,
             cluster_connect_timeout=1.0,
             connection_timeout=1.0,
-            use_public_addresses=False,
+            use_public_ip=False,
         )
 
         member = MemberInfo(

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -846,15 +846,15 @@ class ConfigTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             cfg.token_provider = object()
 
-    def test_use_public_addresses(self):
+    def test_use_public_ip(self):
         config = self.config
-        self.assertFalse(config.use_public_addresses)
+        self.assertFalse(config.use_public_ip)
 
         with self.assertRaises(TypeError):
-            config.use_public_addresses = None
+            config.use_public_ip = None
 
-        config.use_public_addresses = True
-        self.assertTrue(config.use_public_addresses)
+        config.use_public_ip = True
+        self.assertTrue(config.use_public_ip)
 
 
 class IndexConfigTest(unittest.TestCase):

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -846,6 +846,16 @@ class ConfigTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             cfg.token_provider = object()
 
+    def test_use_public_addresses(self):
+        config = self.config
+        self.assertFalse(config.use_public_addresses)
+
+        with self.assertRaises(TypeError):
+            config.use_public_addresses = None
+
+        config.use_public_addresses = True
+        self.assertTrue(config.use_public_addresses)
+
 
 class IndexConfigTest(unittest.TestCase):
     def test_defaults(self):


### PR DESCRIPTION
This PR implements the client-side support for the external smart
client discovery. With this PR, the Python client will be able
to use public addresses reported by the cluster members even
if the client and the cluster are in different networks.

To use it, one has to enable `use_public_addresses` option by setting
it to `True`, and passing at least one public address of the cluster
members to the `cluster_members` config. Client will initiate the
cluster connection using the provided public address, and will
discover the rest of the cluster using the public addresses reported
by them.

Protocol PR: https://github.com/hazelcast/hazelcast-client-protocol/pull/394