### PR TITLE
Adjust test requirements based on Python version and OS

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
 thrift==0.13.0
 nose==1.3.7
 coverage==4.5.4
-psutil>=5.8.0
+psutil>=5.8.0; python_version != "3.4" or os_name != "nt"
 mock==3.0.5
 parameterized==0.7.4


### PR DESCRIPTION
This is a required change because the Python 3.4 on Windows cannot
install one of our dev dependencies. (psutil)

The reasoning is that, psutil does not push Python 3.4 wheel files
for Windows for a long time, and while trying to install the dependency
from the source code, Python 3.4 on Windows fails. I tried to upgrade
pip version on this setup to latest compatible version but that didn't
help.

Downgrading the psutil version is also not an option because as I said,
they are not publishing the wheels for 3.4 for a long time (couple of years).

What I did instead is to provide some requirement specifiers for psutil.
Basically, we would install it in any Python version other than 3.4 or
any OS other than `nt` (windows). Note that, lack of this dev dependency
simply means that we will not collect system & runtime related stats
in Python 3.4 tests on Windows, but we will still execute the whole
test suite. The statistics tests are written in a way that, if the
`psutil` is missing, we would not compare system & runtime stats.