### PR TITLE
Update SqlService API documentation

### DIFF
--- a/hazelcast/sql.py
+++ b/hazelcast/sql.py
@@ -29,7 +29,7 @@ class SqlService(object):
         and the ``hazelcast-sql`` module must be in the classpath of the
         members.
 
-        If you are using the our CLI, Docker image, or distributions to start
+        If you are using the CLI, Docker image, or distributions to start
         Hazelcast members, then you don't need to do anything, as the above
         preconditions are already satisfied for such members.
 


### PR DESCRIPTION
- Removed the warning about the BETA status
- Similar to Java client, simplified the API doc as most of the
things we mention here is already mentioned in the actual
SQL documentation
- Add a warning about enabling Jet and adding `hazelcast-sql`
to the member's classpath
- And other minor updates.