### PR TITLE
Unpack the values correctly in SQL tests

### DIFF
--- a/tests/integration/backward_compatible/sql_test.py
+++ b/tests/integration/backward_compatible/sql_test.py
@@ -166,7 +166,7 @@ class SqlTestBase(HazelcastTestCase):
         for arg in args:
             statement.add_parameter(arg)
 
-        for key, value in kwargs:
+        for key, value in kwargs.items():
             setattr(statement, key, value)
 
         return self.client.sql.execute_statement(statement)


### PR DESCRIPTION
We use different methods to `execute_statement` due to API changes
between the major client versions. While unpacking the keyword args,
we were not using the correct iterator. Now, that is fixed, and we
use `.items()` to iterate over keyword args.