### PR TITLE
[API-879] Wait for listener deregistration requests

### DIFF
--- a/hazelcast/listener.py
+++ b/hazelcast/listener.py
@@ -3,7 +3,6 @@ import sys
 import threading
 from uuid import uuid4
 
-import hazelcast.future
 from hazelcast import six
 from hazelcast.errors import HazelcastError, HazelcastClientNotActiveError, TargetDisconnectedError
 from hazelcast.future import combine_futures, ImmediateFuture
@@ -118,9 +117,10 @@ class ListenerService(object):
                         return
 
                     _logger.warning(
-                        "Deregistration of listener with ID %s has failed for address %s",
+                        "Deregistration of listener with ID %s has failed for address %s: %s",
                         user_registration_id,
                         captured_connection.remote_address,
+                        e,
                     )
 
                 invocation.future.add_done_callback(handler)

--- a/hazelcast/listener.py
+++ b/hazelcast/listener.py
@@ -3,6 +3,7 @@ import sys
 import threading
 from uuid import uuid4
 
+import hazelcast.future
 from hazelcast import six
 from hazelcast.errors import HazelcastError, HazelcastClientNotActiveError, TargetDisconnectedError
 from hazelcast.future import combine_futures, ImmediateFuture
@@ -86,6 +87,7 @@ class ListenerService(object):
             if not listener_registration:
                 return ImmediateFuture(False)
 
+            futures = []
             for connection, event_registration in six.iteritems(
                 listener_registration.connection_registrations
             ):
@@ -105,24 +107,27 @@ class ListenerService(object):
                 )
                 self._invocation_service.invoke(invocation)
 
-                def handler(f, connection=connection):
+                def handler(f, captured_connection=connection):
                     e = f.exception()
-                    if e:
-                        if isinstance(
-                            e, (HazelcastClientNotActiveError, IOError, TargetDisconnectedError)
-                        ):
-                            return
+                    if not e:
+                        return
 
-                        _logger.warning(
-                            "Deregistration of listener with ID %s has failed for address %s",
-                            user_registration_id,
-                            connection.remote_address,
-                        )
+                    if isinstance(
+                        e, (HazelcastClientNotActiveError, IOError, TargetDisconnectedError)
+                    ):
+                        return
+
+                    _logger.warning(
+                        "Deregistration of listener with ID %s has failed for address %s",
+                        user_registration_id,
+                        captured_connection.remote_address,
+                    )
 
                 invocation.future.add_done_callback(handler)
+                futures.append(invocation.future)
 
             listener_registration.connection_registrations.clear()
-            return ImmediateFuture(True)
+            return combine_futures(futures).continue_with(lambda _: True)
 
     def handle_client_message(self, message, correlation_id):
         handler = self._event_handlers.get(correlation_id, None)

--- a/hazelcast/util.py
+++ b/hazelcast/util.py
@@ -101,6 +101,16 @@ class AtomicInteger(object):
             self._counter += 1
             return res
 
+    def increment_and_get(self):
+        """Increments the current value and returns it.
+
+        Returns:
+            int: Incremented value of AtomicInteger.
+        """
+        with self._mux:
+            self._counter += 1
+            return self._counter
+
     def get(self):
         """Returns the current value.
 


### PR DESCRIPTION
With this PR, we will wait for all the listener deregistration
requests to finish before returning `True` to the user.

It is mainly a precaution to the possible problems that might result
in services that expect sync removal of listeners.

While doing that, I have also dived into one of our technical debts
and corrected the implementation of the `combine_futures`.

It now waits for all futures to complete in all scenarios, as it should be,
and sets the result to the first exceptional completion, if some of
the input futures complete as such.

Closes #448 