### PR TITLE
Fix re-registration logic of the ClusterViewListener

### DIFF
--- a/hazelcast/client.py
+++ b/hazelcast/client.py
@@ -393,6 +393,7 @@ class HazelcastClient(object):
             self._internal_partition_service,
             self._internal_cluster_service,
             self._invocation_service,
+            self._reactor,
         )
         self._shutdown_lock = threading.RLock()
         self._invocation_service.init(

--- a/hazelcast/client.py
+++ b/hazelcast/client.py
@@ -393,7 +393,6 @@ class HazelcastClient(object):
             self._internal_partition_service,
             self._internal_cluster_service,
             self._invocation_service,
-            self._reactor,
         )
         self._shutdown_lock = threading.RLock()
         self._invocation_service.init(

--- a/hazelcast/listener.py
+++ b/hazelcast/listener.py
@@ -199,14 +199,12 @@ class ClusterViewListenerService(object):
         partition_service,
         cluster_service,
         invocation_service,
-        reactor,
     ):
         self._client = client
         self._partition_service = partition_service
         self._connection_manager = connection_manager
         self._cluster_service = cluster_service
         self._invocation_service = invocation_service
-        self._reactor = reactor
         self._listener_added_connection = None
 
     def start(self):
@@ -247,17 +245,7 @@ class ClusterViewListenerService(object):
             try:
                 f.result()
             except:
-                # Schedule the next register attempt on the next
-                # iteration of the event loop. This is mainly an attempt
-                # to get rid of the possible StackOverflow errors
-                # due to immediately failing registration attempts.
-                # In case of such scenarios, the thread that does the
-                # registration attempt may execute this callback immediately
-                # and it can result in an infinite chain of registration attempts
-                # until the stack size goes over the limit.
-                self._reactor.add_timer(
-                    0, lambda: self._try_register_to_random_connection(connection)
-                )
+                self._try_register_to_random_connection(connection)
 
         invocation.future.add_done_callback(callback)
 

--- a/tests/integration/backward_compatible/proxy/cp/__init__.py
+++ b/tests/integration/backward_compatible/proxy/cp/__init__.py
@@ -5,6 +5,11 @@ from tests.base import HazelcastTestCase
 
 
 class CPTestCase(HazelcastTestCase):
+
+    rc = None
+    cluster = None
+    client = None
+
     @classmethod
     def setUpClass(cls):
         cls.rc = cls.create_rc()


### PR DESCRIPTION
There was a test failure due to StackOverflow error while trying
to re-register the cluster view listener.

The chain of events that caused the overflow are following:

- client.shutdown() is called
- we have a couple of connections
- while closing the connection manager, we close connections one-by-one
- we close the connection that the cluster view listener is registered to
- after closing this, we trigger a re-registration attempt and try to invoke
the listener registration in one of the remaining connections
- since the client is shutting down, the invocations are failed immediately
- while trying the add a callback to the invocation future, since it
is already done, we call the callback immediately
- that causes an infinite chain of registration attempts and leads the
StackOverflow error

There are two solutions to this problem. While either one of them would
resolve the issue, I decided to apply both to make this re-registration
logic more solid.

- The first solution is to not attempt to register a listener if the client
is about to shut down.

- The second solution is to schedule the next re-registration attempt in
the next iteration of the event loop, so that we would allow the thread
that calls shutdown to complete its work.

Closes #474 