### PR TITLE
[API-900] Wait for the initial response in the SQL queries

### DIFF
--- a/docs/using_python_client_with_hazelcast_imdg.rst
+++ b/docs/using_python_client_with_hazelcast_imdg.rst
@@ -1563,7 +1563,7 @@ The following code prints names of the employees whose age is less than 30:
 
 .. code:: python
 
-    result = client.sql.execute("SELECT name FROM emp WHERE age < ?", 30)
+    result = client.sql.execute("SELECT name FROM emp WHERE age < ?", 30).result()
 
     for row in result:
         name = row.get_object("name")
@@ -1658,6 +1658,7 @@ it:
 .. code:: python
 
     client = hazelcast.HazelcastClient()
+    employees = client.get_map("employees").blocking()
 
     mapping_query = """
     CREATE MAPPING employees (
@@ -1671,17 +1672,14 @@ it:
     );
     """
 
-    with client.sql.execute(mapping_query) as result:
-        # wait until query completes
-        result.update_count().result()
+    client.sql.execute(mapping_query).result():
 
-    employees = client.get_map("employees").blocking()
     employees.set(1, HazelcastJsonValue({"name": "John Doe", "salary": 60000}))
     employees.set(2, HazelcastJsonValue({"name": "Jane Doe", "salary": 80000}))
 
     select_query = "SELECT name FROM employees WHERE salary > 75000"
 
-    with client.sql.execute(select_query) as result:
+    with client.sql.execute(select_query).result() as result:
         for row in result:
             name = row.get_object("name")
             # or, you can use the [] operator

--- a/docs/using_python_client_with_hazelcast_imdg.rst
+++ b/docs/using_python_client_with_hazelcast_imdg.rst
@@ -1672,7 +1672,7 @@ it:
     );
     """
 
-    client.sql.execute(mapping_query).result():
+    client.sql.execute(mapping_query).result()
 
     employees.set(1, HazelcastJsonValue({"name": "John Doe", "salary": 60000}))
     employees.set(2, HazelcastJsonValue({"name": "Jane Doe", "salary": 80000}))

--- a/examples/sql/sql_example.py
+++ b/examples/sql/sql_example.py
@@ -40,8 +40,27 @@ customers.set(1, Customer("Peter", 42, True))
 customers.set(2, Customer("John", 23, False))
 customers.set(3, Customer("Joe", 33, True))
 
+# Create mapping for the customers. This needs to be done only once per map.
+client.sql.execute(
+    """
+CREATE MAPPING customers (
+    __key INT,
+    name VARCHAR,
+    age INT,
+    is_active BOOLEAN
+)
+TYPE IMap
+OPTIONS (
+  'keyFormat' = 'int',
+  'valueFormat' = 'portable',
+  'valuePortableFactoryId' = '1',
+  'valuePortableClassId' = '1'
+)
+    """
+).result()
+
 # Project a single column that fits the criterion
-result = client.sql.execute("SELECT name FROM customers WHERE age < 35 AND is_active")
+result = client.sql.execute("SELECT name FROM customers WHERE age < 35 AND is_active").result()
 
 for row in result:
     # Get the object with the given column name in the row
@@ -52,7 +71,7 @@ for row in result:
 # Also, with statement can be used to close the resources on the
 # server-side if something goes bad while iterating over rows.
 
-with client.sql.execute("SELECT * FROM customers") as result:
+with client.sql.execute("SELECT * FROM customers").result() as result:
     for row in result:
         # Get the objects with column names
         name = row.get_object("name")
@@ -83,9 +102,9 @@ statement = SqlStatement("SELECT __key, age FROM customers WHERE name LIKE ?")
 statement.add_parameter("Jo%")
 statement.timeout = 5
 
-with client.sql.execute_statement(statement) as result:
+with client.sql.execute_statement(statement).result() as result:
     # Row metadata can also be retrieved from the result
-    row_metadata = result.get_row_metadata().result()
+    row_metadata = result.get_row_metadata()
 
     for row in result:
         key = row.get_object("__key")
@@ -100,7 +119,7 @@ with client.sql.execute_statement(statement) as result:
         print(key, age)
 
 # Parameters can be passed directly in the basic execution syntax
-result = client.sql.execute("SELECT this FROM customers WHERE age > ? AND age < ?", 30, 40)
+result = client.sql.execute("SELECT this FROM customers WHERE age > ? AND age < ?", 30, 40).result()
 
 for row in result:
     # Access columns with [] operator

--- a/hazelcast/sql.py
+++ b/hazelcast/sql.py
@@ -591,7 +591,7 @@ class _ExecuteResponse(object):
 
     __slots__ = ("row_metadata", "row_page", "update_count")
 
-    def __init__(self, row_metadata, row_page, update_count, error):
+    def __init__(self, row_metadata, row_page, update_count):
         self.row_metadata = row_metadata
         """SqlRowMetadata: Row metadata or None, if the response only 
         contains update count."""
@@ -1368,10 +1368,10 @@ class _InternalSqlService(object):
             # The result contains some rows, not an update count.
             row_metadata = SqlRowMetadata(row_metadata)
             # Set the update count to -1.
-            return _ExecuteResponse(row_metadata, response["row_page"], -1, None)
+            return _ExecuteResponse(row_metadata, response["row_page"], -1)
 
         # Result only contains the update count.
-        return _ExecuteResponse(None, None, response["update_count"], None)
+        return _ExecuteResponse(None, None, response["update_count"])
 
 
 class SqlExpectedResultType(object):

--- a/hazelcast/sql.py
+++ b/hazelcast/sql.py
@@ -67,7 +67,7 @@ class SqlService(object):
 
         client = hazelcast.HazelcastClient()
 
-        result = client.sql.execute("SELECT * FROM person")
+        result = client.sql.execute("SELECT * FROM person").result()
 
         for row in result:
             print(row.get_object("person_id"))
@@ -1142,7 +1142,7 @@ class SqlResult(object):
             otherwise.
         """
         return (
-            execute_response.row_page is None  # Just an update count
+            execute_response.row_metadata is None  # Just an update count
             or execute_response.row_page.is_last  # Single page result
         )
 

--- a/hazelcast/sql.py
+++ b/hazelcast/sql.py
@@ -891,7 +891,6 @@ class SqlResult(object):
         The iterator may be requested only once.
 
         Raises:
-            HazelcastSqlError: In case of an SQL execution error.
             ValueError: If the result only contains an update count, or the
                 iterator is already requested.
 
@@ -905,9 +904,6 @@ class SqlResult(object):
     def is_row_set(self):
         """Returns whether this result has rows to iterate.
 
-        Raises:
-            HazelcastSqlError: In case of an SQL execution error.
-
         Returns:
             bool:
         """
@@ -920,9 +916,6 @@ class SqlResult(object):
         result is a row set. In case the result doesn't contain rows but the
         update count isn't applicable or known, ``0`` is returned.
 
-        Raises:
-            HazelcastSqlError: In case of an SQL execution error.
-
         Returns:
             int:
         """
@@ -934,7 +927,6 @@ class SqlResult(object):
         """Gets the row metadata.
 
         Raises:
-            HazelcastSqlError: In case of an SQL execution error.
             ValueError: If the result only contains an update count.
 
         Returns:

--- a/tests/integration/backward_compatible/sql_test.py
+++ b/tests/integration/backward_compatible/sql_test.py
@@ -52,14 +52,14 @@ class SqlTestBase(HazelcastTestCase):
     rc = None
     cluster = None
     is_v5_or_newer_server = None
+    is_v5_or_newer_client = None
     client = None
 
     @classmethod
     def setUpClass(cls):
         cls.rc = cls.create_rc()
-
         cls.is_v5_or_newer_server = compare_server_version_with_rc(cls.rc, "5.0") >= 0
-
+        cls.is_v5_or_newer_client = compare_client_version("5.0") >= 0
         # enable Jet if the server is 5.0+
         cluster_config = SERVER_CONFIG % (JET_ENABLED_CONFIG if cls.is_v5_or_newer_server else "")
         cls.cluster = cls.create_cluster(cls.rc, cluster_config)
@@ -80,8 +80,7 @@ class SqlTestBase(HazelcastTestCase):
         self._setup_skip_condition()
 
         # Skip tests if major versions of the client/server do not match.
-        is_v5_or_newer_client = compare_client_version("5.0") >= 0
-        if is_v5_or_newer_client != self.is_v5_or_newer_server:
+        if self.is_v5_or_newer_client != self.is_v5_or_newer_server:
             self.skipTest("Major versions of the client and the server do not match.")
 
     def _setup_skip_condition(self):
@@ -115,8 +114,11 @@ class SqlTestBase(HazelcastTestCase):
             value_format.lower(),
         )
 
-        with self.client.sql.execute(create_mapping_query) as result:
-            result.update_count().result()
+        result = self.execute(create_mapping_query)
+        # We don't throw until a method over the result is called.
+        # We are calling update_count to verify that create mapping
+        # request succeeded.
+        self.update_count(result)
 
     def _create_mapping_for_portable(self, factory_id, class_id, columns):
         if not self.is_v5_or_newer_server:
@@ -143,8 +145,53 @@ class SqlTestBase(HazelcastTestCase):
             class_id,
         )
 
-        with self.client.sql.execute(create_mapping_query) as result:
-            result.update_count().result()
+        result = self.execute(create_mapping_query)
+        # We don't throw until a method over the result is called.
+        # We are calling update_count to verify that create mapping
+        # request succeeded.
+        self.update_count(result)
+
+    def execute(self, query, *args):
+        if self.is_v5_or_newer_client:
+            return self.client.sql.execute(query, *args).result()
+
+        # Compatibility with 4.x clients
+        return self.client.sql.execute(query, *args)
+
+    def execute_statement(self, statement):
+        if self.is_v5_or_newer_client:
+            return self.client.sql.execute_statement(statement).result()
+
+        # Compatibility with 4.x clients
+        return self.client.sql.execute_statement(statement)
+
+    def update_count(self, result):
+        if self.is_v5_or_newer_client:
+            return result.update_count()
+
+        # Compatibility with 4.x clients
+        return result.update_count().result()
+
+    def iterator(self, result):
+        if self.is_v5_or_newer_client:
+            return result.iterator()
+
+        # Compatibility with 4.x clients
+        return result.iterator().result()
+
+    def is_row_set(self, result):
+        if self.is_v5_or_newer_client:
+            return result.is_row_set()
+
+        # Compatibility with 4.x clients
+        return result.is_row_set().result()
+
+    def get_row_metadata(self, result):
+        if self.is_v5_or_newer_client:
+            return result.get_row_metadata()
+
+        # Compatibility with 4.x clients
+        return result.get_row_metadata().result()
 
 
 @unittest.skipIf(
@@ -155,7 +202,7 @@ class SqlServiceTest(SqlTestBase):
         self._create_mapping()
         entry_count = 11
         self._populate_map(entry_count)
-        result = self.client.sql.execute('SELECT * FROM "%s"' % self.map_name)
+        result = self.execute('SELECT * FROM "%s"' % self.map_name)
         six.assertCountEqual(
             self,
             [(i, i) for i in range(entry_count)],
@@ -166,7 +213,7 @@ class SqlServiceTest(SqlTestBase):
         self._create_mapping()
         entry_count = 13
         self._populate_map(entry_count)
-        result = self.client.sql.execute(
+        result = self.execute(
             'SELECT this FROM "%s" WHERE __key > ? AND this > ?' % self.map_name, 5, 6
         )
         six.assertCountEqual(
@@ -178,9 +225,7 @@ class SqlServiceTest(SqlTestBase):
     def test_execute_with_mismatched_params_when_sql_has_more(self):
         self._create_mapping()
         self._populate_map()
-        result = self.client.sql.execute(
-            'SELECT * FROM "%s" WHERE __key > ? AND this > ?' % self.map_name, 5
-        )
+        result = self.execute('SELECT * FROM "%s" WHERE __key > ? AND this > ?' % self.map_name, 5)
 
         with self.assertRaises(HazelcastSqlError):
             for _ in result:
@@ -189,7 +234,7 @@ class SqlServiceTest(SqlTestBase):
     def test_execute_with_mismatched_params_when_params_has_more(self):
         self._create_mapping()
         self._populate_map()
-        result = self.client.sql.execute('SELECT * FROM "%s" WHERE this > ?' % self.map_name, 5, 6)
+        result = self.execute('SELECT * FROM "%s" WHERE this > ?' % self.map_name, 5, 6)
 
         with self.assertRaises(HazelcastSqlError):
             for _ in result:
@@ -200,7 +245,7 @@ class SqlServiceTest(SqlTestBase):
         entry_count = 12
         self._populate_map(entry_count, str)
         statement = SqlStatement('SELECT this FROM "%s"' % self.map_name)
-        result = self.client.sql.execute_statement(statement)
+        result = self.execute_statement(statement)
 
         six.assertCountEqual(
             self,
@@ -216,7 +261,7 @@ class SqlServiceTest(SqlTestBase):
             'SELECT age FROM "%s" WHERE height = CAST(? AS REAL)' % self.map_name
         )
         statement.add_parameter(13.0)
-        result = self.client.sql.execute_statement(statement)
+        result = self.execute_statement(statement)
 
         six.assertCountEqual(self, [13], [row.get_object("age") for row in result])
 
@@ -225,7 +270,7 @@ class SqlServiceTest(SqlTestBase):
         self._populate_map()
         statement = SqlStatement('SELECT * FROM "%s" WHERE __key > ? AND this > ?' % self.map_name)
         statement.parameters = [5]
-        result = self.client.sql.execute_statement(statement)
+        result = self.execute_statement(statement)
 
         with self.assertRaises(HazelcastSqlError):
             for _ in result:
@@ -236,7 +281,7 @@ class SqlServiceTest(SqlTestBase):
         self._populate_map()
         statement = SqlStatement('SELECT * FROM "%s" WHERE this > ?' % self.map_name)
         statement.parameters = [5, 6]
-        result = self.client.sql.execute_statement(statement)
+        result = self.execute_statement(statement)
 
         with self.assertRaises(HazelcastSqlError):
             for _ in result:
@@ -248,7 +293,7 @@ class SqlServiceTest(SqlTestBase):
         self._populate_map(entry_count, lambda v: Student(v, v))
         statement = SqlStatement('SELECT age FROM "%s" WHERE height < 10' % self.map_name)
         statement.timeout = 100
-        result = self.client.sql.execute_statement(statement)
+        result = self.execute_statement(statement)
 
         six.assertCountEqual(
             self, [i for i in range(10)], [row.get_object("age") for row in result]
@@ -260,7 +305,7 @@ class SqlServiceTest(SqlTestBase):
         self._populate_map(entry_count, lambda v: Student(v, v))
         statement = SqlStatement('SELECT age FROM "%s"' % self.map_name)
         statement.cursor_buffer_size = 3
-        result = self.client.sql.execute_statement(statement)
+        result = self.execute_statement(statement)
 
         with patch.object(result, "_fetch_next_page", wraps=result._fetch_next_page) as patched:
             six.assertCountEqual(
@@ -279,10 +324,10 @@ class SqlServiceTest(SqlTestBase):
         copy_statement = statement.copy()
         statement.clear_parameters()
 
-        result = self.client.sql.execute_statement(copy_statement)
+        result = self.execute_statement(copy_statement)
         self.assertEqual([9], [row.get_object_with_index(0) for row in result])
 
-        result = self.client.sql.execute_statement(statement)
+        result = self.execute_statement(statement)
         with self.assertRaises(HazelcastSqlError):
             for _ in result:
                 pass
@@ -295,7 +340,7 @@ class SqlServiceTest(SqlTestBase):
         self._populate_map(entry_count, lambda v: Student(v, v))
         statement = SqlStatement('SELECT age FROM "%s" WHERE age < 3' % self.map_name)
         statement.expected_result_type = SqlExpectedResultType.ROWS
-        result = self.client.sql.execute_statement(statement)
+        result = self.execute_statement(statement)
 
         six.assertCountEqual(self, [i for i in range(3)], [row.get_object("age") for row in result])
 
@@ -308,7 +353,7 @@ class SqlServiceTest(SqlTestBase):
         self._populate_map()
         statement = SqlStatement('SELECT * FROM "%s"' % self.map_name)
         statement.expected_result_type = SqlExpectedResultType.UPDATE_COUNT
-        result = self.client.sql.execute_statement(statement)
+        result = self.execute_statement(statement)
 
         with self.assertRaises(HazelcastSqlError):
             for _ in result:
@@ -325,13 +370,13 @@ class SqlServiceTest(SqlTestBase):
         self.map.put(1, "value-1")
         select_all_query = 'SELECT * FROM "%s"' % self.map_name
         with self.assertRaises(HazelcastSqlError) as cm:
-            with self.client.sql.execute(select_all_query) as result:
-                result.update_count().result()
+            result = self.execute(select_all_query)
+            self.update_count(result)
 
-        with self.client.sql.execute(cm.exception.suggestion) as result:
-            result.update_count().result()
+        result = self.execute(cm.exception.suggestion)
+        self.update_count(result)
 
-        with self.client.sql.execute(select_all_query) as result:
+        with self.execute(select_all_query) as result:
             self.assertEqual(
                 [(1, "value-1")],
                 [(r.get_object("__key"), r.get_object("this")) for r in result],
@@ -345,7 +390,7 @@ class SqlResultTest(SqlTestBase):
     def test_blocking_iterator(self):
         self._create_mapping()
         self._populate_map()
-        result = self.client.sql.execute('SELECT __key FROM "%s"' % self.map_name)
+        result = self.execute('SELECT __key FROM "%s"' % self.map_name)
 
         six.assertCountEqual(
             self, [i for i in range(10)], [row.get_object_with_index(0) for row in result]
@@ -354,7 +399,7 @@ class SqlResultTest(SqlTestBase):
     def test_blocking_iterator_when_iterator_requested_more_than_once(self):
         self._create_mapping()
         self._populate_map()
-        result = self.client.sql.execute('SELECT this FROM "%s"' % self.map_name)
+        result = self.execute('SELECT this FROM "%s"' % self.map_name)
 
         six.assertCountEqual(
             self, [i for i in range(10)], [row.get_object_with_index(0) for row in result]
@@ -369,7 +414,7 @@ class SqlResultTest(SqlTestBase):
         self._populate_map()
         statement = SqlStatement('SELECT __key FROM "%s"' % self.map_name)
         statement.cursor_buffer_size = 1  # Each page will contain just 1 result
-        result = self.client.sql.execute_statement(statement)
+        result = self.execute_statement(statement)
 
         six.assertCountEqual(
             self, [i for i in range(10)], [row.get_object_with_index(0) for row in result]
@@ -378,26 +423,21 @@ class SqlResultTest(SqlTestBase):
     def test_iterator(self):
         self._create_mapping()
         self._populate_map()
-        result = self.client.sql.execute('SELECT __key FROM "%s"' % self.map_name)
+        result = self.execute('SELECT __key FROM "%s"' % self.map_name)
 
-        iterator_future = result.iterator()
+        iterator = self.iterator(result)
 
         rows = []
 
-        def cb(f):
-            iterator = f.result()
+        def iterate(row_future):
+            try:
+                row = row_future.result()
+                rows.append(row.get_object_with_index(0))
+                next(iterator).add_done_callback(iterate)
+            except StopIteration:
+                pass
 
-            def iterate(row_future):
-                try:
-                    row = row_future.result()
-                    rows.append(row.get_object_with_index(0))
-                    next(iterator).add_done_callback(iterate)
-                except StopIteration:
-                    pass
-
-            next(iterator).add_done_callback(iterate)
-
-        iterator_future.add_done_callback(cb)
+        next(iterator).add_done_callback(iterate)
 
         def assertion():
             six.assertCountEqual(
@@ -411,9 +451,9 @@ class SqlResultTest(SqlTestBase):
     def test_iterator_when_iterator_requested_more_than_once(self):
         self._create_mapping()
         self._populate_map()
-        result = self.client.sql.execute('SELECT this FROM "%s"' % self.map_name)
+        result = self.execute('SELECT this FROM "%s"' % self.map_name)
 
-        iterator = result.iterator().result()
+        iterator = self.iterator(result)
 
         rows = []
         for row_future in iterator:
@@ -426,16 +466,16 @@ class SqlResultTest(SqlTestBase):
         six.assertCountEqual(self, [i for i in range(10)], rows)
 
         with self.assertRaises(ValueError):
-            result.iterator().result()
+            self.iterator(result)
 
     def test_iterator_with_multi_paged_result(self):
         self._create_mapping()
         self._populate_map()
         statement = SqlStatement('SELECT __key FROM "%s"' % self.map_name)
         statement.cursor_buffer_size = 1  # Each page will contain just 1 result
-        result = self.client.sql.execute_statement(statement)
+        result = self.execute_statement(statement)
 
-        iterator = result.iterator().result()
+        iterator = self.iterator(result)
 
         rows = []
         for row_future in iterator:
@@ -450,9 +490,9 @@ class SqlResultTest(SqlTestBase):
     def test_request_blocking_iterator_after_iterator(self):
         self._create_mapping()
         self._populate_map()
-        result = self.client.sql.execute('SELECT * FROM "%s"' % self.map_name)
+        result = self.execute('SELECT * FROM "%s"' % self.map_name)
 
-        result.iterator().result()
+        self.iterator(result)
 
         with self.assertRaises(ValueError):
             for _ in result:
@@ -461,35 +501,35 @@ class SqlResultTest(SqlTestBase):
     def test_request_iterator_after_blocking_iterator(self):
         self._create_mapping()
         self._populate_map()
-        result = self.client.sql.execute('SELECT * FROM "%s"' % self.map_name)
+        result = self.execute('SELECT * FROM "%s"' % self.map_name)
 
         for _ in result:
             pass
 
         with self.assertRaises(ValueError):
-            result.iterator().result()
+            self.iterator(result)
 
     # Can't test the case we would expect row to be not set, because the IMDG SQL
     # engine does not support update/insert queries now.
     def test_is_row_set_when_row_is_set(self):
         self._create_mapping()
         self._populate_map()
-        result = self.client.sql.execute('SELECT * FROM "%s"' % self.map_name)
-        self.assertTrue(result.is_row_set().result())
+        result = self.execute('SELECT * FROM "%s"' % self.map_name)
+        self.assertTrue(self.is_row_set(result))
 
     # Can't test the case we would expect a non-negative updated count, because the IMDG SQL
     # engine does not support update/insert queries now.
     def test_update_count_when_there_is_no_update(self):
         self._create_mapping()
         self._populate_map()
-        result = self.client.sql.execute('SELECT * FROM "%s" WHERE __key > 5' % self.map_name)
-        self.assertEqual(-1, result.update_count().result())
+        result = self.execute('SELECT * FROM "%s" WHERE __key > 5' % self.map_name)
+        self.assertEqual(-1, self.update_count(result))
 
     def test_get_row_metadata(self):
         self._create_mapping("VARCHAR")
         self._populate_map(value_factory=str)
-        result = self.client.sql.execute('SELECT __key, this FROM "%s"' % self.map_name)
-        row_metadata = result.get_row_metadata().result()
+        result = self.execute('SELECT __key, this FROM "%s"' % self.map_name)
+        row_metadata = self.get_row_metadata(result)
         self.assertEqual(2, row_metadata.column_count)
         columns = row_metadata.columns
         self.assertEqual(SqlColumnType.INTEGER, columns[0].type)
@@ -500,9 +540,10 @@ class SqlResultTest(SqlTestBase):
     def test_close_after_query_execution(self):
         self._create_mapping()
         self._populate_map()
-        result = self.client.sql.execute('SELECT * FROM "%s"' % self.map_name)
+        result = self.execute('SELECT * FROM "%s"' % self.map_name)
         for _ in result:
             pass
+
         self.assertIsNone(result.close().result())
 
     def test_close_when_query_is_active(self):
@@ -510,7 +551,7 @@ class SqlResultTest(SqlTestBase):
         self._populate_map()
         statement = SqlStatement('SELECT * FROM "%s"' % self.map_name)
         statement.cursor_buffer_size = 1  # Each page will contain 1 row
-        result = self.client.sql.execute_statement(statement)
+        result = self.execute_statement(statement)
 
         # Fetch couple of pages
         iterator = iter(result)
@@ -525,7 +566,7 @@ class SqlResultTest(SqlTestBase):
     def test_with_statement(self):
         self._create_mapping()
         self._populate_map()
-        with self.client.sql.execute('SELECT this FROM "%s"' % self.map_name) as result:
+        with self.execute('SELECT this FROM "%s"' % self.map_name) as result:
             six.assertCountEqual(
                 self, [i for i in range(10)], [row.get_object_with_index(0) for row in result]
             )
@@ -537,7 +578,7 @@ class SqlResultTest(SqlTestBase):
         statement.cursor_buffer_size = 1  # so that it doesn't close immediately
 
         with self.assertRaises(RuntimeError):
-            with self.client.sql.execute_statement(statement) as result:
+            with self.execute_statement(statement) as result:
                 for _ in result:
                     raise RuntimeError("expected")
 
@@ -560,7 +601,7 @@ class SqlResultTest(SqlTestBase):
         res = self.rc.executeOnController(self.cluster.id, script, Lang.JAVASCRIPT)
         self.assertTrue(res.success)
 
-        with self.client.sql.execute('SELECT __key, this FROM "%s"' % self.map_name) as result:
+        with self.execute('SELECT __key, this FROM "%s"' % self.map_name) as result:
             rows = list(result)
             self.assertEqual(1, len(rows))
             row = rows[0]
@@ -737,7 +778,7 @@ class SqlColumnTypesReadTest(SqlTestBase):
     def test_null(self):
         self._create_mapping("INTEGER")
         self._populate_map()
-        result = self.client.sql.execute('SELECT __key, NULL AS this FROM "%s"' % self.map_name)
+        result = self.execute('SELECT __key, NULL AS this FROM "%s"' % self.map_name)
         self._validate_result(result, SqlColumnType.NULL, lambda _: None)
 
     def test_object(self):
@@ -746,19 +787,19 @@ class SqlColumnTypesReadTest(SqlTestBase):
 
         self._create_mapping_for_portable(666, 6, {"age": "BIGINT", "height": "REAL"})
         self._populate_map(value_factory=value_factory)
-        result = self.client.sql.execute('SELECT __key, this FROM "%s"' % self.map_name)
+        result = self.execute('SELECT __key, this FROM "%s"' % self.map_name)
         self._validate_result(result, SqlColumnType.OBJECT, value_factory)
 
     def test_null_only_column(self):
         self._create_mapping("INTEGER")
         self._populate_map()
-        result = self.client.sql.execute(
+        result = self.execute(
             'SELECT __key, CAST(NULL AS INTEGER) as this FROM "%s"' % self.map_name
         )
         self._validate_result(result, SqlColumnType.INTEGER, lambda _: None)
 
     def _validate_rows(self, expected_type, value_factory=lambda key: key):
-        result = self.client.sql.execute('SELECT __key, this FROM "%s"' % self.map_name)
+        result = self.execute('SELECT __key, this FROM "%s"' % self.map_name)
         self._validate_result(result, expected_type, value_factory)
 
     def _validate_result(self, result, expected_type, factory):
@@ -850,8 +891,8 @@ class SqlServiceV5LiteMemberClusterTest(SingleMemberTestCase):
 
     def test_execute(self):
         with self.assertRaises(HazelcastSqlError) as cm:
-            with self.client.sql.execute("SOME QUERY") as result:
-                result.update_count().result()
+            with self.client.sql.execute("SOME QUERY").result() as result:
+                result.update_count()
 
         # Make sure that exception is originating from the server
         self.assertEqual(self.member.uuid, str(cm.exception.originating_member_uuid))
@@ -859,8 +900,8 @@ class SqlServiceV5LiteMemberClusterTest(SingleMemberTestCase):
     def test_execute_statement(self):
         statement = SqlStatement("SOME QUERY")
         with self.assertRaises(HazelcastSqlError) as cm:
-            with self.client.sql.execute_statement(statement) as result:
-                result.update_count().result()
+            with self.client.sql.execute_statement(statement).result() as result:
+                result.update_count()
 
         # Make sure that exception is originating from the server
         self.assertEqual(self.member.uuid, str(cm.exception.originating_member_uuid))
@@ -922,12 +963,15 @@ class SqlServiceV5MixedClusterTest(HazelcastTestCase):
             % map_name
         )
 
-        with self.client.sql.execute(create_mapping_query) as result:
-            result.update_count().result()
+        result = self.client.sql.execute(create_mapping_query).result()
+        # We don't throw until a method over the result is called.
+        # We are calling update_count to verify that create mapping
+        # request succeeded.
+        result.update_count()
 
         m = self.client.get_map(map_name).blocking()
         m.put(1, 1)
-        with self.client.sql.execute("SELECT this FROM %s" % map_name) as result:
+        with self.client.sql.execute("SELECT this FROM %s" % map_name).result() as result:
             rows = [row.get_object("this") for row in result]
 
         self.assertEqual(1, len(rows))
@@ -942,7 +986,7 @@ class JetSqlTest(SqlTestBase):
         skip_if_server_version_older_than(self, self.client, "5.0")
 
     def test_streaming_sql_query(self):
-        with self.client.sql.execute("SELECT * FROM TABLE(generate_stream(100))") as result:
+        with self.execute("SELECT * FROM TABLE(generate_stream(100))") as result:
             for idx, row in enumerate(result):
                 self.assertEqual(idx, row.get_object("v"))
                 if idx == 200:
@@ -965,8 +1009,11 @@ class JetSqlTest(SqlTestBase):
             % self.map_name
         )
 
-        with self.client.sql.execute(query) as result:
-            self.assertEqual(0, result.update_count().result())
+        result = self.execute(query)
+        # We don't throw until a method over the result is called.
+        # We are calling update_count to verify that create mapping
+        # request succeeded.
+        self.update_count(result)
 
         insert_into_query = (
             """
@@ -976,8 +1023,8 @@ class JetSqlTest(SqlTestBase):
             % self.map_name
         )
 
-        with self.client.sql.execute(insert_into_query) as result:
-            self.assertEqual(0, result.update_count().result())
+        with self.execute(insert_into_query) as result:
+            self.assertEqual(0, self.update_count(result))
 
         self.assertEqual(1, self.map.size())
         entry = self.map.get(1)

--- a/tests/integration/backward_compatible/sql_test.py
+++ b/tests/integration/backward_compatible/sql_test.py
@@ -617,7 +617,7 @@ class SqlResultTest(SqlTestBase):
         self._populate_map(entry_count, value_factory)
 
         expected = [(i, value_factory(i)) for i in range(entry_count)]
-        with self.client.sql.execute('SELECT __key, this FROM "%s"' % self.map_name) as result:
+        with self.execute('SELECT __key, this FROM "%s"' % self.map_name) as result:
             # Verify that both row[integer] and row[string] works
             six.assertCountEqual(self, expected, [(row[0], row["this"]) for row in result])
 

--- a/tests/integration/backward_compatible/sql_test.py
+++ b/tests/integration/backward_compatible/sql_test.py
@@ -114,11 +114,7 @@ class SqlTestBase(HazelcastTestCase):
             value_format.lower(),
         )
 
-        result = self.execute(create_mapping_query)
-        # We don't throw until a method over the result is called.
-        # We are calling update_count to verify that create mapping
-        # request succeeded.
-        self.update_count(result)
+        self.execute(create_mapping_query)
 
     def _create_mapping_for_portable(self, factory_id, class_id, columns):
         if not self.is_v5_or_newer_server:
@@ -145,11 +141,7 @@ class SqlTestBase(HazelcastTestCase):
             class_id,
         )
 
-        result = self.execute(create_mapping_query)
-        # We don't throw until a method over the result is called.
-        # We are calling update_count to verify that create mapping
-        # request succeeded.
-        self.update_count(result)
+        self.execute(create_mapping_query)
 
     def execute(self, query, *args):
         if self.is_v5_or_newer_client:
@@ -225,18 +217,20 @@ class SqlServiceTest(SqlTestBase):
     def test_execute_with_mismatched_params_when_sql_has_more(self):
         self._create_mapping()
         self._populate_map()
-        result = self.execute('SELECT * FROM "%s" WHERE __key > ? AND this > ?' % self.map_name, 5)
 
         with self.assertRaises(HazelcastSqlError):
+            result = self.execute(
+                'SELECT * FROM "%s" WHERE __key > ? AND this > ?' % self.map_name, 5
+            )
             for _ in result:
                 pass
 
     def test_execute_with_mismatched_params_when_params_has_more(self):
         self._create_mapping()
         self._populate_map()
-        result = self.execute('SELECT * FROM "%s" WHERE this > ?' % self.map_name, 5, 6)
 
         with self.assertRaises(HazelcastSqlError):
+            result = self.execute('SELECT * FROM "%s" WHERE this > ?' % self.map_name, 5, 6)
             for _ in result:
                 pass
 
@@ -270,9 +264,9 @@ class SqlServiceTest(SqlTestBase):
         self._populate_map()
         statement = SqlStatement('SELECT * FROM "%s" WHERE __key > ? AND this > ?' % self.map_name)
         statement.parameters = [5]
-        result = self.execute_statement(statement)
 
         with self.assertRaises(HazelcastSqlError):
+            result = self.execute_statement(statement)
             for _ in result:
                 pass
 
@@ -281,9 +275,9 @@ class SqlServiceTest(SqlTestBase):
         self._populate_map()
         statement = SqlStatement('SELECT * FROM "%s" WHERE this > ?' % self.map_name)
         statement.parameters = [5, 6]
-        result = self.execute_statement(statement)
 
         with self.assertRaises(HazelcastSqlError):
+            result = self.execute_statement(statement)
             for _ in result:
                 pass
 
@@ -327,8 +321,8 @@ class SqlServiceTest(SqlTestBase):
         result = self.execute_statement(copy_statement)
         self.assertEqual([9], [row.get_object_with_index(0) for row in result])
 
-        result = self.execute_statement(statement)
         with self.assertRaises(HazelcastSqlError):
+            result = self.execute_statement(statement)
             for _ in result:
                 pass
 
@@ -353,9 +347,9 @@ class SqlServiceTest(SqlTestBase):
         self._populate_map()
         statement = SqlStatement('SELECT * FROM "%s"' % self.map_name)
         statement.expected_result_type = SqlExpectedResultType.UPDATE_COUNT
-        result = self.execute_statement(statement)
 
         with self.assertRaises(HazelcastSqlError):
+            result = self.execute_statement(statement)
             for _ in result:
                 pass
 
@@ -370,11 +364,9 @@ class SqlServiceTest(SqlTestBase):
         self.map.put(1, "value-1")
         select_all_query = 'SELECT * FROM "%s"' % self.map_name
         with self.assertRaises(HazelcastSqlError) as cm:
-            result = self.execute(select_all_query)
-            self.update_count(result)
+            self.execute(select_all_query)
 
-        result = self.execute(cm.exception.suggestion)
-        self.update_count(result)
+        self.execute(cm.exception.suggestion)
 
         with self.execute(select_all_query) as result:
             self.assertEqual(
@@ -963,11 +955,7 @@ class SqlServiceV5MixedClusterTest(HazelcastTestCase):
             % map_name
         )
 
-        result = self.client.sql.execute(create_mapping_query).result()
-        # We don't throw until a method over the result is called.
-        # We are calling update_count to verify that create mapping
-        # request succeeded.
-        result.update_count()
+        self.client.sql.execute(create_mapping_query).result()
 
         m = self.client.get_map(map_name).blocking()
         m.put(1, 1)
@@ -1009,11 +997,7 @@ class JetSqlTest(SqlTestBase):
             % self.map_name
         )
 
-        result = self.execute(query)
-        # We don't throw until a method over the result is called.
-        # We are calling update_count to verify that create mapping
-        # request succeeded.
-        self.update_count(result)
+        self.execute(query)
 
         insert_into_query = (
             """

--- a/tests/unit/sql_test.py
+++ b/tests/unit/sql_test.py
@@ -101,9 +101,9 @@ class SqlMockTest(unittest.TestCase):
 
     def test_execute_error(self):
         self.set_execute_error(RuntimeError("expected"))
-        result = self.result.result()
 
         with self.assertRaises(HazelcastSqlError) as cm:
+            result = self.result.result()
             iter(result)
 
         self.assertEqual(_SqlErrorCode.GENERIC, cm.exception._code)
@@ -111,9 +111,9 @@ class SqlMockTest(unittest.TestCase):
     def test_execute_error_when_connection_is_not_live(self):
         self.connection.live = False
         self.set_execute_error(RuntimeError("expected"))
-        result = self.result.result()
 
         with self.assertRaises(HazelcastSqlError) as cm:
+            result = self.result.result()
             iter(result)
 
         self.assertEqual(_SqlErrorCode.CONNECTION_PROBLEM, cm.exception._code)
@@ -129,13 +129,6 @@ class SqlMockTest(unittest.TestCase):
             future.result()
 
         self.assertEqual(_SqlErrorCode.PARSING, cm.exception._code)
-
-    def test_close_when_execute_fails(self):
-        self.set_execute_error(RuntimeError("expected"))
-        result = self.result.result()
-
-        future = result.close()
-        self.assertIsInstance(future, ImmediateFuture)
 
     def test_fetch_error(self):
         self.set_execute_response_with_rows(is_last=False)


### PR DESCRIPTION
Up until now, we were returning the `SqlResult` immediately after
initiating the query to the server, without waiting for the first
response.

The server might not be able to handle some consequences of such
an API. To align the behavior with the Java implementation and
make it more intuitive, we now wait for the initial response
in the `execute` and `execute_statement` methods.

With that change, the return types are changed from `SqlResult` to
`Future[SqlResult]`. Also, I got rid of the Futures in the return types
of the methods over the `SqlResult` except for the `close`, as the
`close` might in fact go to the server.

With this change, I cleaned up the implementation so that it reflects
the new behavior better.

Also, we now return a rejected Future immediately if the first execute
the request fails.