### PR TITLE
Improve the client version filtering in `ClientTcpMetricsTest`

### DIFF
--- a/tests/integration/backward_compatible/client_test.py
+++ b/tests/integration/backward_compatible/client_test.py
@@ -114,7 +114,9 @@ class ClientLabelsTest(HazelcastTestCase):
 
 
 @unittest.skipIf(
-    compare_client_version("5.1") < 0, "Tests the features added in 5.1 version of the client"
+    compare_client_version("4.2.2") < 0 or compare_client_version("5.0") == 0,
+    "Tests the features added in 5.1 version of the client, "
+    "which are backported into 4.2.2 and 5.0.1",
 )
 class ClientTcpMetricsTest(SingleMemberTestCase):
     @classmethod


### PR DESCRIPTION
The features tested in `ClientTcpMetricsTest` are backported into
`4.2.2` and `5.0.1` as well. So, we want to include this test
in their backward compatibility tests.

To do so, the filter is changed so that it will skip tests when
the client version is older than `4.2.2` or equal to `5.0`, which
skips the client versions that do not have such feature.