### PR TITLE
Escape map names while creating mappings

### DIFF
--- a/tests/integration/backward_compatible/sql_test.py
+++ b/tests/integration/backward_compatible/sql_test.py
@@ -99,7 +99,7 @@ class SqlTestBase(HazelcastTestCase):
             return
 
         create_mapping_query = """
-        CREATE MAPPING %s (
+        CREATE MAPPING "%s" (
             __key INT,
             this %s
         )
@@ -123,7 +123,7 @@ class SqlTestBase(HazelcastTestCase):
             return
 
         create_mapping_query = """
-        CREATE MAPPING %s (
+        CREATE MAPPING "%s" (
             __key INT,
             %s
         )


### PR DESCRIPTION
The tests failed on nightly runners due to an error like this

```
ERROR: test_execute_with_params (tests.integration.backward_compatible.sql_test.SqlServiceTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\a\hazelcast-python-client\hazelcast-python-client\tests\integration\backward_compatible\sql_test.py", line 164, in test_execute_with_params
    self._create_mapping()
  File "D:\a\hazelcast-python-client\hazelcast-python-client\tests\integration\backward_compatible\sql_test.py", line 118, in _create_mapping
    result.update_count().result()
  File "D:\a\hazelcast-python-client\hazelcast-python-client\hazelcast\future.py", line 60, in result
    six.reraise(self._exception.__class__, self._exception, self._traceback)
  File "D:\a\hazelcast-python-client\hazelcast-python-client\hazelcast\six.py", line 714, in reraise
    raise value
  File "D:\a\hazelcast-python-client\hazelcast-python-client\hazelcast\future.py", line 147, in callback
    result = continuation_func(f, *args)
  File "D:\a\hazelcast-python-client\hazelcast-python-client\hazelcast\sql.py", line 956, in continuation
    response = future.result()
  File "D:\a\hazelcast-python-client\hazelcast-python-client\hazelcast\future.py", line 60, in result
    six.reraise(self._exception.__class__, self._exception, self._traceback)
  File "D:\a\hazelcast-python-client\hazelcast-python-client\hazelcast\six.py", line 714, in reraise
    raise value
hazelcast.sql.HazelcastSqlError: Encountered "NOT" at line 2, column 24.

Was expecting one of:

    "IF" ...

    <BRACKET_QUOTED_IDENTIFIER> ...

    <QUOTED_IDENTIFIER> ...

    <BACK_QUOTED_IDENTIFIER> ...

    <IDENTIFIER> ...

    <UNICODE_QUOTED_IDENTIFIER> ...
```

So, it seems that the un-escaped map name starts with `NOT` and it confuses
the parser.

This PR escapes those map names so that such a problem will not happen again.