### PR TITLE
Remove leftover `usage` section

### DIFF
--- a/hazelcast/sql.py
+++ b/hazelcast/sql.py
@@ -57,8 +57,6 @@ class SqlService(object):
     Before you can access any object using SQL, a *mapping* has to be created.
     See the documentation for the ``CREATE MAPPING`` command.
 
-    **Usage**
-
     When a query is executed, an :class:`SqlResult` is returned. You may get
     row iterator from the result. The result must be closed at the end. The
     iterator will close the result automatically when it is exhausted given


### PR DESCRIPTION
There was a duplicate `usage` section that we forgot to delete.
This PR removes that.