### PR TITLE
Apply membership events only if the memberlist version is greater than the current version

### DIFF
--- a/hazelcast/cluster.py
+++ b/hazelcast/cluster.py
@@ -220,7 +220,7 @@ class _InternalClusterService(object):
             )
 
         current = self._member_list_snapshot
-        if version >= current.version:
+        if version > current.version:
             self._apply_new_state_and_fire_events(current, snapshot)
 
         if current is _EMPTY_SNAPSHOT:


### PR DESCRIPTION
We couldn't find a reason to apply membership events with the
same memberlist version while evaluating this part of the code
base in the Java client.

Here, we are doing the same and making the check more strict

Closes #485 