### PR TITLE
test_runner.yaml is updated with event type pull_request_target

### DIFF
--- a/.github/workflows/test_runner.yml
+++ b/.github/workflows/test_runner.yml
@@ -4,13 +4,15 @@ on:
     branches:
       - master
       - '[45].*.z'
-  pull_request:
+  pull_request_target:
+    types: [labeled]
     branches:
       - master
       - '[45].*.z'
 jobs:
   run-tests:
     runs-on: ${{ matrix.os }}
+    if: contains(github.event.pull_request.labels.*.name, 'pr_builder') || github.event_name == 'push'
     name: Run tests with Python ${{ matrix.python-version }} on ${{ matrix.os }}
     strategy:
       matrix:
@@ -27,8 +29,17 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: '8'
-      - name: Checkout to code
+          
+      - name: Checkout code for push event
+        if: github.event_name == 'push'
         uses: actions/checkout@v2
+
+      - name: Checkout code for PR
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          
       - name: Install dependencies
         run: |
           pip install -r requirements-test.txt
@@ -45,19 +56,30 @@ jobs:
             rc_stderr.log
             rc_stdout.log
       - name: Publish results to Codecov
+        if: ${{ matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest' }}
         uses: codecov/codecov-action@v1
         with:
           files: ./coverage.xml
   run-linter:
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'pr_builder') || github.event_name == 'push'
     name: Run black to check the code style
     steps:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
           python-version: '3.10'
-      - name: Checkout to code
+          
+      - name: Checkout code for push event
+        if: github.event_name == 'push'
         uses: actions/checkout@v2
+
+      - name: Checkout code for PR
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          
       - name: Install dependencies
         run: |
           pip install -r requirements-dev.txt
@@ -66,14 +88,24 @@ jobs:
           black --check --config black.toml .
   generate_docs:
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'pr_builder') || github.event_name == 'push'
     name: Generate documentation
     steps:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
           python-version: '3.10'
-      - name: Checkout to code
+          
+      - name: Checkout code for push event
+        if: github.event_name == 'push'
         uses: actions/checkout@v2
+
+      - name: Checkout code for PR
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          
       - name: Install dependencies
         run: |
           pip install -r requirements-dev.txt


### PR DESCRIPTION
This PR is changing the event trigger mechanism for PRs. `pull_request` event type is changed to `pull_request_target`
`pull_request_target` is a little bit dangerous because even it is triggered by a PR, it runs the base branch code and also it can reach the repository secrets

https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request_target
https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

For example, normal checkout action checks out the base branch's code and the running workflow is the base branch's workflow instead of the PR.

Another example, if you make some changes on workflow and create a PR, these changes won't affect the triggered workflow for the PR. The triggered workflow will be the base branch's workflow

That is why we need to be careful about this event type.

In order to be safe, a label check is added to workflow. It is triggered when it is labeled but jobs are run if it is labeled as `pr_builder`. So if there is another PR coming from community, we can check changes and then add the label to trigger.
I set a label name but we can also run jobs when it is labeled without checking label's name.

