### PR TITLE
Add v5 maintenance branches to branch filter

### DIFF
--- a/.github/workflows/test_runner.yml
+++ b/.github/workflows/test_runner.yml
@@ -3,11 +3,11 @@ on:
   push:
     branches:
       - master
-      - 4.*.z
+      - '[45].*.z'
   pull_request:
     branches:
       - master
-      - 4.*.z
+      - '[45].*.z'
 jobs:
   run-tests:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
We want to run tests on `5.*.z` branches as well, so the branch
filter is changed accordingly to accept `5.*.z` and `4.*.z`.