### PR TITLE
Remove useless object inheritance

### DIFF
--- a/benchmarks/codec_bench.py
+++ b/benchmarks/codec_bench.py
@@ -6,7 +6,7 @@ from hazelcast.serialization import SerializationServiceV1, calculate_size_data
 from hazelcast.config import  SerializationConfig
 
 
-class Bench(object):
+class Bench:
     def __init__(self):
         self.service = SerializationServiceV1(SerializationConfig())
         key = "Test" * 1000

--- a/benchmarks/map_async_bench.py
+++ b/benchmarks/map_async_bench.py
@@ -42,7 +42,7 @@ def do_benchmark():
 
     client = hazelcast.HazelcastClient(config)
 
-    class Test(object):
+    class Test:
 
         def __init__(self):
             self.ops = 0

--- a/examples/org-website/custom_serializer_sample.py
+++ b/examples/org-website/custom_serializer_sample.py
@@ -3,7 +3,7 @@ import hazelcast
 from hazelcast.serialization.api import StreamSerializer
 
 
-class CustomSerializableType(object):
+class CustomSerializableType:
     def __init__(self, value=None):
         self.value = value
 

--- a/examples/serialization/custom_serialization_example.py
+++ b/examples/serialization/custom_serialization_example.py
@@ -3,7 +3,7 @@ import hazelcast
 from hazelcast.serialization.api import StreamSerializer
 
 
-class TimeOfDay(object):
+class TimeOfDay:
     def __init__(self, hour, minute, second):
         self.hour = hour
         self.minute = minute

--- a/examples/serialization/global_serialization_example.py
+++ b/examples/serialization/global_serialization_example.py
@@ -5,7 +5,7 @@ import hazelcast
 from hazelcast.serialization.api import StreamSerializer
 
 
-class ColorGroup(object):
+class ColorGroup:
     def __init__(self, id, name, colors):
         self.id = id
         self.name = name

--- a/hazelcast/aggregator.py
+++ b/hazelcast/aggregator.py
@@ -4,7 +4,7 @@ from hazelcast.serialization.api import IdentifiedDataSerializable
 _AGGREGATORS_FACTORY_ID = -29
 
 
-class Aggregator(object):
+class Aggregator:
     """Marker base class for all aggregators.
 
     Aggregators allow computing a value of some function (e.g sum or max) over

--- a/hazelcast/client.py
+++ b/hazelcast/client.py
@@ -46,7 +46,7 @@ __all__ = ("HazelcastClient",)
 _logger = logging.getLogger(__name__)
 
 
-class HazelcastClient(object):
+class HazelcastClient:
     """Hazelcast client instance to access and manipulate
     distributed data structures on the Hazelcast clusters.
 
@@ -197,7 +197,7 @@ class HazelcastClient(object):
 
             .. code-block:: python
 
-                class SomeClass(object):
+                class SomeClass:
                     # omitting the implementation
                     pass
 
@@ -752,7 +752,7 @@ class HazelcastClient(object):
         return load_balancer
 
 
-class _ClientContext(object):
+class _ClientContext:
     """
     Context holding all the required services, managers and the configuration for a Hazelcast client.
     """

--- a/hazelcast/cluster.py
+++ b/hazelcast/cluster.py
@@ -10,7 +10,7 @@ from hazelcast.util import check_not_none
 _logger = logging.getLogger(__name__)
 
 
-class _MemberListSnapshot(object):
+class _MemberListSnapshot:
     __slots__ = ("version", "members")
 
     def __init__(self, version, members):
@@ -18,7 +18,7 @@ class _MemberListSnapshot(object):
         self.members = members
 
 
-class ClientInfo(object):
+class ClientInfo:
     """Local information of the client.
 
     Attributes:
@@ -51,7 +51,7 @@ _CLIENT_ENDPOINT_QUALIFIER = EndpointQualifier(ProtocolType.CLIENT, None)
 _MEMBER_ENDPOINT_QUALIFIER = EndpointQualifier(ProtocolType.MEMBER, None)
 
 
-class ClusterService(object):
+class ClusterService:
     """
     Cluster service for Hazelcast clients.
 
@@ -109,7 +109,7 @@ class ClusterService(object):
         return self._service.get_members(member_selector)
 
 
-class _InternalClusterService(object):
+class _InternalClusterService:
     def __init__(self, client, config):
         self._client = client
         self._connection_manager = None
@@ -303,7 +303,7 @@ class _InternalClusterService(object):
         return _MemberListSnapshot(version, new_members)
 
 
-class VectorClock(object):
+class VectorClock:
     """Vector clock consisting of distinct replica logical clocks.
 
     The vector clock may be read from different thread but concurrent

--- a/hazelcast/config.py
+++ b/hazelcast/config.py
@@ -14,7 +14,7 @@ from hazelcast.util import (
 )
 
 
-class IntType(object):
+class IntType:
     """Integer type options that can be used by serialization service."""
 
     VAR = 0
@@ -54,7 +54,7 @@ class IntType(object):
     """
 
 
-class EvictionPolicy(object):
+class EvictionPolicy:
     """Near Cache eviction policy options."""
 
     NONE = 0
@@ -78,7 +78,7 @@ class EvictionPolicy(object):
     """
 
 
-class InMemoryFormat(object):
+class InMemoryFormat:
     """Near Cache in memory format of the values."""
 
     BINARY = 0
@@ -92,7 +92,7 @@ class InMemoryFormat(object):
     """
 
 
-class SSLProtocol(object):
+class SSLProtocol:
     """SSL protocol options.
 
     TLSv1_3 requires at least Python 3.7 build with OpenSSL 1.1.1+
@@ -129,7 +129,7 @@ class SSLProtocol(object):
     """
 
 
-class QueryConstants(object):
+class QueryConstants:
     """Contains constants for Query."""
 
     KEY_ATTRIBUTE_NAME = "__key"
@@ -143,7 +143,7 @@ class QueryConstants(object):
     """
 
 
-class UniqueKeyTransformation(object):
+class UniqueKeyTransformation:
     """Defines an assortment of transformations which can be applied to unique key values."""
 
     OBJECT = 0
@@ -166,7 +166,7 @@ class UniqueKeyTransformation(object):
     """
 
 
-class IndexType(object):
+class IndexType:
     """Type of the index."""
 
     SORTED = 0
@@ -185,7 +185,7 @@ class IndexType(object):
     """
 
 
-class ReconnectMode(object):
+class ReconnectMode:
     """Reconnect options."""
 
     OFF = 0
@@ -204,7 +204,7 @@ class ReconnectMode(object):
     """
 
 
-class TopicOverloadPolicy(object):
+class TopicOverloadPolicy:
     """A policy to deal with an overloaded topic; a topic where there is no
     place to store new messages.
 
@@ -250,7 +250,7 @@ class TopicOverloadPolicy(object):
     """The publish call immediately fails."""
 
 
-class BitmapIndexOptions(object):
+class BitmapIndexOptions:
     __slots__ = ("_unique_key", "_unique_key_transformation")
 
     def __init__(self, unique_key=None, unique_key_transformation=None):
@@ -297,7 +297,7 @@ class BitmapIndexOptions(object):
         )
 
 
-class IndexConfig(object):
+class IndexConfig:
     __slots__ = ("_name", "_type", "_attributes", "_bitmap_index_options")
 
     def __init__(self, name=None, type=None, attributes=None, bitmap_index_options=None):
@@ -389,7 +389,7 @@ class IndexConfig(object):
         )
 
 
-class IndexUtil(object):
+class IndexUtil:
     _MAX_ATTRIBUTES = 255
     """Maximum number of attributes allowed in the index."""
 
@@ -521,7 +521,7 @@ _DEFAULT_STATISTICS_PERIOD = 3.0
 _DEFAULT_OPERATION_BACKUP_TIMEOUT = 5.0
 
 
-class _Config(object):
+class _Config:
     __slots__ = (
         "_cluster_members",
         "_cluster_name",
@@ -1360,7 +1360,7 @@ class _Config(object):
         return config
 
 
-class _NearCacheConfig(object):
+class _NearCacheConfig:
     __slots__ = (
         "_invalidate_on_change",
         "_in_memory_format",
@@ -1487,7 +1487,7 @@ class _NearCacheConfig(object):
         return config
 
 
-class _FlakeIdGeneratorConfig(object):
+class _FlakeIdGeneratorConfig:
     __slots__ = ("_prefetch_count", "_prefetch_validity")
 
     def __init__(self):
@@ -1533,7 +1533,7 @@ class _FlakeIdGeneratorConfig(object):
         return config
 
 
-class _ReliableTopicConfig(object):
+class _ReliableTopicConfig:
     __slots__ = ("_read_batch_size", "_overload_policy")
 
     def __init__(self):

--- a/hazelcast/connection.py
+++ b/hazelcast/connection.py
@@ -52,7 +52,7 @@ _SQL_CONNECTION_RANDOM_ATTEMPTS = 10
 _CLIENT_PUBLIC_ENDPOINT_QUALIFIER = EndpointQualifier(ProtocolType.CLIENT, "public")
 
 
-class _WaitStrategy(object):
+class _WaitStrategy:
     def __init__(self, initial_backoff, max_backoff, multiplier, cluster_connect_timeout, jitter):
         self._initial_backoff = initial_backoff
         self._max_backoff = max_backoff
@@ -103,14 +103,14 @@ class _WaitStrategy(object):
         return True
 
 
-class _AuthenticationStatus(object):
+class _AuthenticationStatus:
     AUTHENTICATED = 0
     CREDENTIALS_FAILED = 1
     SERIALIZATION_VERSION_MISMATCH = 2
     NOT_ALLOWED_IN_CLUSTER = 3
 
 
-class ConnectionManager(object):
+class ConnectionManager:
     """ConnectionManager is responsible for managing ``Connection`` objects."""
 
     def __init__(
@@ -700,7 +700,7 @@ class ConnectionManager(object):
         return addresses
 
 
-class _HeartbeatManager(object):
+class _HeartbeatManager:
     _heartbeat_timer = None
 
     def __init__(self, connection_manager, client, config, reactor, invocation_service):
@@ -752,7 +752,7 @@ class _HeartbeatManager(object):
 _frame_header = struct.Struct("<iH")
 
 
-class _Reader(object):
+class _Reader:
     def __init__(self, builder):
         self._buf = io.BytesIO()
         self._builder = builder
@@ -828,7 +828,7 @@ class _Reader(object):
         return self._bytes_written - self._bytes_read
 
 
-class Connection(object):
+class Connection:
     """Connection object which stores connection related information and operations."""
 
     def __init__(self, connection_manager, connection_id, message_callback):
@@ -912,7 +912,7 @@ class Connection(object):
         return self._id
 
 
-class DefaultAddressProvider(object):
+class DefaultAddressProvider:
     """Provides initial addresses for client to find and connect to a node.
 
     It also provides a no-op translator.

--- a/hazelcast/core.py
+++ b/hazelcast/core.py
@@ -6,7 +6,7 @@ CLIENT_TYPE = "PYH"
 SERIALIZATION_VERSION = 1
 
 
-class MemberInfo(object):
+class MemberInfo:
     """
     Represents a member in the cluster with its address, uuid, lite member
     status, attributes, version, and address map.
@@ -78,7 +78,7 @@ class MemberInfo(object):
         return not self.__eq__(other)
 
 
-class Address(object):
+class Address:
     """Represents an address of a member in the cluster."""
 
     def __init__(self, host, port):
@@ -105,7 +105,7 @@ class Address(object):
         return not self.__eq__(other)
 
 
-class ProtocolType(object):
+class ProtocolType:
     """Types of server sockets.
 
     A member typically responds to several types of protocols for
@@ -134,7 +134,7 @@ class ProtocolType(object):
     """Type of Memcached server sockets."""
 
 
-class EndpointQualifier(object):
+class EndpointQualifier:
     """Uniquely identifies groups of network connections sharing a common
     :class:`ProtocolType` and the same network settings, when Hazelcast server
     is configured with Advanced Network Configuration enabled.
@@ -184,7 +184,7 @@ class EndpointQualifier(object):
         )
 
 
-class AddressHelper(object):
+class AddressHelper:
     @staticmethod
     def get_possible_addresses(address):
         address = AddressHelper.address_from_str(address)
@@ -224,7 +224,7 @@ class AddressHelper(object):
         return Address(host, port)
 
 
-class DistributedObjectInfo(object):
+class DistributedObjectInfo:
     def __init__(self, service_name, name):
         self.service_name = service_name
         self.name = name
@@ -241,7 +241,7 @@ class DistributedObjectInfo(object):
         return False
 
 
-class DistributedObjectEventType(object):
+class DistributedObjectEventType:
     """Type of the distributed object event."""
 
     CREATED = "CREATED"
@@ -255,7 +255,7 @@ class DistributedObjectEventType(object):
     """
 
 
-class DistributedObjectEvent(object):
+class DistributedObjectEvent:
     """Distributed Object Event"""
 
     def __init__(self, name, service_name, event_type, source):
@@ -288,7 +288,7 @@ class DistributedObjectEvent(object):
         )
 
 
-class SimpleEntryView(object):
+class SimpleEntryView:
     """EntryView represents a readonly view of a map entry."""
 
     def __init__(
@@ -388,7 +388,7 @@ class SimpleEntryView(object):
         )
 
 
-class HazelcastJsonValue(object):
+class HazelcastJsonValue:
     """HazelcastJsonValue is a wrapper for JSON formatted strings.
 
     It is preferred to store HazelcastJsonValue instead of Strings for JSON formatted strings.
@@ -450,7 +450,7 @@ class HazelcastJsonValue(object):
         return self._json_string
 
 
-class MemberVersion(object):
+class MemberVersion:
     """
     Determines the Hazelcast codebase version in terms of major.minor.patch version.
     """
@@ -466,7 +466,7 @@ class MemberVersion(object):
         return "MemberVersion(major=%s, minor=%s, patch=%s)" % (self.major, self.minor, self.patch)
 
 
-class MapEntry(object):
+class MapEntry:
     """
     Represents the entry of a Map, with key and value fields.
     """

--- a/hazelcast/cp.py
+++ b/hazelcast/cp.py
@@ -25,7 +25,7 @@ from hazelcast.proxy.cp.semaphore import SessionAwareSemaphore, SessionlessSemap
 from hazelcast.util import check_true, AtomicInteger, thread_id
 
 
-class CPSubsystem(object):
+class CPSubsystem:
     """CP Subsystem is a component of Hazelcast that builds a strongly consistent
     layer for a set of distributed data structures.
 
@@ -194,7 +194,7 @@ LOCK_SERVICE = "hz:raft:lockService"
 SEMAPHORE_SERVICE = "hz:raft:semaphoreService"
 
 
-class CPProxyManager(object):
+class CPProxyManager:
     def __init__(self, context):
         self._context = context
         self._lock_proxies = dict()  # proxy_name to FencedLock
@@ -256,7 +256,7 @@ class CPProxyManager(object):
         return invocation.future.result()
 
 
-class _SessionState(object):
+class _SessionState:
     __slots__ = ("id", "group_id", "ttl", "creation_time", "acquire_count")
 
     def __init__(self, state_id, group_id, ttl):
@@ -295,7 +295,7 @@ class _SessionState(object):
 _NO_SESSION_ID = -1
 
 
-class ProxySessionManager(object):
+class ProxySessionManager:
     def __init__(self, context):
         self._context = context
         self._mutexes = dict()  # RaftGroupId to RLock

--- a/hazelcast/discovery.py
+++ b/hazelcast/discovery.py
@@ -9,7 +9,7 @@ from hazelcast.core import AddressHelper
 _logger = logging.getLogger(__name__)
 
 
-class HazelcastCloudAddressProvider(object):
+class HazelcastCloudAddressProvider:
     """Provides initial addresses for client to find and connect to a node
     and resolves private IP addresses of Hazelcast Cloud service.
     """
@@ -61,7 +61,7 @@ class HazelcastCloudAddressProvider(object):
             _logger.warning("Failed to load addresses from Hazelcast.cloud: %s", e)
 
 
-class HazelcastCloudDiscovery(object):
+class HazelcastCloudDiscovery:
     """Discovery service that discover nodes via Hazelcast.cloud
     https://coordinator.hazelcast.cloud/cluster/discovery?token=<TOKEN>
     """

--- a/hazelcast/errors.py
+++ b/hazelcast/errors.py
@@ -640,7 +640,7 @@ from hazelcast.protocol.builtin import ListMultiFrameCodec
 from hazelcast.protocol.codec.custom.error_holder_codec import ErrorHolderCodec
 
 
-class _ErrorsCodec(object):
+class _ErrorsCodec:
     @staticmethod
     def decode(msg):
         msg.next_frame()

--- a/hazelcast/future.py
+++ b/hazelcast/future.py
@@ -8,7 +8,7 @@ _logger = logging.getLogger(__name__)
 NONE_RESULT = object()
 
 
-class Future(object):
+class Future:
     """Future is used for representing an asynchronous computation result."""
 
     _result = None
@@ -171,7 +171,7 @@ class Future(object):
         chained_future.add_done_callback(callback)
 
 
-class _Event(object):
+class _Event:
     _flag = False
 
     def __init__(self):
@@ -308,7 +308,7 @@ def combine_futures(futures):
     return combined
 
 
-class _BlockingWrapper(object):
+class _BlockingWrapper:
     def __init__(self, wrapped):
         self._wrapped = wrapped
 

--- a/hazelcast/invocation.py
+++ b/hazelcast/invocation.py
@@ -24,7 +24,7 @@ def _no_op_response_handler(_):
     pass
 
 
-class Invocation(object):
+class Invocation:
     __slots__ = (
         "request",
         "timeout",
@@ -79,7 +79,7 @@ class Invocation(object):
         self.future.set_exception(exception, traceback)
 
 
-class InvocationService(object):
+class InvocationService:
     _CLEAN_RESOURCES_PERIOD = 0.1
 
     def __init__(self, client, config, reactor):

--- a/hazelcast/lifecycle.py
+++ b/hazelcast/lifecycle.py
@@ -6,7 +6,7 @@ from hazelcast import __version__
 _logger = logging.getLogger(__name__)
 
 
-class LifecycleState(object):
+class LifecycleState:
     """Lifecycle states."""
 
     STARTING = "STARTING"
@@ -40,7 +40,7 @@ class LifecycleState(object):
     """
 
 
-class LifecycleService(object):
+class LifecycleService:
     """
     Lifecycle service for the Hazelcast client. Allows to determine
     state of the client and add or remove lifecycle listeners.
@@ -83,7 +83,7 @@ class LifecycleService(object):
         self._service.remove_listener(registration_id)
 
 
-class _InternalLifecycleService(object):
+class _InternalLifecycleService:
     def __init__(self, config):
         self.running = False
         self._listeners = {}

--- a/hazelcast/listener.py
+++ b/hazelcast/listener.py
@@ -12,7 +12,7 @@ from hazelcast.util import check_not_none
 _logger = logging.getLogger(__name__)
 
 
-class _ListenerRegistration(object):
+class _ListenerRegistration:
     __slots__ = (
         "registration_request",
         "decode_register_response",
@@ -31,7 +31,7 @@ class _ListenerRegistration(object):
         self.connection_registrations = {}  # Dict of Connection, EventRegistration
 
 
-class _EventRegistration(object):
+class _EventRegistration:
     __slots__ = ("server_registration_id", "correlation_id")
 
     def __init__(self, server_registration_id, correlation_id):
@@ -39,7 +39,7 @@ class _EventRegistration(object):
         self.correlation_id = correlation_id
 
 
-class ListenerService(object):
+class ListenerService:
     def __init__(self, client, config, connection_manager, invocation_service):
         self._client = client
         self._connection_manager = connection_manager
@@ -191,7 +191,7 @@ class ListenerService(object):
                     self.remove_event_handler(event_registration.correlation_id)
 
 
-class ClusterViewListenerService(object):
+class ClusterViewListenerService:
     def __init__(
         self,
         client,

--- a/hazelcast/metrics.py
+++ b/hazelcast/metrics.py
@@ -36,7 +36,7 @@ _OUTPUT_BUFFER_INITIAL_SIZE = 1024
 _OUTPUT_BUFFER_GROW_FACTOR = 1.2
 
 
-class MetricDescriptor(object):
+class MetricDescriptor:
     """Describes a metric to be sent to the members.
 
     It is a simplified version of the Java's MetricDescriptorImpl, sufficient
@@ -64,7 +64,7 @@ class MetricDescriptor(object):
         """ProbeUnit: Unit of the metric."""
 
 
-class ProbeUnit(object):
+class ProbeUnit:
     """Measurement unit of a probe.
 
     The values of the constants below should be in sync with the ProbeUnit
@@ -98,7 +98,7 @@ class ProbeUnit(object):
     # the Python client, as we don't use such enum members.
 
 
-class ValueType(object):
+class ValueType:
     """Type of the metric values.
 
     The values of the constants below should be in sync ValueType enum in Java.
@@ -108,7 +108,7 @@ class ValueType(object):
     DOUBLE = 1
 
 
-class MetricsCompressor(object):
+class MetricsCompressor:
     """Compresses metrics into a ``bytearray`` blob.
 
     The compressor uses dictionary based delta compression and deflates
@@ -281,7 +281,7 @@ class MetricsCompressor(object):
             last_word_text = word_text
 
 
-class _OutputBuffer(object):
+class _OutputBuffer:
     __slots__ = ("_buf", "_pos")
 
     def __init__(self, size=None):
@@ -346,7 +346,7 @@ class _OutputBuffer(object):
         return len(self._buf) - self._pos
 
 
-class _Word(object):
+class _Word:
     __slots__ = ("word", "dict_id")
 
     def __init__(self, word, dict_id):
@@ -354,7 +354,7 @@ class _Word(object):
         self.dict_id = dict_id
 
 
-class _MetricsDictionary(object):
+class _MetricsDictionary:
     """Stores word -> id mappings.
 
     Used by :class:`MetricsCompressor`'s dictionary-based algorithm.

--- a/hazelcast/near_cache.py
+++ b/hazelcast/near_cache.py
@@ -25,7 +25,7 @@ _eviction_key_func = {
 }
 
 
-class DataRecord(object):
+class DataRecord:
     """An expirable and evictable data object which represents a cache entry."""
 
     def __init__(self, key, value, create_time=None, ttl_seconds=None):
@@ -259,7 +259,7 @@ class NearCache(dict):
         return "NearCache(len=%s, evicted=%s)" % (self.__len__(), self._evictions)
 
 
-class NearCacheManager(object):
+class NearCacheManager:
     def __init__(self, config, serialization_service):
         self._config = config
         self._serialization_service = serialization_service

--- a/hazelcast/partition.py
+++ b/hazelcast/partition.py
@@ -6,7 +6,7 @@ from hazelcast.hash import hash_to_index
 _logger = logging.getLogger(__name__)
 
 
-class _PartitionTable(object):
+class _PartitionTable:
     __slots__ = ("connection", "version", "partitions")
 
     def __init__(self, connection, version, partitions):
@@ -18,7 +18,7 @@ class _PartitionTable(object):
         return "PartitionTable(connection=%s, version=%s)" % (self.connection, self.version)
 
 
-class PartitionService(object):
+class PartitionService:
     """
     Allows to retrieve information about the partition count, the partition owner
     or the partition id of a key.
@@ -67,7 +67,7 @@ class PartitionService(object):
         return self._service.partition_count
 
 
-class _InternalPartitionService(object):
+class _InternalPartitionService:
     __slots__ = ("partition_count", "_client", "_partition_table")
 
     def __init__(self, client):

--- a/hazelcast/predicate.py
+++ b/hazelcast/predicate.py
@@ -4,7 +4,7 @@ from hazelcast.util import IterationType, get_attr_name
 PREDICATE_FACTORY_ID = -20
 
 
-class Predicate(object):
+class Predicate:
     """Represents a map entry predicate. Implementations of this class are
     basic building blocks for performing queries on map entries.
 

--- a/hazelcast/projection.py
+++ b/hazelcast/projection.py
@@ -3,7 +3,7 @@ from hazelcast.serialization.api import IdentifiedDataSerializable
 _PROJECTIONS_FACTORY_ID = -30
 
 
-class Projection(object):
+class Projection:
     """Marker base class for all projections.
 
     Projections allow the client to transform (strip down) each query result

--- a/hazelcast/protocol/__init__.py
+++ b/hazelcast/protocol/__init__.py
@@ -1,4 +1,4 @@
-class ErrorHolder(object):
+class ErrorHolder:
     __slots__ = ("error_code", "class_name", "message", "stack_trace_elements")
 
     def __init__(self, error_code, class_name, message, stack_trace_elements):
@@ -20,7 +20,7 @@ class ErrorHolder(object):
         return not self.__eq__(other)
 
 
-class StackTraceElement(object):
+class StackTraceElement:
     __slots__ = ("class_name", "method_name", "file_name", "line_number")
 
     def __init__(self, class_name, method_name, file_name, line_number):
@@ -42,7 +42,7 @@ class StackTraceElement(object):
         return not self.__eq__(other)
 
 
-class RaftGroupId(object):
+class RaftGroupId:
     __slots__ = ("name", "seed", "id")
 
     def __init__(self, name, seed, group_id):
@@ -68,7 +68,7 @@ class RaftGroupId(object):
         return "RaftGroupId(name=%s, seed=%s, id=%s)" % (self.name, self.seed, self.id)
 
 
-class AnchorDataListHolder(object):
+class AnchorDataListHolder:
     __slots__ = ("anchor_page_list", "anchor_data_list")
 
     def __init__(self, page_list, data_list):
@@ -88,7 +88,7 @@ class AnchorDataListHolder(object):
         return object_list
 
 
-class PagingPredicateHolder(object):
+class PagingPredicateHolder:
     __slots__ = (
         "anchor_data_list_holder",
         "predicate_data",

--- a/hazelcast/protocol/builtin.py
+++ b/hazelcast/protocol/builtin.py
@@ -40,7 +40,7 @@ _LOCAL_DATE_TIME_SIZE_IN_BYTES = _LOCAL_DATE_SIZE_IN_BYTES + _LOCAL_TIME_SIZE_IN
 _OFFSET_DATE_TIME_SIZE_IN_BYTES = _LOCAL_DATE_TIME_SIZE_IN_BYTES + INT_SIZE_IN_BYTES
 
 
-class CodecUtil(object):
+class CodecUtil:
     @staticmethod
     def fast_forward_to_end_frame(msg):
         # We are starting from 1 because of the BEGIN_FRAME we read
@@ -82,7 +82,7 @@ class CodecUtil(object):
         return is_null
 
 
-class ByteArrayCodec(object):
+class ByteArrayCodec:
     @staticmethod
     def encode(buf, value, is_final=False):
         header = bytearray(SIZE_OF_FRAME_LENGTH_AND_FLAGS)
@@ -97,7 +97,7 @@ class ByteArrayCodec(object):
         return msg.next_frame().buf
 
 
-class DataCodec(object):
+class DataCodec:
     @staticmethod
     def encode(buf, value, is_final=False):
         value_bytes = value.to_bytes()
@@ -130,7 +130,7 @@ class DataCodec(object):
             return DataCodec.decode(msg)
 
 
-class EntryListCodec(object):
+class EntryListCodec:
     @staticmethod
     def encode(buf, entries, key_encoder, value_encoder, is_final=False):
         buf.extend(BEGIN_FRAME_BUF)
@@ -175,7 +175,7 @@ class EntryListCodec(object):
 _UUID_LONG_ENTRY_SIZE_IN_BYTES = UUID_SIZE_IN_BYTES + LONG_SIZE_IN_BYTES
 
 
-class EntryListUUIDLongCodec(object):
+class EntryListUUIDLongCodec:
     @staticmethod
     def encode(buf, entries, is_final=False):
         n = len(entries)
@@ -204,7 +204,7 @@ class EntryListUUIDLongCodec(object):
         return result
 
 
-class EntryListUUIDListIntegerCodec(object):
+class EntryListUUIDListIntegerCodec:
     @staticmethod
     def encode(buf, entries, is_final=False):
         keys = []
@@ -226,7 +226,7 @@ class EntryListUUIDListIntegerCodec(object):
         return result
 
 
-class FixSizedTypesCodec(object):
+class FixSizedTypesCodec:
     @staticmethod
     def encode_int(buf, offset, value):
         LE_INT.pack_into(buf, offset, value)
@@ -331,7 +331,7 @@ class FixSizedTypesCodec(object):
         return datetime_value.replace(tzinfo=timezone(timedelta(seconds=offset_seconds)))
 
 
-class ListIntegerCodec(object):
+class ListIntegerCodec:
     @staticmethod
     def encode(buf, arr, is_final=False):
         n = len(arr)
@@ -356,7 +356,7 @@ class ListIntegerCodec(object):
         return result
 
 
-class ListLongCodec(object):
+class ListLongCodec:
     @staticmethod
     def encode(buf, arr, is_final=False):
         n = len(arr)
@@ -381,7 +381,7 @@ class ListLongCodec(object):
         return result
 
 
-class ListMultiFrameCodec(object):
+class ListMultiFrameCodec:
     @staticmethod
     def encode(buf, arr, encoder, is_final=False):
         buf.extend(BEGIN_FRAME_BUF)
@@ -446,7 +446,7 @@ class ListMultiFrameCodec(object):
             return ListMultiFrameCodec.decode(msg, decoder)
 
 
-class ListUUIDCodec(object):
+class ListUUIDCodec:
     @staticmethod
     def encode(buf, arr, is_final=False):
         n = len(arr)
@@ -471,7 +471,7 @@ class ListUUIDCodec(object):
         return result
 
 
-class LongArrayCodec(object):
+class LongArrayCodec:
     @staticmethod
     def encode(buf, arr, is_final=False):
         n = len(arr)
@@ -496,7 +496,7 @@ class LongArrayCodec(object):
         return result
 
 
-class MapCodec(object):
+class MapCodec:
     @staticmethod
     def encode(buf, m, key_encoder, value_encoder, is_final=False):
         buf.extend(BEGIN_FRAME_BUF)
@@ -538,7 +538,7 @@ class MapCodec(object):
             return MapCodec.decode(msg, key_decoder, value_decoder)
 
 
-class StringCodec(object):
+class StringCodec:
     @staticmethod
     def encode(buf, value, is_final=False):
         value_bytes = value.encode("utf-8")
@@ -554,7 +554,7 @@ class StringCodec(object):
         return msg.next_frame().buf.decode("utf-8")
 
 
-class ListCNFixedSizeCodec(object):
+class ListCNFixedSizeCodec:
     _TYPE_NULL_ONLY = 1
     _TYPE_NOT_NULL_ONLY = 2
     _TYPE_MIXED = 3
@@ -596,7 +596,7 @@ class ListCNFixedSizeCodec(object):
             return response
 
 
-class ListCNBooleanCodec(object):
+class ListCNBooleanCodec:
     @staticmethod
     def decode(msg):
         return ListCNFixedSizeCodec.decode(
@@ -604,13 +604,13 @@ class ListCNBooleanCodec(object):
         )
 
 
-class ListCNByteCodec(object):
+class ListCNByteCodec:
     @staticmethod
     def decode(msg):
         return ListCNFixedSizeCodec.decode(msg, BYTE_SIZE_IN_BYTES, FixSizedTypesCodec.decode_byte)
 
 
-class ListCNShortCodec(object):
+class ListCNShortCodec:
     @staticmethod
     def decode(msg):
         return ListCNFixedSizeCodec.decode(
@@ -618,19 +618,19 @@ class ListCNShortCodec(object):
         )
 
 
-class ListCNIntegerCodec(object):
+class ListCNIntegerCodec:
     @staticmethod
     def decode(msg):
         return ListCNFixedSizeCodec.decode(msg, INT_SIZE_IN_BYTES, FixSizedTypesCodec.decode_int)
 
 
-class ListCNLongCodec(object):
+class ListCNLongCodec:
     @staticmethod
     def decode(msg):
         return ListCNFixedSizeCodec.decode(msg, LONG_SIZE_IN_BYTES, FixSizedTypesCodec.decode_long)
 
 
-class ListCNFloatCodec(object):
+class ListCNFloatCodec:
     @staticmethod
     def decode(msg):
         return ListCNFixedSizeCodec.decode(
@@ -638,7 +638,7 @@ class ListCNFloatCodec(object):
         )
 
 
-class ListCNDoubleCodec(object):
+class ListCNDoubleCodec:
     @staticmethod
     def decode(msg):
         return ListCNFixedSizeCodec.decode(
@@ -646,7 +646,7 @@ class ListCNDoubleCodec(object):
         )
 
 
-class ListCNLocalDateCodec(object):
+class ListCNLocalDateCodec:
     @staticmethod
     def decode(msg):
         return ListCNFixedSizeCodec.decode(
@@ -654,7 +654,7 @@ class ListCNLocalDateCodec(object):
         )
 
 
-class ListCNLocalTimeCodec(object):
+class ListCNLocalTimeCodec:
     @staticmethod
     def decode(msg):
         return ListCNFixedSizeCodec.decode(
@@ -662,7 +662,7 @@ class ListCNLocalTimeCodec(object):
         )
 
 
-class ListCNLocalDateTimeCodec(object):
+class ListCNLocalDateTimeCodec:
     @staticmethod
     def decode(msg):
         return ListCNFixedSizeCodec.decode(
@@ -670,7 +670,7 @@ class ListCNLocalDateTimeCodec(object):
         )
 
 
-class ListCNOffsetDateTimeCodec(object):
+class ListCNOffsetDateTimeCodec:
     @staticmethod
     def decode(msg):
         return ListCNFixedSizeCodec.decode(
@@ -678,7 +678,7 @@ class ListCNOffsetDateTimeCodec(object):
         )
 
 
-class BigDecimalCodec(object):
+class BigDecimalCodec:
     @staticmethod
     def decode(msg):
         buf = msg.next_frame().buf
@@ -689,7 +689,7 @@ class BigDecimalCodec(object):
         return Decimal((sign, tuple(int(digit) for digit in str(abs(unscaled_value))), -1 * scale))
 
 
-class SqlPageCodec(object):
+class SqlPageCodec:
     @staticmethod
     def decode(msg):
         from hazelcast.sql import SqlColumnType, _SqlPage

--- a/hazelcast/protocol/client_message.py
+++ b/hazelcast/protocol/client_message.py
@@ -63,7 +63,7 @@ def create_initial_buffer_custom(size, is_begin_frame=False):
         return buf
 
 
-class OutboundMessage(object):
+class OutboundMessage:
     __slots__ = ("buf", "retryable")
 
     def __init__(self, buf, retryable):
@@ -97,7 +97,7 @@ class OutboundMessage(object):
         )
 
 
-class Frame(object):
+class Frame:
     __slots__ = ("buf", "flags", "next")
 
     def __init__(self, buf, flags):
@@ -141,7 +141,7 @@ class Frame(object):
         return i == flag_mask
 
 
-class InboundMessage(object):
+class InboundMessage:
     __slots__ = ("start_frame", "end_frame", "_next_frame")
 
     def __init__(self, start_frame):
@@ -219,7 +219,7 @@ LE_UINT16.pack_into(
 )
 
 
-class ClientMessageBuilder(object):
+class ClientMessageBuilder:
     def __init__(self, message_callback):
         self._fragmented_messages = dict()
         self._message_callback = message_callback

--- a/hazelcast/protocol/codec/custom/address_codec.py
+++ b/hazelcast/protocol/codec/custom/address_codec.py
@@ -9,7 +9,7 @@ _PORT_DECODE_OFFSET = 0
 _INITIAL_FRAME_SIZE = _PORT_ENCODE_OFFSET + INT_SIZE_IN_BYTES - SIZE_OF_FRAME_LENGTH_AND_FLAGS
 
 
-class AddressCodec(object):
+class AddressCodec:
     @staticmethod
     def encode(buf, address, is_final=False):
         initial_frame_buf = create_initial_buffer_custom(_INITIAL_FRAME_SIZE)

--- a/hazelcast/protocol/codec/custom/anchor_data_list_holder_codec.py
+++ b/hazelcast/protocol/codec/custom/anchor_data_list_holder_codec.py
@@ -6,7 +6,7 @@ from hazelcast.protocol.builtin import EntryListCodec
 from hazelcast.protocol.builtin import DataCodec
 
 
-class AnchorDataListHolderCodec(object):
+class AnchorDataListHolderCodec:
     @staticmethod
     def encode(buf, anchor_data_list_holder, is_final=False):
         buf.extend(BEGIN_FRAME_BUF)

--- a/hazelcast/protocol/codec/custom/bitmap_index_options_codec.py
+++ b/hazelcast/protocol/codec/custom/bitmap_index_options_codec.py
@@ -9,7 +9,7 @@ _UNIQUE_KEY_TRANSFORMATION_DECODE_OFFSET = 0
 _INITIAL_FRAME_SIZE = _UNIQUE_KEY_TRANSFORMATION_ENCODE_OFFSET + INT_SIZE_IN_BYTES - SIZE_OF_FRAME_LENGTH_AND_FLAGS
 
 
-class BitmapIndexOptionsCodec(object):
+class BitmapIndexOptionsCodec:
     @staticmethod
     def encode(buf, bitmap_index_options, is_final=False):
         initial_frame_buf = create_initial_buffer_custom(_INITIAL_FRAME_SIZE)

--- a/hazelcast/protocol/codec/custom/distributed_object_info_codec.py
+++ b/hazelcast/protocol/codec/custom/distributed_object_info_codec.py
@@ -4,7 +4,7 @@ from hazelcast.protocol.builtin import StringCodec
 from hazelcast.core import DistributedObjectInfo
 
 
-class DistributedObjectInfoCodec(object):
+class DistributedObjectInfoCodec:
     @staticmethod
     def encode(buf, distributed_object_info, is_final=False):
         buf.extend(BEGIN_FRAME_BUF)

--- a/hazelcast/protocol/codec/custom/endpoint_qualifier_codec.py
+++ b/hazelcast/protocol/codec/custom/endpoint_qualifier_codec.py
@@ -9,7 +9,7 @@ _TYPE_DECODE_OFFSET = 0
 _INITIAL_FRAME_SIZE = _TYPE_ENCODE_OFFSET + INT_SIZE_IN_BYTES - SIZE_OF_FRAME_LENGTH_AND_FLAGS
 
 
-class EndpointQualifierCodec(object):
+class EndpointQualifierCodec:
     @staticmethod
     def encode(buf, endpoint_qualifier, is_final=False):
         initial_frame_buf = create_initial_buffer_custom(_INITIAL_FRAME_SIZE)

--- a/hazelcast/protocol/codec/custom/error_holder_codec.py
+++ b/hazelcast/protocol/codec/custom/error_holder_codec.py
@@ -11,7 +11,7 @@ _ERROR_CODE_DECODE_OFFSET = 0
 _INITIAL_FRAME_SIZE = _ERROR_CODE_ENCODE_OFFSET + INT_SIZE_IN_BYTES - SIZE_OF_FRAME_LENGTH_AND_FLAGS
 
 
-class ErrorHolderCodec(object):
+class ErrorHolderCodec:
     @staticmethod
     def encode(buf, error_holder, is_final=False):
         initial_frame_buf = create_initial_buffer_custom(_INITIAL_FRAME_SIZE)

--- a/hazelcast/protocol/codec/custom/index_config_codec.py
+++ b/hazelcast/protocol/codec/custom/index_config_codec.py
@@ -11,7 +11,7 @@ _TYPE_DECODE_OFFSET = 0
 _INITIAL_FRAME_SIZE = _TYPE_ENCODE_OFFSET + INT_SIZE_IN_BYTES - SIZE_OF_FRAME_LENGTH_AND_FLAGS
 
 
-class IndexConfigCodec(object):
+class IndexConfigCodec:
     @staticmethod
     def encode(buf, index_config, is_final=False):
         initial_frame_buf = create_initial_buffer_custom(_INITIAL_FRAME_SIZE)

--- a/hazelcast/protocol/codec/custom/member_info_codec.py
+++ b/hazelcast/protocol/codec/custom/member_info_codec.py
@@ -15,7 +15,7 @@ _LITE_MEMBER_DECODE_OFFSET = _UUID_DECODE_OFFSET + UUID_SIZE_IN_BYTES
 _INITIAL_FRAME_SIZE = _LITE_MEMBER_ENCODE_OFFSET + BOOLEAN_SIZE_IN_BYTES - SIZE_OF_FRAME_LENGTH_AND_FLAGS
 
 
-class MemberInfoCodec(object):
+class MemberInfoCodec:
     @staticmethod
     def encode(buf, member_info, is_final=False):
         initial_frame_buf = create_initial_buffer_custom(_INITIAL_FRAME_SIZE)

--- a/hazelcast/protocol/codec/custom/member_version_codec.py
+++ b/hazelcast/protocol/codec/custom/member_version_codec.py
@@ -12,7 +12,7 @@ _PATCH_DECODE_OFFSET = _MINOR_DECODE_OFFSET + BYTE_SIZE_IN_BYTES
 _INITIAL_FRAME_SIZE = _PATCH_ENCODE_OFFSET + BYTE_SIZE_IN_BYTES - SIZE_OF_FRAME_LENGTH_AND_FLAGS
 
 
-class MemberVersionCodec(object):
+class MemberVersionCodec:
     @staticmethod
     def encode(buf, member_version, is_final=False):
         initial_frame_buf = create_initial_buffer_custom(_INITIAL_FRAME_SIZE)

--- a/hazelcast/protocol/codec/custom/paging_predicate_holder_codec.py
+++ b/hazelcast/protocol/codec/custom/paging_predicate_holder_codec.py
@@ -14,7 +14,7 @@ _ITERATION_TYPE_ID_DECODE_OFFSET = _PAGE_DECODE_OFFSET + INT_SIZE_IN_BYTES
 _INITIAL_FRAME_SIZE = _ITERATION_TYPE_ID_ENCODE_OFFSET + BYTE_SIZE_IN_BYTES - SIZE_OF_FRAME_LENGTH_AND_FLAGS
 
 
-class PagingPredicateHolderCodec(object):
+class PagingPredicateHolderCodec:
     @staticmethod
     def encode(buf, paging_predicate_holder, is_final=False):
         initial_frame_buf = create_initial_buffer_custom(_INITIAL_FRAME_SIZE)

--- a/hazelcast/protocol/codec/custom/raft_group_id_codec.py
+++ b/hazelcast/protocol/codec/custom/raft_group_id_codec.py
@@ -11,7 +11,7 @@ _ID_DECODE_OFFSET = _SEED_DECODE_OFFSET + LONG_SIZE_IN_BYTES
 _INITIAL_FRAME_SIZE = _ID_ENCODE_OFFSET + LONG_SIZE_IN_BYTES - SIZE_OF_FRAME_LENGTH_AND_FLAGS
 
 
-class RaftGroupIdCodec(object):
+class RaftGroupIdCodec:
     @staticmethod
     def encode(buf, raft_group_id, is_final=False):
         initial_frame_buf = create_initial_buffer_custom(_INITIAL_FRAME_SIZE)

--- a/hazelcast/protocol/codec/custom/simple_entry_view_codec.py
+++ b/hazelcast/protocol/codec/custom/simple_entry_view_codec.py
@@ -27,7 +27,7 @@ _MAX_IDLE_DECODE_OFFSET = _TTL_DECODE_OFFSET + LONG_SIZE_IN_BYTES
 _INITIAL_FRAME_SIZE = _MAX_IDLE_ENCODE_OFFSET + LONG_SIZE_IN_BYTES - SIZE_OF_FRAME_LENGTH_AND_FLAGS
 
 
-class SimpleEntryViewCodec(object):
+class SimpleEntryViewCodec:
     @staticmethod
     def encode(buf, simple_entry_view, is_final=False):
         initial_frame_buf = create_initial_buffer_custom(_INITIAL_FRAME_SIZE)

--- a/hazelcast/protocol/codec/custom/sql_column_metadata_codec.py
+++ b/hazelcast/protocol/codec/custom/sql_column_metadata_codec.py
@@ -11,7 +11,7 @@ _NULLABLE_DECODE_OFFSET = _TYPE_DECODE_OFFSET + INT_SIZE_IN_BYTES
 _INITIAL_FRAME_SIZE = _NULLABLE_ENCODE_OFFSET + BOOLEAN_SIZE_IN_BYTES - SIZE_OF_FRAME_LENGTH_AND_FLAGS
 
 
-class SqlColumnMetadataCodec(object):
+class SqlColumnMetadataCodec:
     @staticmethod
     def encode(buf, sql_column_metadata, is_final=False):
         initial_frame_buf = create_initial_buffer_custom(_INITIAL_FRAME_SIZE)

--- a/hazelcast/protocol/codec/custom/sql_error_codec.py
+++ b/hazelcast/protocol/codec/custom/sql_error_codec.py
@@ -11,7 +11,7 @@ _ORIGINATING_MEMBER_ID_DECODE_OFFSET = _CODE_DECODE_OFFSET + INT_SIZE_IN_BYTES
 _INITIAL_FRAME_SIZE = _ORIGINATING_MEMBER_ID_ENCODE_OFFSET + UUID_SIZE_IN_BYTES - SIZE_OF_FRAME_LENGTH_AND_FLAGS
 
 
-class SqlErrorCodec(object):
+class SqlErrorCodec:
     @staticmethod
     def encode(buf, sql_error, is_final=False):
         initial_frame_buf = create_initial_buffer_custom(_INITIAL_FRAME_SIZE)

--- a/hazelcast/protocol/codec/custom/sql_query_id_codec.py
+++ b/hazelcast/protocol/codec/custom/sql_query_id_codec.py
@@ -14,7 +14,7 @@ _LOCAL_ID_LOW_DECODE_OFFSET = _LOCAL_ID_HIGH_DECODE_OFFSET + LONG_SIZE_IN_BYTES
 _INITIAL_FRAME_SIZE = _LOCAL_ID_LOW_ENCODE_OFFSET + LONG_SIZE_IN_BYTES - SIZE_OF_FRAME_LENGTH_AND_FLAGS
 
 
-class SqlQueryIdCodec(object):
+class SqlQueryIdCodec:
     @staticmethod
     def encode(buf, sql_query_id, is_final=False):
         initial_frame_buf = create_initial_buffer_custom(_INITIAL_FRAME_SIZE)

--- a/hazelcast/protocol/codec/custom/stack_trace_element_codec.py
+++ b/hazelcast/protocol/codec/custom/stack_trace_element_codec.py
@@ -9,7 +9,7 @@ _LINE_NUMBER_DECODE_OFFSET = 0
 _INITIAL_FRAME_SIZE = _LINE_NUMBER_ENCODE_OFFSET + INT_SIZE_IN_BYTES - SIZE_OF_FRAME_LENGTH_AND_FLAGS
 
 
-class StackTraceElementCodec(object):
+class StackTraceElementCodec:
     @staticmethod
     def encode(buf, stack_trace_element, is_final=False):
         initial_frame_buf = create_initial_buffer_custom(_INITIAL_FRAME_SIZE)

--- a/hazelcast/proxy/__init__.py
+++ b/hazelcast/proxy/__init__.py
@@ -43,7 +43,7 @@ _proxy_init = {
 }
 
 
-class ProxyManager(object):
+class ProxyManager:
     def __init__(self, context):
         self._context = context
         self._proxies = {}

--- a/hazelcast/proxy/base.py
+++ b/hazelcast/proxy/base.py
@@ -10,7 +10,7 @@ def _no_op_response_handler(_):
     return None
 
 
-class Proxy(object):
+class Proxy:
     """Provides basic functionality for Hazelcast Proxies."""
 
     def __init__(self, service_name, name, context):
@@ -88,7 +88,7 @@ class PartitionSpecificProxy(Proxy):
         return invocation.future
 
 
-class TransactionalProxy(object):
+class TransactionalProxy:
     """Provides an interface for all transactional distributed objects."""
 
     def __init__(self, name, transaction, context):
@@ -110,7 +110,7 @@ class TransactionalProxy(object):
         return '%s(name="%s")' % (type(self).__name__, self.name)
 
 
-class ItemEventType(object):
+class ItemEventType:
     """Type of item events."""
 
     ADDED = 1
@@ -124,7 +124,7 @@ class ItemEventType(object):
     """
 
 
-class EntryEventType(object):
+class EntryEventType:
     """Type of entry event."""
 
     ADDED = 1
@@ -178,7 +178,7 @@ class EntryEventType(object):
     """
 
 
-class ItemEvent(object):
+class ItemEvent:
     """Map Item event.
 
     Attributes:
@@ -200,7 +200,7 @@ class ItemEvent(object):
         return self._to_object(self._item_data)
 
 
-class EntryEvent(object):
+class EntryEvent:
     """Map Entry event.
 
     Attributes:
@@ -268,7 +268,7 @@ class EntryEvent(object):
 _SENTINEL = object()
 
 
-class TopicMessage(object):
+class TopicMessage:
     """Topic message."""
 
     __slots__ = ("_name", "_message_data", "_message", "_publish_time", "_member", "_to_object")

--- a/hazelcast/proxy/cp/__init__.py
+++ b/hazelcast/proxy/cp/__init__.py
@@ -7,7 +7,7 @@ def _no_op_response_handler(_):
     return None
 
 
-class BaseCPProxy(object):
+class BaseCPProxy:
     def __init__(self, context, group_id, service_name, proxy_name, object_name):
         self._context = context
         self._group_id = group_id

--- a/hazelcast/proxy/cp/fenced_lock.py
+++ b/hazelcast/proxy/cp/fenced_lock.py
@@ -448,7 +448,7 @@ class FencedLock(SessionAwareCPProxy):
         return self._invoke(request, codec.decode_response)
 
 
-class _LockOwnershipState(object):
+class _LockOwnershipState:
     def __init__(self, state):
         self.fence = state["fence"]
         self.lock_count = state["lock_count"]

--- a/hazelcast/proxy/flake_id_generator.py
+++ b/hazelcast/proxy/flake_id_generator.py
@@ -73,7 +73,7 @@ class FlakeIdGenerator(Proxy):
         return self._invoke(request, handler)
 
 
-class _AutoBatcher(object):
+class _AutoBatcher:
     def __init__(self, batch_size, validity, id_generator):
         self._batch_size = batch_size
         self._validity = validity
@@ -141,7 +141,7 @@ class _AutoBatcher(object):
                 self._request_in_air = False
 
 
-class _IdBatch(object):
+class _IdBatch:
     def __init__(self, base, increment, batch_size):
         self._base = base
         self._increment = increment
@@ -159,7 +159,7 @@ class _IdBatch(object):
         return next(self._next_id)
 
 
-class _Block(object):
+class _Block:
     def __init__(self, id_batch, validity):
         self._id_batch = id_batch
         self._iterator = iter(self._id_batch)

--- a/hazelcast/proxy/reliable_topic.py
+++ b/hazelcast/proxy/reliable_topic.py
@@ -30,7 +30,7 @@ _MEMBER_ENDPOINT_QUALIFIER = EndpointQualifier(ProtocolType.MEMBER, None)
 _logger = logging.getLogger(__name__)
 
 
-class ReliableMessageListener(object):
+class ReliableMessageListener:
     """A message listener for :class:`ReliableTopic`.
 
     A message listener will not be called concurrently (provided that it's
@@ -150,7 +150,7 @@ class ReliableMessageListener(object):
         raise NotImplementedError("is_terminal")
 
 
-class _MessageRunner(object):
+class _MessageRunner:
     def __init__(
         self,
         registration_id,

--- a/hazelcast/reactor.py
+++ b/hazelcast/reactor.py
@@ -59,7 +59,7 @@ def _set_nonblocking(fd):
     fcntl.fcntl(fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
 
 
-class _SocketAdapter(object):
+class _SocketAdapter:
     def __init__(self, fd):
         self._fd = fd
 
@@ -158,7 +158,7 @@ class _SocketedWaker(_AbstractWaker):
         self._writer.close()
 
 
-class _AbstractLoop(object):
+class _AbstractLoop:
     def __init__(self, map):
         self._map = map
         self._timers = []  # Accessed only from the reactor thread
@@ -326,7 +326,7 @@ class _BasicLoop(_AbstractLoop):
         self._map.clear()
 
 
-class AsyncoreReactor(object):
+class AsyncoreReactor:
     def __init__(self):
         self.map = {}
         loop = None
@@ -584,7 +584,7 @@ class AsyncoreConnection(Connection, asyncore.dispatcher):
 
 
 @total_ordering
-class Timer(object):
+class Timer:
     __slots__ = ("end", "timer_ended_cb", "canceled")
 
     def __init__(self, end, timer_ended_cb):

--- a/hazelcast/security.py
+++ b/hazelcast/security.py
@@ -1,7 +1,7 @@
 from hazelcast.core import Address
 
 
-class TokenProvider(object):
+class TokenProvider:
     """TokenProvider is a base class for token providers."""
 
     def token(self, address=None):

--- a/hazelcast/serialization/api.py
+++ b/hazelcast/serialization/api.py
@@ -3,7 +3,7 @@ User API for Serialization.
 """
 
 
-class ObjectDataOutput(object):
+class ObjectDataOutput:
     """ObjectDataOutput provides an interface to convert any of primitive types or arrays of them to series of bytes and
     write them on a stream.
     """
@@ -229,7 +229,7 @@ class ObjectDataOutput(object):
         raise NotImplementedError()
 
 
-class ObjectDataInput(object):
+class ObjectDataInput:
     """ObjectDataInput provides an interface to read bytes from a stream and reconstruct it to any of primitive types or
     arrays of them.
     """
@@ -475,7 +475,7 @@ class ObjectDataInput(object):
         raise NotImplementedError()
 
 
-class IdentifiedDataSerializable(object):
+class IdentifiedDataSerializable:
     """IdentifiedDataSerializable is an alternative serialization method to Python pickle, which also avoids reflection
     during de-serialization.
 
@@ -523,7 +523,7 @@ class IdentifiedDataSerializable(object):
         )
 
 
-class Portable(object):
+class Portable:
     """Portable provides an alternative serialization method.
 
     Instead of relying on reflection, each Portable is created by a registered PortableFactory.
@@ -567,7 +567,7 @@ class Portable(object):
         raise NotImplementedError()
 
 
-class StreamSerializer(object):
+class StreamSerializer:
     """A base class for custom serialization."""
 
     def write(self, out, obj):
@@ -606,7 +606,7 @@ class StreamSerializer(object):
         raise NotImplementedError()
 
 
-class PortableReader(object):
+class PortableReader:
     """Provides a mean of reading portable fields from binary in form of Python primitives and arrays of these
     primitives, nested portable fields and array of portable fields.
     """
@@ -920,7 +920,7 @@ class PortableReader(object):
         raise NotImplementedError()
 
 
-class PortableWriter(object):
+class PortableWriter:
     """Provides a mean of writing portable fields to a binary in form of Python primitives and arrays of these
     primitives, nested portable fields and array of portable fields.
     """

--- a/hazelcast/serialization/base.py
+++ b/hazelcast/serialization/base.py
@@ -40,7 +40,7 @@ def index_for_default_type(type_id):
     return -type_id
 
 
-class BaseSerializationService(object):
+class BaseSerializationService:
     def __init__(
         self, version, global_partition_strategy, output_buffer_size, is_big_endian, int_type
     ):
@@ -160,7 +160,7 @@ class BaseSerializationService(object):
         self._registry.destroy()
 
 
-class SerializerRegistry(object):
+class SerializerRegistry:
     def __init__(self, int_type):
         self._global_serializer = None
         self._portable_serializer = None

--- a/hazelcast/serialization/data.py
+++ b/hazelcast/serialization/data.py
@@ -9,7 +9,7 @@ DATA_OFFSET = 8
 HEAP_DATA_OVERHEAD = DATA_OFFSET
 
 
-class Data(object):
+class Data:
     """Data is basic unit of serialization.
 
     It stores binary form of an object serialized by serialization service.

--- a/hazelcast/serialization/portable/classdef.py
+++ b/hazelcast/serialization/portable/classdef.py
@@ -1,7 +1,7 @@
 from hazelcast.errors import HazelcastSerializationError
 
 
-class FieldType(object):
+class FieldType:
     PORTABLE = 0
     BYTE = 1
     BOOLEAN = 2
@@ -26,7 +26,7 @@ class FieldType(object):
     STRING_ARRAY = 19
 
 
-class FieldDefinition(object):
+class FieldDefinition:
     def __init__(self, index, field_name, field_type, version, factory_id=0, class_id=0):
         self.index = index
         self.field_name = field_name
@@ -59,7 +59,7 @@ class FieldDefinition(object):
         )
 
 
-class ClassDefinition(object):
+class ClassDefinition:
     def __init__(self, factory_id, class_id, version):
         self.factory_id = factory_id
         self.class_id = class_id
@@ -130,7 +130,7 @@ class ClassDefinition(object):
         return hash((self.factory_id, self.class_id, self.version))
 
 
-class ClassDefinitionBuilder(object):
+class ClassDefinitionBuilder:
     """Builder class to construct :class:`ClassDefinition` of
     :class:`hazelcast.serialization.api.Portable` objects.
 

--- a/hazelcast/serialization/portable/context.py
+++ b/hazelcast/serialization/portable/context.py
@@ -12,7 +12,7 @@ from hazelcast.serialization.portable.classdef import (
 from hazelcast.serialization.portable.writer import ClassDefinitionWriter
 
 
-class PortableContext(object):
+class PortableContext:
     def __init__(self, serialization_service, portable_version):
         self.serialization_service = serialization_service
         self.portable_version = portable_version
@@ -115,7 +115,7 @@ class PortableContext(object):
         return self._class_defs[factory_id]
 
 
-class ClassDefinitionContext(object):
+class ClassDefinitionContext:
     def __init__(self, factory_id, portable_version):
         self._factory_id = factory_id
         self._portable_version = portable_version

--- a/hazelcast/sql.py
+++ b/hazelcast/sql.py
@@ -19,7 +19,7 @@ from hazelcast.util import (
 _logger = logging.getLogger(__name__)
 
 
-class SqlService(object):
+class SqlService:
     """A service to execute SQL statements.
 
     Warnings:
@@ -151,7 +151,7 @@ class SqlService(object):
         return self._service.execute(sql, params, kwargs)
 
 
-class _SqlQueryId(object):
+class _SqlQueryId:
     """Cluster-wide unique query ID."""
 
     __slots__ = ("member_id_high", "member_id_low", "local_id_high", "local_id_low")
@@ -191,7 +191,7 @@ class _SqlQueryId(object):
         return cls(member_msb, member_lsb, local_msb, local_lsb)
 
 
-class SqlColumnMetadata(object):
+class SqlColumnMetadata:
     """Metadata of a column in an SQL row."""
 
     __slots__ = ("_name", "_type", "_nullable")
@@ -222,7 +222,7 @@ class SqlColumnMetadata(object):
         return "%s %s" % (self.name, get_attr_name(SqlColumnType, self.type))
 
 
-class _SqlError(object):
+class _SqlError:
     """Server-side error that is propagated to the client."""
 
     __slots__ = ("code", "message", "originating_member_uuid", "suggestion")
@@ -241,7 +241,7 @@ class _SqlError(object):
         """str: Suggested SQL statement to remediate experienced error."""
 
 
-class _SqlPage(object):
+class _SqlPage:
     """A finite set of rows returned to the user."""
 
     __slots__ = ("_column_types", "_columns", "_is_last")
@@ -280,7 +280,7 @@ class _SqlPage(object):
         return self._columns[column_index][row_index]
 
 
-class SqlColumnType(object):
+class SqlColumnType:
 
     VARCHAR = 0
     """
@@ -360,7 +360,7 @@ class SqlColumnType(object):
     """
 
 
-class _SqlErrorCode(object):
+class _SqlErrorCode:
 
     GENERIC = -1
     """
@@ -436,7 +436,7 @@ class HazelcastSqlError(HazelcastError):
         return self._suggestion
 
 
-class SqlRowMetadata(object):
+class SqlRowMetadata:
     """Metadata for the returned rows."""
 
     __slots__ = ("_columns", "_name_to_index")
@@ -495,7 +495,7 @@ class SqlRowMetadata(object):
         )
 
 
-class SqlRow(object):
+class SqlRow:
     """One of the rows of an SQL query result.
 
     The columns of the rows can be retrieved using
@@ -619,7 +619,7 @@ class SqlRow(object):
         )
 
 
-class _ExecuteResponse(object):
+class _ExecuteResponse:
     """Represent the response of the first execute request."""
 
     __slots__ = ("row_metadata", "row_page", "update_count")
@@ -638,7 +638,7 @@ class _ExecuteResponse(object):
         """int: Update count or -1 if the result is a rowset."""
 
 
-class _IteratorBase(object):
+class _IteratorBase:
     """Base class for the blocking and Future-producing
     iterators to use."""
 
@@ -811,7 +811,7 @@ class _BlockingIterator(_IteratorBase):
         return True
 
 
-class SqlResult(object):
+class SqlResult:
     """SQL query result.
 
     Depending on the statement type it represents a stream of
@@ -1182,7 +1182,7 @@ class SqlResult(object):
         self.close().result()
 
 
-class _InternalSqlService(object):
+class _InternalSqlService:
     """Internal SQL service that offers more public API
     than the one exposed to the user.
     """
@@ -1386,7 +1386,7 @@ class _InternalSqlService(object):
         return _ExecuteResponse(None, None, response["update_count"])
 
 
-class SqlExpectedResultType(object):
+class SqlExpectedResultType:
     """The expected statement result type."""
 
     ANY = 0
@@ -1409,7 +1409,7 @@ _TIMEOUT_NOT_SET = -1
 _DEFAULT_CURSOR_BUFFER_SIZE = 4096
 
 
-class _SqlStatement(object):
+class _SqlStatement:
     """Definition of an SQL statement."""
 
     def __init__(

--- a/hazelcast/statistics.py
+++ b/hazelcast/statistics.py
@@ -28,7 +28,7 @@ _NEAR_CACHE_DESCRIPTOR_DISCRIMINATOR = "name"
 _TCP_METRICS_PREFIX = "tcp"
 
 
-class Statistics(object):
+class Statistics:
     def __init__(
         self, client, config, reactor, connection_manager, invocation_service, near_cache_manager
     ):

--- a/hazelcast/transaction.py
+++ b/hazelcast/transaction.py
@@ -44,7 +44,7 @@ inconsistent state.
 RETRY_COUNT = 20
 
 
-class TransactionManager(object):
+class TransactionManager:
     """Manages the execution of client transactions and provides Transaction objects."""
 
     def __init__(self, context):
@@ -83,7 +83,7 @@ class TransactionManager(object):
         return Transaction(self._context, connection, timeout, durability, transaction_type)
 
 
-class Transaction(object):
+class Transaction:
     """Provides transactional operations: beginning/committing transactions, but also retrieving
     transactional data-structures like the TransactionalMap.
     """

--- a/hazelcast/util.py
+++ b/hazelcast/util.py
@@ -78,7 +78,7 @@ def validate_serializer(serializer, _type):
         raise ValueError("Serializer should be an instance of %s" % _type.__name__)
 
 
-class AtomicInteger(object):
+class AtomicInteger:
     """An Integer which can work atomically."""
 
     def __init__(self, initial=0):
@@ -257,7 +257,7 @@ number_types = (int, float)
 none_type = type(None)
 
 
-class LoadBalancer(object):
+class LoadBalancer:
     """Load balancer allows you to send operations to one of a number of endpoints (Members).
     It is up to the implementation to use different load balancing policies.
 
@@ -329,7 +329,7 @@ class RandomLB(_AbstractLoadBalancer):
         return members[idx]
 
 
-class IterationType(object):
+class IterationType:
     """To differentiate users selection on result collection on map-wide
     operations like ``entry_set``, ``key_set``, ``values`` etc.
     """
@@ -344,7 +344,7 @@ class IterationType(object):
     """Iterate over entries"""
 
 
-class UUIDUtil(object):
+class UUIDUtil:
     @staticmethod
     def to_bits(value):
         i = value.int

--- a/tests/base.py
+++ b/tests/base.py
@@ -10,7 +10,7 @@ import hazelcast
 from hazelcast.core import Address
 
 
-class _Member(object):
+class _Member:
     def __init__(self, rc, cluster, member):
         self.rc, self.cluster, self.member = rc, cluster, member
         self.uuid = member.uuid
@@ -20,7 +20,7 @@ class _Member(object):
         self.rc.terminateMember(self.cluster.id, self.member.uuid)
 
 
-class _Cluster(object):
+class _Cluster:
     def __init__(self, rc, cluster):
         self.cluster = cluster
         self.rc = rc

--- a/tests/hzrc/RemoteController.py
+++ b/tests/hzrc/RemoteController.py
@@ -19,7 +19,7 @@ from thrift.transport import TTransport
 all_structs = []
 
 
-class Iface(object):
+class Iface:
     def ping(self):
         pass
 
@@ -1027,7 +1027,7 @@ class Processor(Iface, TProcessor):
 # HELPER FUNCTIONS AND STRUCTURES
 
 
-class ping_args(object):
+class ping_args:
 
 
     def read(self, iprot):
@@ -1070,7 +1070,7 @@ ping_args.thrift_spec = (
 )
 
 
-class ping_result(object):
+class ping_result:
     """
     Attributes:
      - success
@@ -1131,7 +1131,7 @@ ping_result.thrift_spec = (
 )
 
 
-class clean_args(object):
+class clean_args:
 
 
     def read(self, iprot):
@@ -1174,7 +1174,7 @@ clean_args.thrift_spec = (
 )
 
 
-class clean_result(object):
+class clean_result:
     """
     Attributes:
      - success
@@ -1235,7 +1235,7 @@ clean_result.thrift_spec = (
 )
 
 
-class exit_args(object):
+class exit_args:
 
 
     def read(self, iprot):
@@ -1278,7 +1278,7 @@ exit_args.thrift_spec = (
 )
 
 
-class exit_result(object):
+class exit_result:
     """
     Attributes:
      - success
@@ -1339,7 +1339,7 @@ exit_result.thrift_spec = (
 )
 
 
-class createCluster_args(object):
+class createCluster_args:
     """
     Attributes:
      - hzVersion
@@ -1413,7 +1413,7 @@ createCluster_args.thrift_spec = (
 )
 
 
-class createCluster_result(object):
+class createCluster_result:
     """
     Attributes:
      - success
@@ -1488,7 +1488,7 @@ createCluster_result.thrift_spec = (
 )
 
 
-class createClusterKeepClusterName_args(object):
+class createClusterKeepClusterName_args:
     """
     Attributes:
      - hzVersion
@@ -1562,7 +1562,7 @@ createClusterKeepClusterName_args.thrift_spec = (
 )
 
 
-class createClusterKeepClusterName_result(object):
+class createClusterKeepClusterName_result:
     """
     Attributes:
      - success
@@ -1637,7 +1637,7 @@ createClusterKeepClusterName_result.thrift_spec = (
 )
 
 
-class startMember_args(object):
+class startMember_args:
     """
     Attributes:
      - clusterId
@@ -1699,7 +1699,7 @@ startMember_args.thrift_spec = (
 )
 
 
-class startMember_result(object):
+class startMember_result:
     """
     Attributes:
      - success
@@ -1774,7 +1774,7 @@ startMember_result.thrift_spec = (
 )
 
 
-class shutdownMember_args(object):
+class shutdownMember_args:
     """
     Attributes:
      - clusterId
@@ -1848,7 +1848,7 @@ shutdownMember_args.thrift_spec = (
 )
 
 
-class shutdownMember_result(object):
+class shutdownMember_result:
     """
     Attributes:
      - success
@@ -1909,7 +1909,7 @@ shutdownMember_result.thrift_spec = (
 )
 
 
-class terminateMember_args(object):
+class terminateMember_args:
     """
     Attributes:
      - clusterId
@@ -1983,7 +1983,7 @@ terminateMember_args.thrift_spec = (
 )
 
 
-class terminateMember_result(object):
+class terminateMember_result:
     """
     Attributes:
      - success
@@ -2044,7 +2044,7 @@ terminateMember_result.thrift_spec = (
 )
 
 
-class suspendMember_args(object):
+class suspendMember_args:
     """
     Attributes:
      - clusterId
@@ -2118,7 +2118,7 @@ suspendMember_args.thrift_spec = (
 )
 
 
-class suspendMember_result(object):
+class suspendMember_result:
     """
     Attributes:
      - success
@@ -2179,7 +2179,7 @@ suspendMember_result.thrift_spec = (
 )
 
 
-class resumeMember_args(object):
+class resumeMember_args:
     """
     Attributes:
      - clusterId
@@ -2253,7 +2253,7 @@ resumeMember_args.thrift_spec = (
 )
 
 
-class resumeMember_result(object):
+class resumeMember_result:
     """
     Attributes:
      - success
@@ -2314,7 +2314,7 @@ resumeMember_result.thrift_spec = (
 )
 
 
-class shutdownCluster_args(object):
+class shutdownCluster_args:
     """
     Attributes:
      - clusterId
@@ -2376,7 +2376,7 @@ shutdownCluster_args.thrift_spec = (
 )
 
 
-class shutdownCluster_result(object):
+class shutdownCluster_result:
     """
     Attributes:
      - success
@@ -2437,7 +2437,7 @@ shutdownCluster_result.thrift_spec = (
 )
 
 
-class terminateCluster_args(object):
+class terminateCluster_args:
     """
     Attributes:
      - clusterId
@@ -2499,7 +2499,7 @@ terminateCluster_args.thrift_spec = (
 )
 
 
-class terminateCluster_result(object):
+class terminateCluster_result:
     """
     Attributes:
      - success
@@ -2560,7 +2560,7 @@ terminateCluster_result.thrift_spec = (
 )
 
 
-class splitMemberFromCluster_args(object):
+class splitMemberFromCluster_args:
     """
     Attributes:
      - memberId
@@ -2622,7 +2622,7 @@ splitMemberFromCluster_args.thrift_spec = (
 )
 
 
-class splitMemberFromCluster_result(object):
+class splitMemberFromCluster_result:
     """
     Attributes:
      - success
@@ -2684,7 +2684,7 @@ splitMemberFromCluster_result.thrift_spec = (
 )
 
 
-class mergeMemberToCluster_args(object):
+class mergeMemberToCluster_args:
     """
     Attributes:
      - clusterId
@@ -2758,7 +2758,7 @@ mergeMemberToCluster_args.thrift_spec = (
 )
 
 
-class mergeMemberToCluster_result(object):
+class mergeMemberToCluster_result:
     """
     Attributes:
      - success
@@ -2820,7 +2820,7 @@ mergeMemberToCluster_result.thrift_spec = (
 )
 
 
-class executeOnController_args(object):
+class executeOnController_args:
     """
     Attributes:
      - clusterId
@@ -2906,7 +2906,7 @@ executeOnController_args.thrift_spec = (
 )
 
 
-class executeOnController_result(object):
+class executeOnController_result:
     """
     Attributes:
      - success

--- a/tests/hzrc/ttypes.py
+++ b/tests/hzrc/ttypes.py
@@ -17,7 +17,7 @@ from thrift.transport import TTransport
 all_structs = []
 
 
-class Lang(object):
+class Lang:
     JAVASCRIPT = 1
     GROOVY = 2
     PYTHON = 3
@@ -38,7 +38,7 @@ class Lang(object):
     }
 
 
-class Cluster(object):
+class Cluster:
     """
     Attributes:
      - id
@@ -95,7 +95,7 @@ class Cluster(object):
         return not (self == other)
 
 
-class Member(object):
+class Member:
     """
     Attributes:
      - uuid
@@ -174,7 +174,7 @@ class Member(object):
         return not (self == other)
 
 
-class Response(object):
+class Response:
     """
     Attributes:
      - success

--- a/tests/integration/connection_manager_translate_test.py
+++ b/tests/integration/connection_manager_translate_test.py
@@ -116,7 +116,7 @@ class ConnectionManagerTranslateTest(HazelcastTestCase):
             conn_manager._get_or_connect_to_member(member).result()
 
 
-class StaticAddressProvider(object):
+class StaticAddressProvider:
     def __init__(self, should_translate, member_address):
         self.should_translate = should_translate
         self.member_address = member_address

--- a/tests/soak_test/map_soak_test.py
+++ b/tests/soak_test/map_soak_test.py
@@ -25,7 +25,7 @@ ENTRY_COUNT = 10000
 OBSERVATION_INTERVAL = 10.0
 
 
-class SoakTestCoordinator(object):
+class SoakTestCoordinator:
     def __init__(self, test_duration, address):
         self._tests_failed = False
         self._thread_count_before = threading.active_count()
@@ -212,7 +212,7 @@ class OperationCountObserver(threading.Thread):
             logging.info("Operations Per Second: %s\n", op_count / OBSERVATION_INTERVAL)
 
 
-class OperationCounter(object):
+class OperationCounter:
     def __init__(self):
         self._count = 0
         self._lock = threading.Lock()

--- a/tests/unit/client_message_test.py
+++ b/tests/unit/client_message_test.py
@@ -338,7 +338,7 @@ class EncodeDecodeTest(unittest.TestCase):
         self.assertIsNone(CodecUtil.decode_nullable(message, StringCodec.decode))
 
 
-class _MutableInteger(object):
+class _MutableInteger:
     def __init__(self, initial_value):
         self.value = initial_value
 

--- a/tests/unit/discovery/hazelcast_cloud_discovery_test.py
+++ b/tests/unit/discovery/hazelcast_cloud_discovery_test.py
@@ -68,7 +68,7 @@ class CloudHTTPHandler(BaseHTTPRequestHandler):
         self.wfile.write(message.encode())
 
 
-class Server(object):
+class Server:
     cur_dir = os.path.dirname(__file__)
 
     def __init__(self):

--- a/tests/unit/future_test.py
+++ b/tests/unit/future_test.py
@@ -473,7 +473,7 @@ class CombineFutureTest(unittest.TestCase):
 
 
 class MakeBlockingTest(unittest.TestCase):
-    class Calculator(object):
+    class Calculator:
         def __init__(self):
             self.name = "calc"
 

--- a/tests/unit/hazelcast_json_value_test.py
+++ b/tests/unit/hazelcast_json_value_test.py
@@ -23,7 +23,7 @@ class HazelcastJsonValueTest(unittest.TestCase):
         self.assertEqual(json.dumps(self.json_obj), json_value.to_string())
 
     def test_hazelcast_json_value_construction_with_non_json_serializable_object(self):
-        class A(object):
+        class A:
             def __init__(self):
                 self.b = "c"
 

--- a/tests/unit/load_balancer_test.py
+++ b/tests/unit/load_balancer_test.py
@@ -3,7 +3,7 @@ import unittest
 from hazelcast.util import RandomLB, RoundRobinLB
 
 
-class _MockClusterService(object):
+class _MockClusterService:
     def __init__(self, members):
         self._members = members
 

--- a/tests/unit/reactor_test.py
+++ b/tests/unit/reactor_test.py
@@ -272,7 +272,7 @@ class PipedWakerTest(unittest.TestCase):
             os.read(r_fd, 1)
 
 
-class MockServer(object):
+class MockServer:
     def __init__(self):
         self._s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._s.settimeout(3.0)

--- a/tests/unit/serialization/binary_compatibility/reference_objects.py
+++ b/tests/unit/serialization/binary_compatibility/reference_objects.py
@@ -81,7 +81,7 @@ class AnInnerPortable(Portable):
         return not self.__eq__(other)
 
 
-class CustomStreamSerializable(object):
+class CustomStreamSerializable:
     def __init__(self, i=None, f=None):
         self.i = i
         self.f = f
@@ -97,7 +97,7 @@ class CustomStreamSerializable(object):
         return not self.__eq__(other)
 
 
-class CustomByteArraySerializable(object):
+class CustomByteArraySerializable:
     def __init__(self, i=None, f=None):
         self.i = i
         self.f = f

--- a/tests/unit/serialization/custom_global_serialization_test.py
+++ b/tests/unit/serialization/custom_global_serialization_test.py
@@ -29,7 +29,7 @@ class GlobalSerializer(StreamSerializer):
         pass
 
 
-class CustomClass(object):
+class CustomClass:
     def __init__(self, uid, name, text, source=None):
         self.uid = uid
         self.name = name

--- a/tests/unit/serialization/serializers_test.py
+++ b/tests/unit/serialization/serializers_test.py
@@ -12,7 +12,7 @@ from hazelcast.predicate import *
 from hazelcast.serialization.service import SerializationServiceV1
 
 
-class A(object):
+class A:
     def __init__(self, x):
         self.x = x
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -144,7 +144,7 @@ def open_connection_to_address(client, uuid):
     m.destroy()
 
 
-class LoggingContext(object):
+class LoggingContext:
     def __init__(self, logger, level):
         self.logger = logger
         self.level = level


### PR DESCRIPTION
We were using `object` inheritance to use new-style classes in Python 2.
However, that is not necessary anymore, as we have dropped support for
Python 2.

This PR simply replaces all occurrences of `(object):` string with
`:`, to get rid of that useless base object class.

Protocol PR: https://github.com/hazelcast/hazelcast-client-protocol/pull/406