### PR TITLE
Reduce test duration for the integration tests

### DIFF
--- a/tests/integration/backward_compatible/client_test.py
+++ b/tests/integration/backward_compatible/client_test.py
@@ -10,7 +10,7 @@ from tests.util import get_current_timestamp
 class ClientTest(HazelcastTestCase):
     def test_client_only_listens(self):
         rc = self.create_rc()
-        client_heartbeat_seconds = 8
+        client_heartbeat_seconds = 4
 
         cluster_config = (
             """

--- a/tests/integration/backward_compatible/heartbeat_test.py
+++ b/tests/integration/backward_compatible/heartbeat_test.py
@@ -17,7 +17,9 @@ class HeartbeatTest(HazelcastTestCase):
         self.cluster = self.create_cluster(self.rc)
         self.member = self.rc.startMember(self.cluster.id)
         self.client = HazelcastClient(
-            cluster_name=self.cluster.id, heartbeat_interval=0.5, heartbeat_timeout=2
+            cluster_name=self.cluster.id,
+            heartbeat_interval=0.5,
+            heartbeat_timeout=2,
         )
 
     def tearDown(self):

--- a/tests/integration/backward_compatible/listener_test.py
+++ b/tests/integration/backward_compatible/listener_test.py
@@ -1,3 +1,5 @@
+from parameterized import parameterized
+
 from tests.base import HazelcastTestCase
 from tests.util import (
     random_string,
@@ -6,8 +8,19 @@ from tests.util import (
     wait_for_partition_table,
 )
 
+LISTENER_TYPES = [
+    (
+        "smart",
+        True,
+    ),
+    (
+        "non-smart",
+        False,
+    ),
+]
 
-class ListenerTest(HazelcastTestCase):
+
+class ListenerRemoveMemberTest(HazelcastTestCase):
     def setUp(self):
         self.rc = self.create_rc()
         self.cluster = self.create_cluster(self.rc, None)
@@ -15,71 +28,57 @@ class ListenerTest(HazelcastTestCase):
         self.m2 = self.cluster.start_member()
         self.client_config = {
             "cluster_name": self.cluster.id,
+            "heartbeat_interval": 1.0,
         }
         self.collector = event_collector()
 
     def tearDown(self):
         self.shutdown_all_clients()
+        self.rc.terminateCluster(self.cluster.id)
         self.rc.exit()
 
-    # -------------------------- test_remove_member ----------------------- #
-    def test_smart_listener_remove_member(self):
-        self.client_config["smart_routing"] = True
+    @parameterized.expand(LISTENER_TYPES)
+    def test_remove_member(self, _, is_smart):
+        self.client_config["smart_routing"] = is_smart
         client = self.create_client(self.client_config)
         wait_for_partition_table(client)
         key_m1 = generate_key_owned_by_instance(client, self.m1.uuid)
-        map = client.get_map(random_string()).blocking()
-        map.put(key_m1, "value1")
-        map.add_entry_listener(updated_func=self.collector)
+        random_map = client.get_map(random_string()).blocking()
+        random_map.add_entry_listener(added_func=self.collector)
         self.m1.shutdown()
-        map.put(key_m1, "value2")
+        random_map.put(key_m1, "value2")
 
         def assert_event():
             self.assertEqual(1, len(self.collector.events))
 
         self.assertTrueEventually(assert_event)
 
-    def test_non_smart_listener_remove_member(self):
-        self.client_config["smart_routing"] = False
+
+class ListenerAddMemberTest(HazelcastTestCase):
+    def setUp(self):
+        self.rc = self.create_rc()
+        self.cluster = self.create_cluster(self.rc, None)
+        self.m1 = self.cluster.start_member()
+        self.client_config = {
+            "cluster_name": self.cluster.id,
+        }
+        self.collector = event_collector()
+
+    def tearDown(self):
+        self.shutdown_all_clients()
+        self.rc.terminateCluster(self.cluster.id)
+        self.rc.exit()
+
+    @parameterized.expand(LISTENER_TYPES)
+    def test_add_member(self, _, is_smart):
+        self.client_config["smart_routing"] = is_smart
         client = self.create_client(self.client_config)
-        map = client.get_map(random_string()).blocking()
-        map.add_entry_listener(added_func=self.collector)
-        self.m2.shutdown()
+        random_map = client.get_map(random_string()).blocking()
+        random_map.add_entry_listener(added_func=self.collector)
+        m2 = self.cluster.start_member()
         wait_for_partition_table(client)
-
-        generated_key = generate_key_owned_by_instance(client, self.m1.uuid)
-        map.put(generated_key, "value")
-
-        def assert_event():
-            self.assertEqual(1, len(self.collector.events))
-
-        self.assertTrueEventually(assert_event)
-
-    # -------------------------- test_add_member ----------------------- #
-    def test_smart_listener_add_member(self):
-        self.client_config["smart_routing"] = True
-        client = self.create_client(self.client_config)
-        map = client.get_map(random_string()).blocking()
-        map.add_entry_listener(added_func=self.collector)
-        m3 = self.cluster.start_member()
-        wait_for_partition_table(client)
-        key_m3 = generate_key_owned_by_instance(client, m3.uuid)
-        map.put(key_m3, "value")
-
-        def assert_event():
-            self.assertEqual(1, len(self.collector.events))
-
-        self.assertTrueEventually(assert_event)
-
-    def test_non_smart_listener_add_member(self):
-        self.client_config["smart_routing"] = False
-        client = self.create_client(self.client_config)
-        map = client.get_map(random_string()).blocking()
-        map.add_entry_listener(added_func=self.collector)
-        m3 = self.cluster.start_member()
-        wait_for_partition_table(client)
-        key_m3 = generate_key_owned_by_instance(client, m3.uuid)
-        map.put(key_m3, "value")
+        key_m2 = generate_key_owned_by_instance(client, m2.uuid)
+        random_map.put(key_m2, "value")
 
         def assert_event():
             self.assertEqual(1, len(self.collector.events))

--- a/tests/integration/backward_compatible/smart_listener_test.py
+++ b/tests/integration/backward_compatible/smart_listener_test.py
@@ -4,16 +4,20 @@ from time import sleep
 
 
 class SmartListenerTest(HazelcastTestCase):
+
+    rc = None
+    cluster = None
+
     @classmethod
     def setUpClass(cls):
         cls.rc = cls.create_rc()
         cls.cluster = cls.create_cluster(cls.rc, None)
-        cls.m1 = cls.cluster.start_member()
-        cls.m2 = cls.cluster.start_member()
-        cls.m3 = cls.cluster.start_member()
+        cls.cluster.start_member()
+        cls.cluster.start_member()
 
     @classmethod
     def tearDownClass(cls):
+        cls.rc.terminateCluster(cls.cluster.id)
         cls.rc.exit()
 
     def setUp(self):
@@ -28,52 +32,48 @@ class SmartListenerTest(HazelcastTestCase):
     def tearDown(self):
         self.shutdown_all_clients()
 
-    # -------------------------- test_local_only ----------------------- #
     def test_list_smart_listener_local_only(self):
         list = self.client.get_list(random_string()).blocking()
         list.add_listener(item_added_func=self.collector)
         list.add("item-value")
-        sleep(5)
-        self.assertEqual(1, len(self.collector.events))
+        self.assert_event_received_once()
 
     def test_map_smart_listener_local_only(self):
         map = self.client.get_map(random_string()).blocking()
         map.add_entry_listener(added_func=self.collector)
         map.put("key", "value")
-        sleep(5)
-        self.assertEqual(1, len(self.collector.events))
+        self.assert_event_received_once()
 
     def test_multimap_smart_listener_local_only(self):
         multimap = self.client.get_map(random_string()).blocking()
         multimap.add_entry_listener(added_func=self.collector)
         multimap.put("key", "value")
-        sleep(5)
-        self.assertEqual(1, len(self.collector.events))
+        self.assert_event_received_once()
 
     def test_queue_smart_listener_local_only(self):
         queue = self.client.get_queue(random_string()).blocking()
         queue.add_listener(item_added_func=self.collector)
         queue.add("item-value")
-        sleep(5)
-        self.assertEqual(1, len(self.collector.events))
+        self.assert_event_received_once()
 
     def test_replicated_map_smart_listener_local_only(self):
         replicated_map = self.client.get_replicated_map(random_string()).blocking()
         replicated_map.add_entry_listener(added_func=self.collector)
         replicated_map.put("key", "value")
-        sleep(5)
-        self.assertEqual(1, len(self.collector.events))
+        self.assert_event_received_once()
 
     def test_set_smart_listener_local_only(self):
         set = self.client.get_set(random_string()).blocking()
         set.add_listener(item_added_func=self.collector)
         set.add("item-value")
-        sleep(5)
-        self.assertEqual(1, len(self.collector.events))
+        self.assert_event_received_once()
 
     def test_topic_smart_listener_local_only(self):
         topic = self.client.get_topic(random_string()).blocking()
         topic.add_listener(on_message=self.collector)
         topic.publish("item-value")
-        sleep(5)
+        self.assert_event_received_once()
+
+    def assert_event_received_once(self):
+        sleep(2)
         self.assertEqual(1, len(self.collector.events))


### PR DESCRIPTION
There were some tests that are taking too much time to run. Most
of the time, we either create too many members or sleep too much
while waiting on some assertions.

This is a PR to tackle with that. I went over the long running
tests and either shorten the duration of the waits (of course without
breaking the test) or reduced the number of members we create without
changing the behavior of the tests.