### PR TITLE
Backport important fixes to 4.2.z

### DIFF
--- a/.github/workflows/test_runner.yml
+++ b/.github/workflows/test_runner.yml
@@ -80,4 +80,4 @@ jobs:
       - name: Generate documentation
         working-directory: docs
         run: |
-          make html SPHINXOPTS="-W --keep-going"
+          make html SPHINXOPTS="-W --keep-going -b linkcheck"

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Hazelcast Python Client
 
 ----
 
-`Hazelcast <https://hazelcast.org/>`__ is an open-source distributed
+`Hazelcast <https://hazelcast.com/>`__ is an open-source distributed
 in-memory data store and computation platform that provides a wide
 variety of distributed data structures and concurrency primitives.
 
@@ -52,7 +52,7 @@ images <https://hub.docker.com/r/hazelcast/hazelcast/>`__.
    docker run -p 5701:5701 hazelcast/hazelcast:4.2
 
 You can also use our ZIP or TAR
-`distributions <https://hazelcast.org/imdg/download/archives/#hazelcast-imdg>`__.
+`distributions <https://hazelcast.com/open-source-projects/downloads/>`__.
 Once you have downloaded, you can start the Hazelcast member using
 the ``bin/start.sh`` script.
 
@@ -149,7 +149,7 @@ Features
 -  Ability to listen to client lifecycle, cluster state, and distributed
    data structure events
 -  and `many
-   more <https://hazelcast.org/imdg/clients-languages/python/#client-features>`__
+   more <https://hazelcast.com/clients/python/#client-features>`__
 
 Getting Help
 ------------
@@ -235,5 +235,5 @@ Copyright
 
 Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
 
-Visit `www.hazelcast.com <http://www.hazelcast.com>`__ for more
+Visit `hazelcast.com <https://hazelcast.com>`__ for more
 information.

--- a/docs/copyright.rst
+++ b/docs/copyright.rst
@@ -3,5 +3,5 @@ Copyright
 
 Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
 
-Visit `www.hazelcast.com <http://www.hazelcast.com>`__ for more
+Visit `hazelcast.com <https://hazelcast.com>`__ for more
 information.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -57,7 +57,8 @@ Running Standalone JARs
 
 Follow the instructions below to create a Hazelcast IMDG cluster:
 
-1. Go to Hazelcast’s download `page <https://hazelcast.org/download/>`__
+1. Go to Hazelcast’s download `page
+   <https://hazelcast.com/open-source-projects/downloads/>`__
    and download either the ``.zip`` or ``.tar`` distribution of
    Hazelcast IMDG.
 2. Decompress the contents into any directory that you want to run
@@ -127,7 +128,7 @@ If you want to add a ``Portable`` class, you should use
 the above configuration.
 
 See the `Hazelcast IMDG Reference
-Manual <http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#getting-started>`__
+Manual <https://docs.hazelcast.com/imdg/latest/installation/installing-upgrading>`__
 for more information on setting up the clusters.
 
 Downloading and Installing
@@ -170,7 +171,7 @@ that can be used in the Python client are discussed in the following
 sections.
 
 See the `Hazelcast IMDG Reference
-Manual <https://docs.hazelcast.org/docs/latest/manual/html-single/index.html>`__
+Manual <https://docs.hazelcast.com/imdg/latest/>`__
 and :ref:`configuration_overview:configuration overview` section for
 more information.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,7 @@ Hazelcast Python Client
 
 ----
 
-`Hazelcast <https://hazelcast.org/>`__ is an open-source distributed
+`Hazelcast <https://hazelcast.com/>`__ is an open-source distributed
 in-memory data store and computation platform that provides a wide
 variety of distributed data structures and concurrency primitives.
 

--- a/docs/securing_client_connection.rst
+++ b/docs/securing_client_connection.rst
@@ -33,7 +33,7 @@ TLS/SSL for Hazelcast Members
 Hazelcast allows you to encrypt socket level communication between
 Hazelcast members and between Hazelcast clients and members, for end to
 end encryption. To use it, see the `TLS/SSL for Hazelcast Members
-section <http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#tls-ssl-for-hazelcast-members>`__.
+section <https://docs.hazelcast.com/imdg/latest/security/tls-ssl#tlsssl-for-hazelcast-members>`__.
 
 TLS/SSL for Hazelcast Python Clients
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -252,7 +252,7 @@ property on the server side in the ``hazelcast.xml`` file:
 
 You can see the details of setting mutual authentication on the server
 side in the `Mutual Authentication
-section <https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#mutual-authentication>`__
+section <https://docs.hazelcast.com/imdg/latest/security/tls-ssl#mutual-authentication>`__
 of the Hazelcast IMDG Reference Manual.
 
 On the client side, you have to provide ``ssl_cafile``, ``ssl_certfile``

--- a/docs/using_python_client_with_hazelcast_imdg.rst
+++ b/docs/using_python_client_with_hazelcast_imdg.rst
@@ -163,7 +163,7 @@ Using Map
 Hazelcast Map is a distributed dictionary. Through the Python client,
 you can perform operations like reading and writing from/to a Hazelcast
 Map with the well known get and put methods. For details, see the `Map
-section <https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#map>`__
+section <https://docs.hazelcast.com/imdg/latest/data-structures/map>`__
 in the Hazelcast IMDG Reference Manual.
 
 A Map usage example is shown below.
@@ -186,7 +186,7 @@ Using MultiMap
 
 Hazelcast MultiMap is a distributed and specialized map where you can
 store multiple values under a single key. For details, see the `MultiMap
-section <https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#multimap>`__
+section <https://docs.hazelcast.com/imdg/latest/data-structures/multimap>`__
 in the Hazelcast IMDG Reference Manual.
 
 A MultiMap usage example is shown below.
@@ -216,7 +216,7 @@ Hazelcast Replicated Map is a distributed key-value data structure where
 the data is replicated to all members in the cluster. It provides full
 replication of entries to all members for high speed access. For
 details, see the `Replicated Map
-section <https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#replicated-map>`__
+section <https://docs.hazelcast.com/imdg/latest/data-structures/replicated-map>`__
 in the Hazelcast IMDG Reference Manual.
 
 A Replicated Map usage example is shown below.
@@ -243,7 +243,7 @@ Using Queue
 
 Hazelcast Queue is a distributed queue which enables all cluster members
 to interact with it. For details, see the `Queue
-section <https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#queue>`__
+section <https://docs.hazelcast.com/imdg/latest/data-structures/queue>`__
 in the Hazelcast IMDG Reference Manual.
 
 A Queue usage example is shown below.
@@ -273,7 +273,7 @@ Using Set
 
 Hazelcast Set is a distributed set which does not allow duplicate
 elements. For details, see the `Set
-section <https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#set>`__
+section <https://docs.hazelcast.com/imdg/latest/data-structures/set>`__
 in the Hazelcast IMDG Reference Manual.
 
 A Set usage example is shown below.
@@ -300,7 +300,7 @@ Using List
 
 Hazelcast List is a distributed list which allows duplicate elements and
 preserves the order of elements. For details, see the `List
-section <https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#list>`__
+section <https://docs.hazelcast.com/imdg/latest/data-structures/list>`__
 in the Hazelcast IMDG Reference Manual.
 
 A List usage example is shown below.
@@ -334,7 +334,7 @@ items are overwritten or expired. You can reach each element in a
 Ringbuffer using a sequence ID, which is mapped to the elements between
 the head and tail (inclusive) of the Ringbuffer. For details, see the
 `Ringbuffer
-section <https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#ringbuffer>`__
+section <https://docs.hazelcast.com/imdg/latest/data-structures/ringbuffer>`__
 in the Hazelcast IMDG Reference Manual.
 
 A Ringbuffer usage example is shown below.
@@ -410,7 +410,7 @@ Using Topic
 
 Hazelcast Topic is a distribution mechanism for publishing messages that
 are delivered to multiple subscribers. For details, see the `Topic
-section <https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#topic>`__
+section <https://docs.hazelcast.com/imdg/latest/data-structures/topic>`__
 in the Hazelcast IMDG Reference Manual.
 
 A Topic usage example is shown below.
@@ -444,7 +444,7 @@ begin, commit and rollback a transaction. You can obtain
 transaction-aware instances of queues, maps, sets, lists and multimaps
 via the ``Transaction`` object, work with them and commit or rollback in
 one shot. For details, see the `Transactions
-section <https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#transactions>`__
+section <https://docs.hazelcast.com/imdg/latest/transactions/transactions>`__
 in the Hazelcast IMDG Reference Manual.
 
 .. code:: python
@@ -521,7 +521,7 @@ Hazelcast ``PNCounter`` (Positive-Negative Counter) is a CRDT
 positive-negative counter implementation. It is an eventually consistent
 counter given there is no member failure. For details, see the `PN
 Counter
-section <https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#pn-counter>`__
+section <https://docs.hazelcast.com/imdg/latest/data-structures/pn-counter>`__
 in the Hazelcast IMDG Reference Manual.
 
 A PN Counter usage example is shown below.
@@ -551,7 +551,7 @@ Hazelcast ``FlakeIdGenerator`` is used to generate cluster-wide unique
 identifiers. Generated identifiers are long primitive values and are
 k-ordered (roughly ordered). IDs are in the range from ``0`` to ``2^63-1``
 (maximum signed long value). For details, see the `FlakeIdGenerator
-section <https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#flakeidgenerator>`__
+section <https://docs.hazelcast.com/imdg/latest/data-structures/flake-id-generator>`__
 in the Hazelcast IMDG Reference Manual.
 
 .. code:: python
@@ -611,7 +611,7 @@ All data structures within CP Subsystem are available through
 
 Before using Atomic Long, Lock, and Semaphore, CP Subsystem has to be
 enabled on cluster-side. Refer to `CP
-Subsystem <https://docs.hazelcast.org/docs/latest/manual/html-single/#cp-subsystem>`__
+Subsystem <https://docs.hazelcast.com/imdg/latest/cp-subsystem/cp-subsystem>`__
 documentation for more information.
 
 Data structures in CP Subsystem run in CP groups. Each CP group elects
@@ -659,7 +659,7 @@ execution semantics. It goes with at-least-once execution semantics by
 default and can cause an API call to be committed multiple times in case
 of CP member failures. It can be tuned to offer at-most-once execution
 semantics. Please see
-`fail-on-indeterminate-operation-state <https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#cp-subsystem-configuration>`__
+`fail-on-indeterminate-operation-state <https://docs.hazelcast.com/imdg/latest/cp-subsystem/configuration>`__
 server-side setting.
 
 Using Lock
@@ -689,7 +689,7 @@ A basic Lock usage example is shown below.
 
 FencedLock works on top of CP sessions. It keeps a CP session open while
 the lock is acquired. Please refer to `CP
-Session <https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#cp-sessions>`__
+Session <https://docs.hazelcast.com/imdg/latest/cp-subsystem/sessions>`__
 documentation for more information.
 
 By default, FencedLock is reentrant. Once a caller acquires the lock, it
@@ -737,7 +737,7 @@ After that, once Client-1 comes back alive, its write request will be
 rejected by the external service, and only Client-2 will be able to
 safely talk to it.
 
-.. figure:: https://docs.hazelcast.org/docs/latest/manual/html-single/images/FencedLock.png
+.. figure:: https://docs.hazelcast.com/imdg/latest/_images/FencedLock.png
    :alt: CP Fenced Lock diagram
 
    CP Fenced Lock diagram
@@ -824,7 +824,7 @@ Semaphore data structure has two variations:
   they will not be automatically released. You can use the sessionless
   CP Semaphore implementation by enabling JDK compatibility
   ``jdk-compatible`` server-side setting. Refer to `Semaphore
-  configuration <https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#semaphore-configuration>`__
+  configuration <https://docs.hazelcast.com/imdg/latest/cp-subsystem/configuration>`__
   documentation for more details.
 
 Using CountDownLatch
@@ -927,7 +927,7 @@ semantics. It goes with at-least-once execution semantics by default and
 can cause an API call to be committed multiple times in case of CP
 member failures. It can be tuned to offer at-most-once execution
 semantics. Please see
-`fail-on-indeterminate-operation-state <https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#cp-subsystem-configuration>`__
+`fail-on-indeterminate-operation-state <https://docs.hazelcast.com/imdg/latest/cp-subsystem/configuration>`__
 server-side setting.
 
 Distributed Events
@@ -1330,7 +1330,7 @@ The code that runs on the entries is implemented in Java on the server
 side. The client side entry processor is used to specify which entry
 processor should be called. For more details about the Java
 implementation of the entry processor, see the `Entry Processor
-section <https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#entry-processor>`__
+section <https://docs.hazelcast.com/imdg/latest/computing/entry-processor>`__
 in the Hazelcast IMDG Reference Manual.
 
 After the above implementations and configuration are done and you start
@@ -2347,7 +2347,7 @@ Near Cache Invalidation
 Invalidation is the process of removing an entry from the Near Cache
 when its value is updated or it is removed from the original map (to
 prevent stale reads). See the `Near Cache Invalidation
-section <https://docs.hazelcast.org/docs/latest/manual/html-single/#near-cache-invalidation>`__
+section <https://docs.hazelcast.com/imdg/latest/performance/near-cache#near-cache-invalidation>`__
 in the Hazelcast IMDG Reference Manual.
 
 Monitoring and Logging
@@ -2409,7 +2409,7 @@ client as follows:
 
 After enabling the client statistics, you can monitor your clients using
 Hazelcast Management Center. Please refer to the `Monitoring Clients
-section <https://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#monitoring-clients>`__
+section <https://docs.hazelcast.com/management-center/latest/monitor-imdg/monitor-clients>`__
 in the Hazelcast Management Center Reference Manual for more information
 on the client statistics.
 
@@ -2519,7 +2519,7 @@ connections.
 You can also group your clients using the client labels. These client
 groups can be blacklisted in Hazelcast Management Center so that they
 can be prevented from connecting to a cluster. See the `related
-section <https://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#changing-cluster-client-filtering>`__
+section <https://docs.hazelcast.com/management-center/latest/monitor-imdg/client-filtering>`__
 in the Hazelcast Management Center Reference Manual for more information
 on this topic.
 

--- a/hazelcast/core.py
+++ b/hazelcast/core.py
@@ -308,7 +308,6 @@ class HazelcastJsonValue(object):
     JSON strings.
 
     HazelcastJsonValue is queried using Hazelcast's querying language.
-    See `Distributed Query section <https://github.com/hazelcast/hazelcast-python-client#77-distributed-query>`_.
 
     In terms of querying, numbers in JSON strings are treated as either
     Long or Double in the Java side. str, bool and None

--- a/hazelcast/util.py
+++ b/hazelcast/util.py
@@ -411,7 +411,7 @@ else:
         if buffer[0] & 0x80:
             neg = bytearray()
             for c in buffer:
-                neg.append(~c)
+                neg.append(c ^ 0xFF)
             return -1 * int(binascii.hexlify(neg), 16) - 1
         return int(binascii.hexlify(buffer), 16)
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -27,6 +27,8 @@ if __name__ == "__main__":
             rc_process = start_rc(rc_stdout, rc_stderr)
             try:
                 wait_until_rc_is_ready()
+                sys.stdout.flush()
+
                 args = [
                     __file__,
                     "-v",
@@ -36,6 +38,7 @@ if __name__ == "__main__":
                     "--cover-package=hazelcast",
                     "--cover-inclusive",
                     "--nologcapture",
+                    "--traverse-namespace",
                     "tests",
                 ]
 


### PR DESCRIPTION
This is combined PR to backport some important changes that would
apply to 4.2.z. Mainly it fixes

- broken links
- test runners on Windows
- wrong `int_from_bytes` calculation