### PR TITLE
Convert `Config` classes to public API [API-1280]

### DIFF
--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -5,7 +5,6 @@ API Documentation
 
     aggregator
     cluster
-    config
     core
     cp
     errors

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1,8 +1,12 @@
-Config
-======
+Configuration API Documentation
+===============================
 
 .. py:currentmodule:: hazelcast.config
 
+.. autoclass:: Config
+.. autoclass:: NearCacheConfig
+.. autoclass:: FlakeIdGeneratorConfig
+.. autoclass:: ReliableTopicConfig
 .. autoclass:: IntType
 .. autoclass:: EvictionPolicy
 .. autoclass:: InMemoryFormat

--- a/docs/configuration_overview.rst
+++ b/docs/configuration_overview.rst
@@ -1,15 +1,43 @@
 Configuration Overview
 ======================
 
-For configuration of the Hazelcast Python client, just pass the keyword
-arguments to the client to configure the desired aspects. An example is
-shown below.
+The client can be configured either by keyword arguments or by a configuration
+object.
+
+Keyword Arguments Configuration
+-------------------------------
+
+It is possible to pass keyword arguments directly to the client's constructor
+to configure desired aspects of the client.
+
+The keyword argument names must be valid property names of the
+:class:`hazelcast.config.Config` class with valid values.
 
 .. code:: python
 
-    client = hazelcast.HazelcastClient(
-        cluster_members=["127.0.0.1:5701"]
+    from hazelcast import HazelcastClient
+
+    client = HazelcastClient(
+        cluster_name="a-cluster",
+        cluster_members=["127.0.0.1:5701"],
     )
 
-See the API documentation of :class:`hazelcast.client.HazelcastClient`
-for details.
+
+Using a Configuration Object
+----------------------------
+
+Alternatively, you can create a configuration object, and pass it to the client
+as its only argument.
+
+This way might provide better user experience as it provides hints for the
+configuration option names and their types.
+
+.. code:: python
+
+    from hazelcast import HazelcastClient
+    from hazelcast.config import Config
+
+    config = Config()
+    config.cluster_name = "a-cluster"
+    config.cluster_members = ["127.0.0.1:5701"]
+    client = HazelcastClient(config)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -117,6 +117,7 @@ Features
     :hidden:
 
     client
+    config
     api/modules
     getting_started
     features

--- a/examples/configuration/kwargs_configuration_example.py
+++ b/examples/configuration/kwargs_configuration_example.py
@@ -1,0 +1,17 @@
+from hazelcast import HazelcastClient
+
+client = HazelcastClient(
+    cluster_name="a-cluster",
+    cluster_members=["10.212.1.132:5701"],
+    ssl_enabled=True,
+    near_caches={
+        "a-map": {
+            "time_to_live": 120,
+            "max_idle": 60,
+        }
+    },
+)
+
+# Do something with the client
+
+client.shutdown()

--- a/examples/configuration/object_configuration_example.py
+++ b/examples/configuration/object_configuration_example.py
@@ -1,0 +1,21 @@
+from hazelcast import HazelcastClient
+from hazelcast.config import Config, NearCacheConfig
+
+config = Config()
+config.cluster_name = "a-cluster"
+config.cluster_members = ["10.212.1.132:5701"]
+config.ssl_enabled = True
+
+near_cache_config = NearCacheConfig()
+near_cache_config.time_to_live = 120
+near_cache_config.max_idle = 60
+
+config.near_caches = {
+    "a-map": near_cache_config,
+}
+
+client = HazelcastClient(config)
+
+# Do something with the client
+
+client.shutdown()

--- a/hazelcast/client.py
+++ b/hazelcast/client.py
@@ -107,7 +107,7 @@ class HazelcastClient:
             if kwargs:
                 raise InvalidConfigurationError(
                     "Ambiguous client configuration is found. Either provide "
-                    "the ``config`` object as the only parameter, or do not "
+                    "the config object as the only parameter, or do not "
                     "pass it and use keyword arguments to configure the "
                     "client."
                 )

--- a/hazelcast/client.py
+++ b/hazelcast/client.py
@@ -5,12 +5,12 @@ import typing
 
 from hazelcast.cluster import ClusterService, _InternalClusterService
 from hazelcast.compact import CompactSchemaService
-from hazelcast.config import _Config
+from hazelcast.config import Config
 from hazelcast.connection import ConnectionManager, DefaultAddressProvider
 from hazelcast.core import DistributedObjectEvent, DistributedObjectInfo
 from hazelcast.cp import CPSubsystem, ProxySessionManager
 from hazelcast.discovery import HazelcastCloudAddressProvider
-from hazelcast.errors import IllegalStateError
+from hazelcast.errors import IllegalStateError, InvalidConfigurationError
 from hazelcast.future import Future
 from hazelcast.invocation import InvocationService, Invocation
 from hazelcast.lifecycle import LifecycleService, LifecycleState, _InternalLifecycleService
@@ -64,321 +64,56 @@ _logger = logging.getLogger(__name__)
 
 
 class HazelcastClient:
-    """Hazelcast client instance to access and manipulate
-    distributed data structures on the Hazelcast clusters.
-
-    Keyword Args:
-        cluster_members (`list[str]`): Candidate address list that the client
-            will use to establish initial connection. By default, set to
-            ``["127.0.0.1"]``.
-        cluster_name (str): Name of the cluster to connect to. The name is
-            sent as part of the the client authentication message and may
-            be verified on the member. By default, set to ``dev``.
-        client_name (str): Name of the client instance. By default,
-            set to ``hz.client_${CLIENT_ID}``, where ``CLIENT_ID`` starts
-            from ``0`` and it is incremented by ``1`` for each new client.
-        connection_timeout (float): Socket timeout value in seconds for the
-            client to connect member nodes. Setting this to ``0`` makes
-            the connection blocking. By default, set to ``5.0``.
-        socket_options (`list[tuple]`): List of socket option tuples. The
-            tuples must contain the parameters passed into the
-            :func:`socket.setsockopt` in the same order.
-        redo_operation (bool): When set to ``True``, the client will redo
-            the operations that were executing on the server in case if the
-            client lost connection. This can happen because of network problems,
-            or simply because the member died. However it is not clear whether
-            the operation was performed or not. For idempotent operations this is
-            harmless, but for non idempotent ones retrying can cause to undesirable
-            effects. Note that the redo can be processed on any member. By default,
-            set to ``False``.
-        smart_routing (bool): Enables smart mode for the client instead of
-            unisocket client. Smart clients send key based operations to owner of
-            the keys. Unisocket clients send all operations to a single node. By
-            default, set to ``True``.
-        ssl_enabled (bool): If it is ``True``, SSL is enabled. By default, set
-            to ``False``.
-        ssl_cafile (str): Absolute path of concatenated CA certificates used to
-            validate server's certificates in PEM format. When SSL is enabled and
-            cafile is not set, a set of default CA certificates from default
-            locations will be used.
-        ssl_certfile (str): Absolute path of the client certificate in PEM format.
-        ssl_keyfile (str): Absolute path of the private key file for the client
-            certificate in the PEM format. If this parameter is ``None``, private
-            key will be taken from the certfile.
-        ssl_password (str|bytes|bytearray|function): Password for decrypting the
-            keyfile if it is encrypted. The password may be a function to call to
-            get the password. It will be called with no arguments, and it should
-            return a string, bytes, or bytearray. If the return value is a string
-            it will be encoded as UTF-8 before using it to decrypt the key.
-            Alternatively a string, bytes, or bytearray value may be supplied
-            directly as the password.
-        ssl_protocol (int|str): Protocol version used in SSL communication.
-            By default, set to ``TLSv1_2``. See the
-            :class:`hazelcast.config.SSLProtocol` for possible values.
-        ssl_ciphers (str): String in the OpenSSL cipher list format to set the
-            available ciphers for sockets. More than one cipher can be set by
-            separating them with a colon.
-        ssl_check_hostname (bool): When set to ``True``, verifies that the
-            hostname in the member's certificate and the address of the member
-            matches during the handshake. By default, set to ``False``.
-        cloud_discovery_token (str): Discovery token of the Hazelcast Cloud cluster.
-            When this value is set, Hazelcast Cloud discovery is enabled.
-        async_start (bool): Enables non-blocking start mode of the client.
-            When set to ``True``, the client creation will not wait to connect to
-            cluster. The client instance will throw exceptions until it connects to
-            cluster and becomes ready. If set to ``False``, the client
-            will block until a cluster connection established and it is ready to use
-            the client instance. By default, set to ``False``.
-        reconnect_mode (int|str): Defines how the client reconnects to cluster after a
-            disconnect. By default, set to ``ON``. See the
-            :class:`hazelcast.config.ReconnectMode` for possible values.
-        retry_initial_backoff (float): Wait period in seconds after the first failure
-            before retrying. Must be non-negative. By default, set to ``1.0``.
-        retry_max_backoff (float): Upper bound for the backoff interval in seconds.
-            Must be non-negative. By default, set to ``30.0``.
-        retry_jitter (float): Defines how much to randomize backoffs. At each iteration
-            the calculated back-off is randomized via following method in pseudo-code
-            ``Random(-jitter * current_backoff, jitter * current_backoff)``. Must be
-            in range ``[0.0, 1.0]``. By default, set to ``0.0`` (no randomization).
-        retry_multiplier (float): The factor with which to multiply backoff after a
-            failed retry. Must be greater than or equal to ``1``. By default,
-            set to ``1.05``.
-        cluster_connect_timeout (float): Timeout value in seconds for the client to
-            give up connecting to the cluster. Must be non-negative or
-            equal to `-1`. By default, set to `-1`. `-1` means that the client
-            will not stop trying to the target cluster. (infinite timeout)
-        portable_version (int): Default value for the portable version if the
-            class does not have the :func:`get_portable_version` method. Portable
-            versions are used to differentiate two versions of the
-            :class:`hazelcast.serialization.api.Portable` classes that have added
-            or removed fields, or fields with different types.
-        data_serializable_factories (dict[int, dict[int, class]]): Dictionary of
-            factory id and corresponding
-            :class:`hazelcast.serialization.api.IdentifiedDataSerializable` factories.
-            A factory is simply a dictionary with class id and callable class
-            constructors.
-
-            .. code-block:: python
-
-                FACTORY_ID = 1
-                CLASS_ID = 1
-
-                class SomeSerializable(IdentifiedDataSerializable):
-                    # omitting the implementation
-                    pass
-
-
-                client = HazelcastClient(data_serializable_factories={
-                    FACTORY_ID: {
-                        CLASS_ID: SomeSerializable
-                    }
-                })
-
-        portable_factories (dict[int, dict[int, class]]): Dictionary of
-            factory id and corresponding
-            :class:`hazelcast.serialization.api.Portable` factories.
-            A factory is simply a dictionary with class id and callable class
-            constructors.
-
-            .. code-block:: python
-
-                FACTORY_ID = 2
-                CLASS_ID = 2
-
-                class SomeSerializable(Portable):
-                    # omitting the implementation
-                    pass
-
-
-                client = HazelcastClient(portable_factories={
-                    FACTORY_ID: {
-                        CLASS_ID: SomeSerializable
-                    }
-                })
-
-        compact_serializers (list[hazelcast.serialization.api.CompactSerializer]):
-            List of Compact serializers.
-
-            .. code-block:: python
-
-                class Foo:
-                    pass
-
-                class FooSerializer(CompactSerializer[Foo]):
-                    pass
-
-                client = HazelcastClient(
-                    compact_serializers=[
-                        FooSerializer(),
-                    ],
-                )
-
-        class_definitions (`list[hazelcast.serialization.portable.classdef.ClassDefinition]`):
-            List of all portable class definitions.
-        check_class_definition_errors (bool): When enabled, serialization system
-            will check for class definitions error at start and throw an
-            ``HazelcastSerializationError`` with error definition. By default,
-            set to ``True``.
-        is_big_endian (bool): Defines if big-endian is used as the byte order
-            for the serialization. By default, set to ``True``.
-        default_int_type (int|str): Defines how the ``int``/``long`` type is
-            represented on the cluster side. By default, it is serialized
-            as ``INT`` (``32`` bits). See the
-            :class:`hazelcast.config.IntType` for possible values.
-        global_serializer (hazelcast.serialization.api.StreamSerializer):
-            Defines the global serializer. This serializer
-            is registered as a fallback serializer to handle all other objects
-            if a serializer cannot be located for them.
-        custom_serializers (dict[class, hazelcast.serialization.api.StreamSerializer]):
-            Dictionary of class and the corresponding custom serializers.
-
-            .. code-block:: python
-
-                class SomeClass:
-                    # omitting the implementation
-                    pass
-
-
-                class SomeClassSerializer(StreamSerializer):
-                    # omitting the implementation
-                    pass
-
-                client = HazelcastClient(custom_serializers={
-                    SomeClass: SomeClassSerializer
-                })
-
-        near_caches (dict[str, dict[str, any]]): Dictionary of near cache
-            names and the corresponding near cache configurations as a dictionary.
-            The near cache configurations contains the following options.
-            When an option is missing from the configuration, it will be
-            set to its default value.
-
-            - **invalidate_on_change** (bool): Enables cluster-assisted invalidate
-              on change behavior. When set to ``True``, entries are invalidated
-              when they are changed in cluster. By default, set to ``True``.
-            - **in_memory_format** (int|str): Specifies in which format data will be
-              stored in the Near Cache. By default, set to ``BINARY``. See the
-              :class:`hazelcast.config.InMemoryFormat` for possible values.
-            - **time_to_live** (float): Maximum number of seconds that an entry can
-              stay in cache. When not set, entries won't be evicted due
-              to expiration.
-            - **max_idle** (float): Maximum number of seconds that an entry can stay
-              in the Near Cache until it is accessed. When not set, entries won't be
-              evicted due to inactivity.
-            - **eviction_policy** (int|str): Defines eviction policy configuration.
-              By default, set to ``LRU``. See the
-              :class:`hazelcast.config.EvictionPolicy` for possible values.
-            - **eviction_max_size** (int): Defines maximum number of entries kept in
-              the memory before eviction kicks in. By default, set to ``10000``.
-            - **eviction_sampling_count** (int): Number of random entries that are
-              evaluated to see if some of them are already expired. By default,
-              set to ``8``.
-            - **eviction_sampling_pool_size** (int): Size of the pool for eviction
-              candidates. The pool is kept sorted according to the eviction policy.
-              By default, set to ``16``.
-
-        load_balancer (hazelcast.util.LoadBalancer): Load balancer implementation
-            for the client.
-        membership_listeners (`list[tuple[function, function]]`): List of membership
-            listener tuples. Tuples must be of size ``2``. The first element will
-            be the function to be called when a member is added, and the second
-            element will be the function to be called when the member is removed
-            with the :class:`hazelcast.core.MemberInfo` as the only parameter.
-            Any of the elements can be ``None``, but not at the same time.
-        lifecycle_listeners (`list[function]`): List of lifecycle listeners.
-            Listeners will be called with the new lifecycle state as the only
-            parameter when the client changes lifecycle states.
-        flake_id_generators (dict[str, dict[str, any]]): Dictionary of flake id
-            generator names and the corresponding flake id generator configurations
-            as a dictionary. The flake id generator configurations contains the
-            following options. When an option is missing from the configuration, it
-            will be set to its default value.
-
-            - **prefetch_count** (int): Defines how many IDs are pre-fetched on the
-              background when a new flake id is requested from the cluster. Should
-              be in the range ``1..100000``. By default, set to ``100``.
-            - **prefetch_validity** (float): Defines for how long the pre-fetched IDs
-              can be used. If this time elapsed, a new batch of IDs will be fetched.
-              Time unit is in seconds. By default, set to ``600`` (10 minutes).
-
-              The IDs contain timestamp component, which ensures rough global ordering
-              of IDs. If an ID is assigned to an object that was created much later,
-              it will be much out of order. If you don't care about ordering, set this
-              value to ``0`` for unlimited ID validity.
-
-        reliable_topics (dict[str, dict[str, any]]): Dictionary of reliable
-            topic names and the corresponding reliable topic configurations as
-            a dictionary. The reliable topic configurations contain the
-            following options. When an option is missing from the
-            configuration, it will be set to its default value.
-
-            - **overload_policy** (int|str): Policy to handle an overloaded
-              topic. By default, set to ``BLOCK``. See the
-              :class:`hazelcast.config.TopicOverloadPolicy` for possible values.
-            - **read_batch_size** (int): Number of messages the reliable topic
-              will try to read in batch. It will get at least one, but if
-              there are more available, then it will try to get more to
-              increase throughput. By default, set to ``10``.
-
-        labels (`list[str]`): Labels for the client to be sent to the cluster.
-        heartbeat_interval (float): Time interval between the heartbeats sent by the
-            client to the member nodes in seconds. By default, set to ``5.0``.
-        heartbeat_timeout (float): If there is no message passing between the client
-            and a member within the given time via this property in seconds, the
-            connection will be closed. By default, set to ``60.0``.
-        invocation_timeout (float): When an invocation gets an exception because
-
-            - Member throws an exception.
-            - Connection between the client and member is closed.
-            - The client's heartbeat requests are timed out.
-
-            Time passed since invocation started is compared with this property.
-            If the time is already passed, then the exception is delegated to the user.
-            If not, the invocation is retried. Note that, if invocation gets no exception
-            and it is a long running one, then it will not get any exception, no matter
-            how small this timeout is set. Time unit is in seconds. By default,
-            set to ``120.0``.
-
-        invocation_retry_pause (float): Pause time between each retry cycle of an
-            invocation in seconds. By default, set to ``1.0``.
-        statistics_enabled (bool): When set to ``True``, the client statistics
-            collection is enabled. By default, set to ``False``.
-        statistics_period (float): The period in seconds the statistics run.
-        shuffle_member_list (bool): The Client shuffles the given member list
-            to prevent all clients to connect to the same node when this
-            property is set to ``True``. When it is set to ``False``, the
-            client tries to connect to the nodes in the given order. By
-            default, set to ``True``.
-        backup_ack_to_client_enabled (bool): Enables the client to get backup
-            acknowledgements directly from the member that backups are applied,
-            which reduces number of hops and increases performance for smart clients.
-            This option has no effect for unisocket clients. By default, set
-            to ``True`` (enabled).
-        operation_backup_timeout (float): If an operation has backups, defines
-            how long the invocation will wait for acks from the backup replicas
-            in seconds. If acks are not received from some backups, there won't
-            be any rollback on other successful replicas. By default, set to ``5.0``.
-        fail_on_indeterminate_operation_state (bool): When enabled, if an operation
-            has sync backups and acks are not received from backup replicas in time,
-            or the member which owns primary replica of the target partition leaves
-            the cluster, then the invocation fails with
-            :class:`hazelcast.errors.IndeterminateOperationStateError`. However,
-            even if the invocation fails, there will not be any rollback on other
-            successful replicas. By default, set to ``False`` (do not fail).
-        creds_username (str): Username for credentials authentication (Enterprise feature).
-        creds_password (str): Password for credentials authentication (Enterprise feature).
-        token_provider (hazelcast.security.TokenProvider): Token provider for
-            custom authentication (Enterprise feature). Note that token_provider
-            setting has priority over credentials settings.
-        use_public_ip (bool): When set to ``True``, the client uses the public
-            IP addresses reported by members while connecting to them, if
-            available. By default, set to ``False``.
+    """Hazelcast client instance to access and manipulate distributed data
+    structures on the Hazelcast clusters.
     """
 
     _CLIENT_ID = AtomicInteger()
 
-    def __init__(self, **kwargs):
-        config = _Config.from_dict(kwargs)
+    def __init__(self, config: Config = None, **kwargs):
+        """The client can be configured either by:
+
+        - providing a configuration object as the first parameter of the
+          constructor
+
+        .. code:: python
+
+            from hazelcast import HazelcastClient
+            from hazelcast.config import Config
+
+            config = Config()
+            config.cluster_name = "a-cluster"
+            client = HazelcastClient(config)
+
+        - passing configuration options as keyword arguments
+
+        .. code:: python
+
+            from hazelcast import HazelcastClient
+
+            client = HazelcastClient(
+                cluster_name="a-cluster",
+            )
+
+
+        See the :class:`hazelcast.config.Config` documentation for the possible
+        configuration options.
+
+        Args:
+            config: Optional configuration object.
+            **kwargs: Optional keyword arguments of the client configuration.
+        """
+        if config:
+            if kwargs:
+                raise InvalidConfigurationError(
+                    "Ambiguous client configuration is found. Either provide "
+                    "the ``config`` object as the only parameter, or do not "
+                    "pass it and use keyword arguments to configure the "
+                    "client."
+                )
+        else:
+            config = Config.from_dict(kwargs)
+
         self._config = config
         self._context = _ClientContext()
         client_id = HazelcastClient._CLIENT_ID.get_and_increment()

--- a/hazelcast/config.py
+++ b/hazelcast/config.py
@@ -272,6 +272,7 @@ _DEFAULT_STATISTICS_PERIOD = 3.0
 _DEFAULT_OPERATION_BACKUP_TIMEOUT = 5.0
 
 _MembershipListenerType = typing.Optional[typing.Callable[[MemberInfo], None]]
+_Numeric = typing.Union[int, float]
 
 
 class Config:
@@ -338,7 +339,7 @@ class Config:
         self._cluster_members: typing.List[str] = []
         self._cluster_name: str = _DEFAULT_CLUSTER_NAME
         self._client_name: typing.Optional[str] = None
-        self._connection_timeout: float = _DEFAULT_CONNECTION_TIMEOUT
+        self._connection_timeout: _Numeric = _DEFAULT_CONNECTION_TIMEOUT
         self._socket_options: typing.List[typing.Tuple[int, int, typing.Union[int, bytes]]] = []
         self._redo_operation: bool = False
         self._smart_routing: bool = True
@@ -355,11 +356,11 @@ class Config:
         self._cloud_discovery_token: typing.Optional[str] = None
         self._async_start: bool = False
         self._reconnect_mode: int = ReconnectMode.ON
-        self._retry_initial_backoff: float = _DEFAULT_RETRY_INITIAL_BACKOFF
-        self._retry_max_backoff: float = _DEFAULT_RETRY_MAX_BACKOFF
-        self._retry_jitter: float = _DEFAULT_RETRY_JITTER
-        self._retry_multiplier: float = _DEFAULT_RETRY_MULTIPLIER
-        self._cluster_connect_timeout: float = _DEFAULT_CLUSTER_CONNECT_TIMEOUT
+        self._retry_initial_backoff: _Numeric = _DEFAULT_RETRY_INITIAL_BACKOFF
+        self._retry_max_backoff: _Numeric = _DEFAULT_RETRY_MAX_BACKOFF
+        self._retry_jitter: _Numeric = _DEFAULT_RETRY_JITTER
+        self._retry_multiplier: _Numeric = _DEFAULT_RETRY_MULTIPLIER
+        self._cluster_connect_timeout: _Numeric = _DEFAULT_CLUSTER_CONNECT_TIMEOUT
         self._portable_version: int = _DEFAULT_PORTABLE_VERSION
         self._data_serializable_factories: typing.Dict[
             int, typing.Dict[int, typing.Type[IdentifiedDataSerializable]]
@@ -383,15 +384,15 @@ class Config:
         self._flake_id_generators: typing.Dict[str, "FlakeIdGeneratorConfig"] = {}
         self._reliable_topics: typing.Dict[str, "ReliableTopicConfig"] = {}
         self._labels: typing.List[str] = []
-        self._heartbeat_interval: float = _DEFAULT_HEARTBEAT_INTERVAL
-        self._heartbeat_timeout: float = _DEFAULT_HEARTBEAT_TIMEOUT
-        self._invocation_timeout: float = _DEFAULT_INVOCATION_TIMEOUT
-        self._invocation_retry_pause: float = _DEFAULT_INVOCATION_RETRY_PAUSE
+        self._heartbeat_interval: _Numeric = _DEFAULT_HEARTBEAT_INTERVAL
+        self._heartbeat_timeout: _Numeric = _DEFAULT_HEARTBEAT_TIMEOUT
+        self._invocation_timeout: _Numeric = _DEFAULT_INVOCATION_TIMEOUT
+        self._invocation_retry_pause: _Numeric = _DEFAULT_INVOCATION_RETRY_PAUSE
         self._statistics_enabled: bool = False
-        self._statistics_period: float = _DEFAULT_STATISTICS_PERIOD
+        self._statistics_period: _Numeric = _DEFAULT_STATISTICS_PERIOD
         self._shuffle_member_list: bool = True
         self._backup_ack_to_client_enabled: bool = True
-        self._operation_backup_timeout: float = _DEFAULT_OPERATION_BACKUP_TIMEOUT
+        self._operation_backup_timeout: _Numeric = _DEFAULT_OPERATION_BACKUP_TIMEOUT
         self._fail_on_indeterminate_operation_state: bool = False
         self._creds_username: typing.Optional[str] = None
         self._creds_password: typing.Optional[str] = None
@@ -451,7 +452,7 @@ class Config:
         self._client_name = value
 
     @property
-    def connection_timeout(self) -> float:
+    def connection_timeout(self) -> _Numeric:
         """Socket timeout value in seconds for the client to connect member
         nodes.
 
@@ -461,7 +462,7 @@ class Config:
         return self._connection_timeout
 
     @connection_timeout.setter
-    def connection_timeout(self, value: float):
+    def connection_timeout(self, value: _Numeric):
         if not isinstance(value, number_types):
             raise TypeError("connection_timeout must be a number")
 
@@ -661,9 +662,9 @@ class Config:
 
     @property
     def cloud_discovery_token(self) -> typing.Optional[str]:
-        """Discovery token of the Hazelcast Cloud cluster.
+        """Discovery token of the Hazelcast Viridian cluster.
 
-        When this value is set, Hazelcast Cloud discovery is enabled.
+        When this value is set, Hazelcast Viridian discovery is enabled.
         """
         return self._cloud_discovery_token
 
@@ -707,7 +708,7 @@ class Config:
         self._reconnect_mode = try_to_get_enum_value(value, ReconnectMode)
 
     @property
-    def retry_initial_backoff(self) -> float:
+    def retry_initial_backoff(self) -> _Numeric:
         """Wait period in seconds after the first failure before retrying.
 
         Must be non-negative. By default, set to ``1.0``.
@@ -715,7 +716,7 @@ class Config:
         return self._retry_initial_backoff
 
     @retry_initial_backoff.setter
-    def retry_initial_backoff(self, value: float) -> None:
+    def retry_initial_backoff(self, value: _Numeric) -> None:
         if not isinstance(value, number_types):
             raise TypeError("retry_initial_backoff must be a number")
 
@@ -725,7 +726,7 @@ class Config:
         self._retry_initial_backoff = value
 
     @property
-    def retry_max_backoff(self) -> float:
+    def retry_max_backoff(self) -> _Numeric:
         """Upper bound for the backoff interval in seconds.
 
         Must be non-negative. By default, set to ``30.0``.
@@ -733,7 +734,7 @@ class Config:
         return self._retry_max_backoff
 
     @retry_max_backoff.setter
-    def retry_max_backoff(self, value: float) -> None:
+    def retry_max_backoff(self, value: _Numeric) -> None:
         if not isinstance(value, number_types):
             raise TypeError("retry_max_backoff must be a number")
 
@@ -743,7 +744,7 @@ class Config:
         self._retry_max_backoff = value
 
     @property
-    def retry_jitter(self) -> float:
+    def retry_jitter(self) -> _Numeric:
         """Defines how much to randomize backoffs.
 
         At each iteration the calculated back-off is randomized via following
@@ -757,7 +758,7 @@ class Config:
         return self._retry_jitter
 
     @retry_jitter.setter
-    def retry_jitter(self, value: float) -> None:
+    def retry_jitter(self, value: _Numeric) -> None:
         if not isinstance(value, number_types):
             raise TypeError("retry_jitter must be a number")
 
@@ -767,7 +768,7 @@ class Config:
         self._retry_jitter = value
 
     @property
-    def retry_multiplier(self) -> float:
+    def retry_multiplier(self) -> _Numeric:
         """The factor with which to multiply backoff after a failed retry.
 
         Must be greater than or equal to ``1``. By default, set to ``1.05``.
@@ -775,7 +776,7 @@ class Config:
         return self._retry_multiplier
 
     @retry_multiplier.setter
-    def retry_multiplier(self, value: float) -> None:
+    def retry_multiplier(self, value: _Numeric) -> None:
         if not isinstance(value, number_types):
             raise TypeError("retry_multiplier must be a number")
 
@@ -785,7 +786,7 @@ class Config:
         self._retry_multiplier = value
 
     @property
-    def cluster_connect_timeout(self) -> float:
+    def cluster_connect_timeout(self) -> _Numeric:
         """Timeout value in seconds for the client to give up connecting to
         the cluster.
 
@@ -796,7 +797,7 @@ class Config:
         return self._cluster_connect_timeout
 
     @cluster_connect_timeout.setter
-    def cluster_connect_timeout(self, value: float) -> None:
+    def cluster_connect_timeout(self, value: _Numeric) -> None:
         if not isinstance(value, number_types):
             raise TypeError("cluster_connect_timeout must be a number")
 
@@ -1277,7 +1278,7 @@ class Config:
         self._labels = value
 
     @property
-    def heartbeat_interval(self) -> float:
+    def heartbeat_interval(self) -> _Numeric:
         """Time interval between the heartbeats sent by the client to the
         member nodes in seconds.
 
@@ -1286,7 +1287,7 @@ class Config:
         return self._heartbeat_interval
 
     @heartbeat_interval.setter
-    def heartbeat_interval(self, value: float) -> None:
+    def heartbeat_interval(self, value: _Numeric) -> None:
         if not isinstance(value, number_types):
             raise TypeError("heartbeat_interval must be a number")
 
@@ -1296,7 +1297,7 @@ class Config:
         self._heartbeat_interval = value
 
     @property
-    def heartbeat_timeout(self) -> float:
+    def heartbeat_timeout(self) -> _Numeric:
         """If there is no message passing between the client and a member
         within the given time via this property in seconds, the connection
         will be closed.
@@ -1306,7 +1307,7 @@ class Config:
         return self._heartbeat_timeout
 
     @heartbeat_timeout.setter
-    def heartbeat_timeout(self, value: float) -> None:
+    def heartbeat_timeout(self, value: _Numeric) -> None:
         if not isinstance(value, number_types):
             raise TypeError("heartbeat_timeout must be a number")
 
@@ -1316,7 +1317,7 @@ class Config:
         self._heartbeat_timeout = value
 
     @property
-    def invocation_timeout(self) -> float:
+    def invocation_timeout(self) -> _Numeric:
         """When an invocation gets an exception because
 
         - Member throws an exception.
@@ -1335,7 +1336,7 @@ class Config:
         return self._invocation_timeout
 
     @invocation_timeout.setter
-    def invocation_timeout(self, value: float) -> None:
+    def invocation_timeout(self, value: _Numeric) -> None:
         if not isinstance(value, number_types):
             raise TypeError("invocation_timeout must be a number")
 
@@ -1345,7 +1346,7 @@ class Config:
         self._invocation_timeout = value
 
     @property
-    def invocation_retry_pause(self) -> float:
+    def invocation_retry_pause(self) -> _Numeric:
         """Pause time between each retry cycle of an invocation in seconds.
 
         By default, set to ``1.0``.
@@ -1353,7 +1354,7 @@ class Config:
         return self._invocation_retry_pause
 
     @invocation_retry_pause.setter
-    def invocation_retry_pause(self, value: float) -> None:
+    def invocation_retry_pause(self, value: _Numeric) -> None:
         if not isinstance(value, number_types):
             raise TypeError("invocation_retry_pause must be a number")
 
@@ -1378,12 +1379,12 @@ class Config:
         self._statistics_enabled = value
 
     @property
-    def statistics_period(self) -> float:
+    def statistics_period(self) -> _Numeric:
         """The period in seconds the statistics run."""
         return self._statistics_period
 
     @statistics_period.setter
-    def statistics_period(self, value: float) -> None:
+    def statistics_period(self, value: _Numeric) -> None:
         if not isinstance(value, number_types):
             raise TypeError("statistics_period must be a number")
 
@@ -1431,7 +1432,7 @@ class Config:
         self._backup_ack_to_client_enabled = value
 
     @property
-    def operation_backup_timeout(self) -> float:
+    def operation_backup_timeout(self) -> _Numeric:
         """If an operation has backups, defines how long the invocation will
         wait for acks from the backup replicas in seconds.
 
@@ -1443,7 +1444,7 @@ class Config:
         return self._operation_backup_timeout
 
     @operation_backup_timeout.setter
-    def operation_backup_timeout(self, value: float) -> None:
+    def operation_backup_timeout(self, value: _Numeric) -> None:
         if not isinstance(value, number_types):
             raise TypeError("operation_backup_timeout must be a number")
 
@@ -1572,12 +1573,12 @@ class NearCacheConfig:
     def __init__(self):
         self._invalidate_on_change: bool = True
         self._in_memory_format: int = InMemoryFormat.BINARY
-        self._time_to_live: typing.Optional[float] = None
-        self._max_idle: typing.Optional[float] = None
+        self._time_to_live: typing.Optional[_Numeric] = None
+        self._max_idle: typing.Optional[_Numeric] = None
         self._eviction_policy: int = EvictionPolicy.LRU
-        self._eviction_max_size: float = 10000
-        self._eviction_sampling_count: float = 8
-        self._eviction_sampling_pool_size: float = 16
+        self._eviction_max_size: int = 10000
+        self._eviction_sampling_count: int = 8
+        self._eviction_sampling_pool_size: int = 16
 
     @property
     def invalidate_on_change(self) -> bool:
@@ -1612,7 +1613,7 @@ class NearCacheConfig:
         self._in_memory_format = try_to_get_enum_value(value, InMemoryFormat)
 
     @property
-    def time_to_live(self) -> typing.Optional[float]:
+    def time_to_live(self) -> typing.Optional[_Numeric]:
         """Maximum number of seconds that an entry can stay in cache.
 
         When not set, entries won't be evicted due to expiration.
@@ -1620,7 +1621,7 @@ class NearCacheConfig:
         return self._time_to_live
 
     @time_to_live.setter
-    def time_to_live(self, value: float) -> None:
+    def time_to_live(self, value: _Numeric) -> None:
         if not isinstance(value, number_types):
             raise TypeError("time_to_live must be a number")
 
@@ -1630,7 +1631,7 @@ class NearCacheConfig:
         self._time_to_live = value
 
     @property
-    def max_idle(self) -> typing.Optional[float]:
+    def max_idle(self) -> typing.Optional[_Numeric]:
         """Maximum number of seconds that an entry can stay in the Near Cache
         until it is accessed.
 
@@ -1639,7 +1640,7 @@ class NearCacheConfig:
         return self._max_idle
 
     @max_idle.setter
-    def max_idle(self, value: float) -> None:
+    def max_idle(self, value: _Numeric) -> None:
         if not isinstance(value, number_types):
             raise TypeError("max_idle must be a number")
 
@@ -1663,7 +1664,7 @@ class NearCacheConfig:
         self._eviction_policy = try_to_get_enum_value(value, EvictionPolicy)
 
     @property
-    def eviction_max_size(self) -> float:
+    def eviction_max_size(self) -> int:
         """Defines maximum number of entries kept in the memory before
         eviction kicks in.
 
@@ -1672,9 +1673,9 @@ class NearCacheConfig:
         return self._eviction_max_size
 
     @eviction_max_size.setter
-    def eviction_max_size(self, value: float):
-        if not isinstance(value, number_types):
-            raise TypeError("eviction_max_size must be a number")
+    def eviction_max_size(self, value: int):
+        if not isinstance(value, int):
+            raise TypeError("eviction_max_size must be an int")
 
         if value < 1:
             raise ValueError("eviction_max_size must be greater than 1")
@@ -1682,7 +1683,7 @@ class NearCacheConfig:
         self._eviction_max_size = value
 
     @property
-    def eviction_sampling_count(self) -> float:
+    def eviction_sampling_count(self) -> int:
         """Number of random entries that are evaluated to see if some of them
         are already expired.
 
@@ -1691,9 +1692,9 @@ class NearCacheConfig:
         return self._eviction_sampling_count
 
     @eviction_sampling_count.setter
-    def eviction_sampling_count(self, value: float) -> None:
-        if not isinstance(value, number_types):
-            raise TypeError("eviction_sampling_count must be a number")
+    def eviction_sampling_count(self, value: int) -> None:
+        if not isinstance(value, int):
+            raise TypeError("eviction_sampling_count must be an int")
 
         if value < 1:
             raise ValueError("eviction_sampling_count must be greater than 1")
@@ -1701,7 +1702,7 @@ class NearCacheConfig:
         self._eviction_sampling_count = value
 
     @property
-    def eviction_sampling_pool_size(self) -> float:
+    def eviction_sampling_pool_size(self) -> int:
         """Size of the pool for eviction candidates.
 
         The pool is kept sorted  according to the eviction policy. By default,
@@ -1710,9 +1711,9 @@ class NearCacheConfig:
         return self._eviction_sampling_pool_size
 
     @eviction_sampling_pool_size.setter
-    def eviction_sampling_pool_size(self, value: float) -> None:
-        if not isinstance(value, number_types):
-            raise TypeError("eviction_sampling_pool_size must be a number")
+    def eviction_sampling_pool_size(self, value: int) -> None:
+        if not isinstance(value, int):
+            raise TypeError("eviction_sampling_pool_size must be an int")
 
         if value < 1:
             raise ValueError("eviction_sampling_pool_size must be greater than 1")
@@ -1754,7 +1755,7 @@ class FlakeIdGeneratorConfig:
         self._prefetch_validity = 600
 
     @property
-    def prefetch_count(self) -> float:
+    def prefetch_count(self) -> int:
         """Defines how many IDs are pre-fetched on the background when a new
         flake id is requested from the cluster.
 
@@ -1763,9 +1764,9 @@ class FlakeIdGeneratorConfig:
         return self._prefetch_count
 
     @prefetch_count.setter
-    def prefetch_count(self, value: float) -> None:
-        if not isinstance(value, number_types):
-            raise TypeError("prefetch_count must be a number")
+    def prefetch_count(self, value: int) -> None:
+        if not isinstance(value, int):
+            raise TypeError("prefetch_count must be an int")
 
         if not (0 < value <= 100000):
             raise ValueError("prefetch_count must be in range 1 to 100000")
@@ -1773,7 +1774,7 @@ class FlakeIdGeneratorConfig:
         self._prefetch_count = value
 
     @property
-    def prefetch_validity(self) -> float:
+    def prefetch_validity(self) -> _Numeric:
         """Defines for how long the pre-fetched IDs can be used.
 
         If this time elapsed, a new batch of IDs will be fetched. Time unit is
@@ -1787,7 +1788,7 @@ class FlakeIdGeneratorConfig:
         return self._prefetch_validity
 
     @prefetch_validity.setter
-    def prefetch_validity(self, value):
+    def prefetch_validity(self, value: _Numeric):
         if not isinstance(value, number_types):
             raise TypeError("prefetch_validity must be a number")
 
@@ -1827,11 +1828,11 @@ class ReliableTopicConfig:
     __slots__ = ("_read_batch_size", "_overload_policy")
 
     def __init__(self):
-        self._read_batch_size: float = 10
+        self._read_batch_size: int = 10
         self._overload_policy: int = TopicOverloadPolicy.BLOCK
 
     @property
-    def read_batch_size(self) -> float:
+    def read_batch_size(self) -> int:
         """Number of messages the reliable topic will try to read in batch.
 
         It will get at least one, but if there are more available, then it
@@ -1840,9 +1841,9 @@ class ReliableTopicConfig:
         return self._read_batch_size
 
     @read_batch_size.setter
-    def read_batch_size(self, value: float) -> None:
-        if not isinstance(value, number_types):
-            raise TypeError("read_batch_size must be a number")
+    def read_batch_size(self, value: int) -> None:
+        if not isinstance(value, int):
+            raise TypeError("read_batch_size must be an int")
 
         if value <= 0:
             raise ValueError("read_batch_size must be positive")

--- a/hazelcast/config.py
+++ b/hazelcast/config.py
@@ -2,6 +2,7 @@ import re
 import types
 import typing
 
+from hazelcast.core import MemberInfo
 from hazelcast.errors import InvalidConfigurationError
 from hazelcast.serialization.api import (
     StreamSerializer,
@@ -255,6 +256,1639 @@ class TopicOverloadPolicy:
     """The publish call immediately fails."""
 
 
+_DEFAULT_CLUSTER_NAME = "dev"
+_DEFAULT_CONNECTION_TIMEOUT = 5.0
+_DEFAULT_RETRY_INITIAL_BACKOFF = 1.0
+_DEFAULT_RETRY_MAX_BACKOFF = 30.0
+_DEFAULT_RETRY_JITTER = 0.0
+_DEFAULT_RETRY_MULTIPLIER = 1.05
+_DEFAULT_CLUSTER_CONNECT_TIMEOUT = -1
+_DEFAULT_PORTABLE_VERSION = 0
+_DEFAULT_HEARTBEAT_INTERVAL = 5.0
+_DEFAULT_HEARTBEAT_TIMEOUT = 60.0
+_DEFAULT_INVOCATION_TIMEOUT = 120.0
+_DEFAULT_INVOCATION_RETRY_PAUSE = 1.0
+_DEFAULT_STATISTICS_PERIOD = 3.0
+_DEFAULT_OPERATION_BACKUP_TIMEOUT = 5.0
+
+_MembershipListenerType = typing.Optional[typing.Callable[[MemberInfo], None]]
+
+
+class Config:
+    """Hazelcast client configuration."""
+
+    __slots__ = (
+        "_cluster_members",
+        "_cluster_name",
+        "_client_name",
+        "_connection_timeout",
+        "_socket_options",
+        "_redo_operation",
+        "_smart_routing",
+        "_ssl_enabled",
+        "_ssl_cafile",
+        "_ssl_certfile",
+        "_ssl_keyfile",
+        "_ssl_password",
+        "_ssl_protocol",
+        "_ssl_ciphers",
+        "_ssl_check_hostname",
+        "_cloud_discovery_token",
+        "_async_start",
+        "_reconnect_mode",
+        "_retry_initial_backoff",
+        "_retry_max_backoff",
+        "_retry_jitter",
+        "_retry_multiplier",
+        "_cluster_connect_timeout",
+        "_portable_version",
+        "_data_serializable_factories",
+        "_portable_factories",
+        "_compact_serializers",
+        "_class_definitions",
+        "_check_class_definition_errors",
+        "_is_big_endian",
+        "_default_int_type",
+        "_global_serializer",
+        "_custom_serializers",
+        "_near_caches",
+        "_load_balancer",
+        "_membership_listeners",
+        "_lifecycle_listeners",
+        "_flake_id_generators",
+        "_reliable_topics",
+        "_labels",
+        "_heartbeat_interval",
+        "_heartbeat_timeout",
+        "_invocation_timeout",
+        "_invocation_retry_pause",
+        "_statistics_enabled",
+        "_statistics_period",
+        "_shuffle_member_list",
+        "_backup_ack_to_client_enabled",
+        "_operation_backup_timeout",
+        "_fail_on_indeterminate_operation_state",
+        "_creds_username",
+        "_creds_password",
+        "_token_provider",
+        "_use_public_ip",
+    )
+
+    def __init__(self):
+        self._cluster_members: typing.List[str] = []
+        self._cluster_name: str = _DEFAULT_CLUSTER_NAME
+        self._client_name: typing.Optional[str] = None
+        self._connection_timeout: float = _DEFAULT_CONNECTION_TIMEOUT
+        self._socket_options: typing.List[typing.Tuple[int, int, typing.Union[int, bytes]]] = []
+        self._redo_operation: bool = False
+        self._smart_routing: bool = True
+        self._ssl_enabled: bool = False
+        self._ssl_cafile: typing.Optional[str] = None
+        self._ssl_certfile: typing.Optional[str] = None
+        self._ssl_keyfile: typing.Optional[str] = None
+        self._ssl_password: typing.Optional[
+            typing.Union[typing.Callable[[], typing.Union[str, bytes]], str, bytes]
+        ] = None
+        self._ssl_protocol: int = SSLProtocol.TLSv1_2
+        self._ssl_ciphers: typing.Optional[str] = None
+        self._ssl_check_hostname: bool = False
+        self._cloud_discovery_token: typing.Optional[str] = None
+        self._async_start: bool = False
+        self._reconnect_mode: int = ReconnectMode.ON
+        self._retry_initial_backoff: float = _DEFAULT_RETRY_INITIAL_BACKOFF
+        self._retry_max_backoff: float = _DEFAULT_RETRY_MAX_BACKOFF
+        self._retry_jitter: float = _DEFAULT_RETRY_JITTER
+        self._retry_multiplier: float = _DEFAULT_RETRY_MULTIPLIER
+        self._cluster_connect_timeout: float = _DEFAULT_CLUSTER_CONNECT_TIMEOUT
+        self._portable_version: int = _DEFAULT_PORTABLE_VERSION
+        self._data_serializable_factories: typing.Dict[
+            int, typing.Dict[int, typing.Type[IdentifiedDataSerializable]]
+        ] = {}
+        self._portable_factories: typing.Dict[int, typing.Dict[int, typing.Type[Portable]]] = {}
+        self._compact_serializers: typing.List[CompactSerializer] = []
+        self._class_definitions: typing.List[ClassDefinition] = []
+        self._check_class_definition_errors: bool = True
+        self._is_big_endian: bool = True
+        self._default_int_type: int = IntType.INT
+        self._global_serializer: typing.Optional[typing.Type[StreamSerializer]] = None
+        self._custom_serializers: typing.Dict[
+            typing.Type[typing.Any], typing.Type[StreamSerializer]
+        ] = {}
+        self._near_caches: typing.Dict[str, "NearCacheConfig"] = {}
+        self._load_balancer: typing.Optional[LoadBalancer] = None
+        self._membership_listeners: typing.List[
+            typing.Tuple[_MembershipListenerType, _MembershipListenerType]
+        ] = []
+        self._lifecycle_listeners: typing.List[typing.Callable[[str], None]] = []
+        self._flake_id_generators: typing.Dict[str, "FlakeIdGeneratorConfig"] = {}
+        self._reliable_topics: typing.Dict[str, "ReliableTopicConfig"] = {}
+        self._labels: typing.List[str] = []
+        self._heartbeat_interval: float = _DEFAULT_HEARTBEAT_INTERVAL
+        self._heartbeat_timeout: float = _DEFAULT_HEARTBEAT_TIMEOUT
+        self._invocation_timeout: float = _DEFAULT_INVOCATION_TIMEOUT
+        self._invocation_retry_pause: float = _DEFAULT_INVOCATION_RETRY_PAUSE
+        self._statistics_enabled: bool = False
+        self._statistics_period: float = _DEFAULT_STATISTICS_PERIOD
+        self._shuffle_member_list: bool = True
+        self._backup_ack_to_client_enabled: bool = True
+        self._operation_backup_timeout: float = _DEFAULT_OPERATION_BACKUP_TIMEOUT
+        self._fail_on_indeterminate_operation_state: bool = False
+        self._creds_username: typing.Optional[str] = None
+        self._creds_password: typing.Optional[str] = None
+        self._token_provider: typing.Optional[TokenProvider] = None
+        self._use_public_ip: bool = False
+
+    @property
+    def cluster_members(self) -> typing.List[str]:
+        """Candidate address list that the client will use to establish
+        initial connection.
+
+        By default, set to ``["127.0.0.1"]``.
+        """
+        return self._cluster_members
+
+    @cluster_members.setter
+    def cluster_members(self, value: typing.List[str]) -> None:
+        if not isinstance(value, list):
+            raise TypeError("cluster_members must be a list")
+
+        for address in value:
+            if not isinstance(address, str):
+                raise TypeError("cluster_members must be list of strings")
+
+        self._cluster_members = value
+
+    @property
+    def cluster_name(self) -> str:
+        """Name of the cluster to connect to.
+
+        The name is sent as part of the client authentication message and may
+        be verified on the member. By default, set to ``dev``.
+        """
+        return self._cluster_name
+
+    @cluster_name.setter
+    def cluster_name(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError("cluster_name must be a string")
+
+        self._cluster_name = value
+
+    @property
+    def client_name(self) -> typing.Optional[str]:
+        """Name of the client instance.
+
+        By default, set to ``hz.client_${CLIENT_ID}``, where ``CLIENT_ID``
+        starts from ``0`` and it is incremented by ``1`` for each new client.
+        """
+        return self._client_name
+
+    @client_name.setter
+    def client_name(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError("client_name must be a string")
+
+        self._client_name = value
+
+    @property
+    def connection_timeout(self) -> float:
+        """Socket timeout value in seconds for the client to connect member
+        nodes.
+
+        Setting this to ``0`` makes the connection blocking. By default, set
+        to ``5.0``.
+        """
+        return self._connection_timeout
+
+    @connection_timeout.setter
+    def connection_timeout(self, value: float):
+        if not isinstance(value, number_types):
+            raise TypeError("connection_timeout must be a number")
+
+        if value < 0:
+            raise ValueError("connection_timeout must be non-negative")
+
+        self._connection_timeout = value
+
+    @property
+    def socket_options(self) -> typing.List[typing.Tuple[int, int, typing.Union[int, bytes]]]:
+        """List of socket option tuples.
+
+        The tuples must contain the parameters passed into the
+        :func:`socket.setsockopt` in the same order.
+        """
+        return self._socket_options
+
+    @socket_options.setter
+    def socket_options(
+        self, value: typing.List[typing.Tuple[int, int, typing.Union[int, bytes]]]
+    ) -> None:
+        if not isinstance(value, list):
+            raise TypeError("socket_options must be a list")
+
+        for options in value:
+            if not isinstance(options, tuple) or len(options) != 3:
+                raise TypeError("socket_options must contain tuples of length 3 as items")
+
+        self._socket_options = value
+
+    @property
+    def redo_operation(self) -> bool:
+        """When set to ``True``, the client will redo the operations that
+        were executing on the server in case if the client lost connection.
+
+        This can happen because of network problems, or simply because the
+        member died. However, it is not clear whether the operation was
+        performed or not. For idempotent operations this is harmless, but for
+        non-idempotent ones retrying can cause to undesirable effects. Note
+        that the redo can be processed on any member. By default, set to
+        ``False``.
+        """
+        return self._redo_operation
+
+    @redo_operation.setter
+    def redo_operation(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError("redo_operation must be a boolean")
+
+        self._redo_operation = value
+
+    @property
+    def smart_routing(self) -> bool:
+        """Enables smart mode for the client instead of unisocket client.
+
+        Smart clients send key based operations to owner of the keys.
+        Unisocket clients send all operations to a single node. By default,
+        set to ``True``.
+        """
+        return self._smart_routing
+
+    @smart_routing.setter
+    def smart_routing(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError("smart_routing must be a boolean")
+
+        self._smart_routing = value
+
+    @property
+    def ssl_enabled(self) -> bool:
+        """If it is ``True``, SSL is enabled.
+
+        By default, set to ``False``.
+        """
+        return self._ssl_enabled
+
+    @ssl_enabled.setter
+    def ssl_enabled(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError("ssl_enabled must be a boolean")
+
+        self._ssl_enabled = value
+
+    @property
+    def ssl_cafile(self) -> typing.Optional[str]:
+        """Absolute path of concatenated CA certificates used to validate
+        server's certificates in PEM format.
+
+        When SSL is enabled and ``cafile`` is not set, a set of default CA
+        certificates from default locations will be used.
+        """
+        return self._ssl_cafile
+
+    @ssl_cafile.setter
+    def ssl_cafile(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError("ssl_cafile must be a string")
+
+        self._ssl_cafile = value
+
+    @property
+    def ssl_certfile(self) -> typing.Optional[str]:
+        """Absolute path of the client certificate in PEM format."""
+        return self._ssl_certfile
+
+    @ssl_certfile.setter
+    def ssl_certfile(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError("ssl_certfile must be a string")
+
+        self._ssl_certfile = value
+
+    @property
+    def ssl_keyfile(self) -> typing.Optional[str]:
+        """Absolute path of the private key file for the client certificate in
+        the PEM format.
+
+        If this parameter is ``None``, private key will be taken from the
+        ``certfile``.
+        """
+        return self._ssl_keyfile
+
+    @ssl_keyfile.setter
+    def ssl_keyfile(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError("ssl_keyfile must be a string")
+
+        self._ssl_keyfile = value
+
+    @property
+    def ssl_password(
+        self,
+    ) -> typing.Optional[typing.Union[typing.Callable[[], typing.Union[str, bytes]], str, bytes]]:
+        """Password for decrypting the keyfile if it is encrypted.
+
+        The password may be a function to call to get the password. It will be
+        called with no arguments, and it should return a string, bytes, or
+        bytearray. If the return value is a string it will be encoded as UTF-8
+        before using it to decrypt the key. Alternatively a string, bytes, or
+        bytearray value may be supplied directly as the password.
+        """
+        return self._ssl_password
+
+    @ssl_password.setter
+    def ssl_password(
+        self, value: typing.Union[typing.Callable[[], typing.Union[str, bytes]], str, bytes]
+    ) -> None:
+        if not isinstance(value, (str, bytes)) and not callable(value):
+            raise TypeError("ssl_password must be string, bytes, or callable")
+
+        self._ssl_password = value
+
+    @property
+    def ssl_protocol(self) -> int:
+        """Protocol version used in SSL communication.
+
+        By default, set to ``TLSv1_2``. See the
+        :class:`hazelcast.config.SSLProtocol` for possible values.
+        """
+        return self._ssl_protocol
+
+    @ssl_protocol.setter
+    def ssl_protocol(self, value: typing.Union[str, int]) -> None:
+        self._ssl_protocol = try_to_get_enum_value(value, SSLProtocol)
+
+    @property
+    def ssl_ciphers(self) -> typing.Optional[str]:
+        """String in the OpenSSL cipher list format to set the available
+        ciphers for sockets.
+
+        More than one cipher can be set by separating them with a colon.
+        """
+        return self._ssl_ciphers
+
+    @ssl_ciphers.setter
+    def ssl_ciphers(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError("ssl_ciphers must be a string")
+
+        self._ssl_ciphers = value
+
+    @property
+    def ssl_check_hostname(self) -> bool:
+        """When set to ``True``, verifies that the hostname in the member's
+        certificate and the address of the member matches during the handshake.
+
+        By default, set to ``False``.
+        """
+        return self._ssl_check_hostname
+
+    @ssl_check_hostname.setter
+    def ssl_check_hostname(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError("ssl_check_hostname must be a boolean")
+
+        self._ssl_check_hostname = value
+
+    @property
+    def cloud_discovery_token(self) -> typing.Optional[str]:
+        """Discovery token of the Hazelcast Cloud cluster.
+
+        When this value is set, Hazelcast Cloud discovery is enabled.
+        """
+        return self._cloud_discovery_token
+
+    @cloud_discovery_token.setter
+    def cloud_discovery_token(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError("cloud_discovery_token must be a string")
+
+        self._cloud_discovery_token = value
+
+    @property
+    def async_start(self) -> bool:
+        """Enables non-blocking start mode of the client.
+
+        When set to ``True``, the client creation will not wait to connect to
+        cluster. The client instance will throw exceptions until it connects
+        to cluster and becomes ready. If set to ``False``, the client will
+        block until a cluster connection established, and it is ready to use
+        the client instance. By default, set to ``False``.
+        """
+        return self._async_start
+
+    @async_start.setter
+    def async_start(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError("async_start must be a boolean")
+
+        self._async_start = value
+
+    @property
+    def reconnect_mode(self) -> int:
+        """Defines how the client reconnects to cluster after a disconnect.
+
+        By default, set to ``ON``. See the
+        :class:`hazelcast.config.ReconnectMode` for possible values.
+        """
+        return self._reconnect_mode
+
+    @reconnect_mode.setter
+    def reconnect_mode(self, value: typing.Union[int, str]) -> None:
+        self._reconnect_mode = try_to_get_enum_value(value, ReconnectMode)
+
+    @property
+    def retry_initial_backoff(self) -> float:
+        """Wait period in seconds after the first failure before retrying.
+
+        Must be non-negative. By default, set to ``1.0``.
+        """
+        return self._retry_initial_backoff
+
+    @retry_initial_backoff.setter
+    def retry_initial_backoff(self, value: float) -> None:
+        if not isinstance(value, number_types):
+            raise TypeError("retry_initial_backoff must be a number")
+
+        if value < 0:
+            raise ValueError("retry_initial_backoff must be non-negative")
+
+        self._retry_initial_backoff = value
+
+    @property
+    def retry_max_backoff(self) -> float:
+        """Upper bound for the backoff interval in seconds.
+
+        Must be non-negative. By default, set to ``30.0``.
+        """
+        return self._retry_max_backoff
+
+    @retry_max_backoff.setter
+    def retry_max_backoff(self, value: float) -> None:
+        if not isinstance(value, number_types):
+            raise TypeError("retry_max_backoff must be a number")
+
+        if value < 0:
+            raise ValueError("retry_max_backoff must be non-negative")
+
+        self._retry_max_backoff = value
+
+    @property
+    def retry_jitter(self) -> float:
+        """Defines how much to randomize backoffs.
+
+        At each iteration the calculated back-off is randomized via following
+        method in pseudocode:
+
+        ``Random(-jitter * current_backoff, jitter * current_backoff)``.
+
+        Must be in range ``[0.0, 1.0]``. By default, set to ``0.0`` (no
+        randomization).
+        """
+        return self._retry_jitter
+
+    @retry_jitter.setter
+    def retry_jitter(self, value: float) -> None:
+        if not isinstance(value, number_types):
+            raise TypeError("retry_jitter must be a number")
+
+        if value < 0 or value > 1:
+            raise ValueError("retry_jitter must be in range [0.0, 1.0]")
+
+        self._retry_jitter = value
+
+    @property
+    def retry_multiplier(self) -> float:
+        """The factor with which to multiply backoff after a failed retry.
+
+        Must be greater than or equal to ``1``. By default, set to ``1.05``.
+        """
+        return self._retry_multiplier
+
+    @retry_multiplier.setter
+    def retry_multiplier(self, value: float) -> None:
+        if not isinstance(value, number_types):
+            raise TypeError("retry_multiplier must be a number")
+
+        if value < 1:
+            raise ValueError("retry_multiplier must be greater than or equal to 1.0")
+
+        self._retry_multiplier = value
+
+    @property
+    def cluster_connect_timeout(self) -> float:
+        """Timeout value in seconds for the client to give up connecting to
+        the cluster.
+
+        Must be non-negative or equal to `-1`. By default, set to `-1`. `-1`
+        means that the client will not stop trying to the target cluster.
+        (infinite timeout)
+        """
+        return self._cluster_connect_timeout
+
+    @cluster_connect_timeout.setter
+    def cluster_connect_timeout(self, value: float) -> None:
+        if not isinstance(value, number_types):
+            raise TypeError("cluster_connect_timeout must be a number")
+
+        if value < 0 and value != _DEFAULT_CLUSTER_CONNECT_TIMEOUT:
+            raise ValueError(
+                "cluster_connect_timeout must be non-negative or equal to %s"
+                % _DEFAULT_CLUSTER_CONNECT_TIMEOUT
+            )
+
+        self._cluster_connect_timeout = value
+
+    @property
+    def portable_version(self) -> int:
+        """Default value for the portable version if the class does not have
+        the :func:`get_portable_version` method.
+
+        Portable versions are used to differentiate two versions of the
+        :class:`hazelcast.serialization.api.Portable` classes that have added
+        or removed fields, or fields with different types.
+        """
+        return self._portable_version
+
+    @portable_version.setter
+    def portable_version(self, value: int) -> None:
+        if not isinstance(value, int):
+            raise TypeError("portable_version must be a number")
+
+        if value < 0:
+            raise ValueError("portable_version must be non-negative")
+
+        self._portable_version = value
+
+    @property
+    def data_serializable_factories(
+        self,
+    ) -> typing.Dict[int, typing.Dict[int, typing.Type[IdentifiedDataSerializable]]]:
+        """Dictionary of factory id and corresponding
+        :class:`hazelcast.serialization.api.IdentifiedDataSerializable`
+        factories.
+
+        A factory is simply a dictionary with class id and callable class
+        constructors.
+
+        .. code-block:: python
+
+            FACTORY_ID = 1
+            CLASS_ID = 1
+
+            class SomeSerializable(IdentifiedDataSerializable):
+                # omitting the implementation
+                pass
+
+
+            client = HazelcastClient(data_serializable_factories={
+                FACTORY_ID: {
+                    CLASS_ID: SomeSerializable
+                }
+            })
+        """
+        return self._data_serializable_factories
+
+    @data_serializable_factories.setter
+    def data_serializable_factories(
+        self, value: typing.Dict[int, typing.Dict[int, typing.Type[IdentifiedDataSerializable]]]
+    ) -> None:
+        if not isinstance(value, dict):
+            raise TypeError("data_serializable_factories must be a dict")
+
+        for factory_id, factory in value.items():
+            if not isinstance(factory_id, int):
+                raise TypeError("Keys of data_serializable_factories must be integers")
+
+            if not isinstance(factory, dict):
+                raise TypeError("Values of data_serializable_factories must be dict")
+
+            for class_id, clazz in factory.items():
+                if not isinstance(class_id, int):
+                    raise TypeError(
+                        "Keys of factories of data_serializable_factories must be integers"
+                    )
+
+                if not (isinstance(clazz, type) and issubclass(clazz, IdentifiedDataSerializable)):
+                    raise TypeError(
+                        "Values of factories of data_serializable_factories must be "
+                        "subclasses of IdentifiedDataSerializable"
+                    )
+
+        self._data_serializable_factories = value
+
+    @property
+    def portable_factories(self) -> typing.Dict[int, typing.Dict[int, typing.Type[Portable]]]:
+        """Dictionary of factory id and corresponding
+        :class:`hazelcast.serialization.api.Portable` factories.
+
+        A factory is simply a dictionary with class id and callable class
+        constructors.
+
+        .. code-block:: python
+
+            FACTORY_ID = 2
+            CLASS_ID = 2
+
+            class SomeSerializable(Portable):
+                # omitting the implementation
+                pass
+
+
+            client = HazelcastClient(portable_factories={
+                FACTORY_ID: {
+                    CLASS_ID: SomeSerializable
+                }
+            })
+        """
+        return self._portable_factories
+
+    @portable_factories.setter
+    def portable_factories(
+        self, value: typing.Dict[int, typing.Dict[int, typing.Type[Portable]]]
+    ) -> None:
+        if not isinstance(value, dict):
+            raise TypeError("portable_factories must be a dict")
+
+        for factory_id, factory in value.items():
+            if not isinstance(factory_id, int):
+                raise TypeError("Keys of portable_factories must be integers")
+
+            if not isinstance(factory, dict):
+                raise TypeError("Values of portable_factories must be dict")
+
+            for class_id, clazz in factory.items():
+                if not isinstance(class_id, int):
+                    raise TypeError("Keys of factories of portable_factories must be integers")
+
+                if not (isinstance(clazz, type) and issubclass(clazz, Portable)):
+                    raise TypeError(
+                        "Values of factories of portable_factories must be "
+                        "subclasses of Portable"
+                    )
+
+        self._portable_factories = value
+
+    @property
+    def compact_serializers(self) -> typing.List[CompactSerializer]:
+        """List of Compact serializers.
+
+        .. code-block:: python
+
+            class Foo:
+                pass
+
+            class FooSerializer(CompactSerializer[Foo]):
+                pass
+
+            client = HazelcastClient(
+                compact_serializers=[
+                    FooSerializer(),
+                ],
+            )
+
+        """
+        return self._compact_serializers
+
+    @compact_serializers.setter
+    def compact_serializers(self, value: typing.List[CompactSerializer]) -> None:
+        if not isinstance(value, list):
+            raise TypeError("compact_serializers must be a dict")
+
+        for serializer in value:
+            if not isinstance(serializer, CompactSerializer):
+                raise TypeError("Values of compact_serializers must be CompactSerializer")
+
+        self._compact_serializers = value
+
+    @property
+    def class_definitions(self) -> typing.List[ClassDefinition]:
+        """List of all portable class definitions."""
+        return self._class_definitions
+
+    @class_definitions.setter
+    def class_definitions(self, value: typing.List[ClassDefinition]) -> None:
+        if not isinstance(value, list):
+            raise TypeError("class_definitions must be a list")
+
+        for cd in value:
+            if not isinstance(cd, ClassDefinition):
+                raise TypeError("class_definitions must contain objects of type ClassDefinition")
+
+        self._class_definitions = value
+
+    @property
+    def check_class_definition_errors(self) -> bool:
+        """When enabled, serialization system will check for class definition
+        errors at start and throw an
+        :class:`hazelcast.errors.HazelcastSerializationError` with error
+        definition.
+
+        By default, set to ``True``.
+        """
+        return self._check_class_definition_errors
+
+    @check_class_definition_errors.setter
+    def check_class_definition_errors(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError("check_class_definition_errors must be a boolean")
+
+        self._check_class_definition_errors = value
+
+    @property
+    def is_big_endian(self) -> bool:
+        """Defines if big-endian is used as the byte order for the
+        serialization.
+
+        By default, set to ``True``.
+        """
+        return self._is_big_endian
+
+    @is_big_endian.setter
+    def is_big_endian(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError("is_big_endian must be a boolean")
+
+        self._is_big_endian = value
+
+    @property
+    def default_int_type(self) -> int:
+        """Defines how the ``int`` type is represented on the member side.
+
+        By default, it is serialized as ``INT`` (``32`` bits). See the
+        :class:`hazelcast.config.IntType` for possible values.
+        """
+        return self._default_int_type
+
+    @default_int_type.setter
+    def default_int_type(self, value: typing.Union[int, str]) -> None:
+        self._default_int_type = try_to_get_enum_value(value, IntType)
+
+    @property
+    def global_serializer(self) -> typing.Optional[typing.Type[StreamSerializer]]:
+        """Defines the global serializer.
+
+        This serializer is registered as a fallback serializer to handle all
+        other objects if a serializer cannot be located for them.
+        """
+        return self._global_serializer
+
+    @global_serializer.setter
+    def global_serializer(self, value: typing.Type[StreamSerializer]) -> None:
+        if not isinstance(value, type) or not issubclass(value, StreamSerializer):
+            raise TypeError("global_serializer must be a StreamSerializer")
+
+        self._global_serializer = value
+
+    @property
+    def custom_serializers(
+        self,
+    ) -> typing.Dict[typing.Type[typing.Any], typing.Type[StreamSerializer]]:
+        """Dictionary of class and the corresponding custom serializers.
+
+        .. code-block:: python
+
+            class SomeClass:
+                # omitting the implementation
+                pass
+
+
+            class SomeClassSerializer(StreamSerializer):
+                # omitting the implementation
+                pass
+
+            client = HazelcastClient(custom_serializers={
+                SomeClass: SomeClassSerializer
+            })
+        """
+        return self._custom_serializers
+
+    @custom_serializers.setter
+    def custom_serializers(
+        self, value: typing.Dict[typing.Type[typing.Any], typing.Type[StreamSerializer]]
+    ) -> None:
+        if not isinstance(value, dict):
+            raise TypeError("custom_serializers must be a dict")
+
+        for _type, serializer in value.items():
+            if not isinstance(_type, type):
+                raise TypeError("Keys of custom_serializers must be types")
+
+            if not (isinstance(serializer, type) and issubclass(serializer, StreamSerializer)):
+                raise TypeError(
+                    "Values of custom_serializers must be subclasses of StreamSerializer"
+                )
+
+        self._custom_serializers = value
+
+    @property
+    def near_caches(self) -> typing.Dict[str, "NearCacheConfig"]:
+        """Dictionary of near cache names to the corresponding near cache
+        configurations.
+
+        See the :class:`hazelcast.config.NearCacheConfig` for the possible
+        configuration options.
+
+        The near cache configuration can also be passed as a dictionary of
+        configuration option name to value. When an option is missing from the
+        dictionary configuration, it will be set to its default value.
+        """
+        return self._near_caches
+
+    @near_caches.setter
+    def near_caches(self, value: typing.Dict[str, "NearCacheConfig"]) -> None:
+        if not isinstance(value, dict):
+            raise TypeError("near_caches must be a dict")
+
+        configs = dict()
+        for name, config in value.items():
+            if not isinstance(name, str):
+                raise TypeError("Keys of near_caches must be strings")
+
+            if not isinstance(config, (dict, NearCacheConfig)):
+                raise TypeError("Values of near_caches must be a NearCacheConfig or a dict")
+
+            if isinstance(config, dict):
+                config = NearCacheConfig.from_dict(config)
+
+            configs[name] = config
+
+        self._near_caches = configs
+
+    @property
+    def load_balancer(self) -> typing.Optional[LoadBalancer]:
+        """Load balancer implementation for the client."""
+        return self._load_balancer
+
+    @load_balancer.setter
+    def load_balancer(self, value: LoadBalancer) -> None:
+        if not isinstance(value, LoadBalancer):
+            raise TypeError("load_balancer must be a LoadBalancer")
+
+        self._load_balancer = value
+
+    @property
+    def membership_listeners(
+        self,
+    ) -> typing.List[typing.Tuple[_MembershipListenerType, _MembershipListenerType]]:
+        """List of membership listener tuples.
+
+        Tuples must be of size ``2``. The first element will be the function
+        to be called when a member is added, and the second element will be
+        the function to be called when the member is removed with the
+        :class:`hazelcast.core.MemberInfo` as the only parameter.
+
+        Any of the elements can be ``None``, but not at the same time.
+        """
+        return self._membership_listeners
+
+    @membership_listeners.setter
+    def membership_listeners(
+        self, value: typing.List[typing.Tuple[_MembershipListenerType, _MembershipListenerType]]
+    ) -> None:
+        if not isinstance(value, list):
+            raise TypeError("membership_listeners must be a list")
+
+        for listener in value:
+            if not isinstance(listener, tuple) or len(listener) != 2:
+                raise TypeError("membership_listeners must contain tuples of length 2 as items")
+
+            added, removed = listener
+
+            if not (callable(added) or callable(removed)):
+                raise TypeError("At least one of the listeners in the tuple most be callable")
+
+        self._membership_listeners = value
+
+    @property
+    def lifecycle_listeners(self) -> typing.List[typing.Callable[[str], None]]:
+        """List of lifecycle listeners.
+
+        Listeners will be called with the new lifecycle state as the only
+        parameter when the client changes lifecycle states.
+        """
+        return self._lifecycle_listeners
+
+    @lifecycle_listeners.setter
+    def lifecycle_listeners(self, value: typing.List[typing.Callable[[str], None]]) -> None:
+        if not isinstance(value, list):
+            raise TypeError("lifecycle_listeners must be a list")
+
+        for listener in value:
+            if not callable(listener):
+                raise TypeError("lifecycle_listeners must contain callable items")
+
+        self._lifecycle_listeners = value
+
+    @property
+    def flake_id_generators(self) -> typing.Dict[str, "FlakeIdGeneratorConfig"]:
+        """Dictionary of flake id generator names to the corresponding flake
+        id generator configurations.
+
+        See the :class:`hazelcast.config.FlakeIdGeneratorConfig` for the
+        possible configuration options.
+
+        The flake id generator configuration can also be passed as a
+        dictionary of configuration option name to value. When an option is
+        missing from the dictionary configuration, it will be set to its
+        default value.
+        """
+        return self._flake_id_generators
+
+    @flake_id_generators.setter
+    def flake_id_generators(self, value: typing.Dict[str, "FlakeIdGeneratorConfig"]) -> None:
+        if not isinstance(value, dict):
+            raise TypeError("flake_id_generators must be a dict")
+
+        configs = dict()
+        for name, config in value.items():
+            if not isinstance(name, str):
+                raise TypeError("Keys of flake_id_generators must be strings")
+
+            if not isinstance(config, (dict, FlakeIdGeneratorConfig)):
+                raise TypeError(
+                    "Values of flake_id_generators must be a FlakeIdGeneratorConfig or a dict"
+                )
+
+            if isinstance(config, dict):
+                config = FlakeIdGeneratorConfig.from_dict(config)
+
+            configs[name] = config
+
+        self._flake_id_generators = configs
+
+    @property
+    def reliable_topics(self) -> typing.Dict[str, "ReliableTopicConfig"]:
+        """Dictionary of reliable topic names to the corresponding reliable
+        topic configurations.
+
+        See the :class:`hazelcast.config.ReliableTopicConfig` for the
+        possible configuration options.
+
+        The reliable topic configuration can also be passed as a dictionary of
+        configuration option name to value. When an option is missing from the
+        dictionary configuration, it will be set to its default value.
+        """
+        return self._reliable_topics
+
+    @reliable_topics.setter
+    def reliable_topics(self, value: typing.Dict[str, "ReliableTopicConfig"]) -> None:
+        if not isinstance(value, dict):
+            raise TypeError("reliable_topics must be a dict")
+
+        configs = {}
+        for name, config in value.items():
+            if not isinstance(name, str):
+                raise TypeError("Keys of reliable_topics must be strings")
+
+            if not isinstance(config, (dict, ReliableTopicConfig)):
+                raise TypeError("Values of reliable_topics must be a ReliableTopicConfig or a dict")
+
+            if isinstance(config, dict):
+                config = ReliableTopicConfig.from_dict(config)
+
+            configs[name] = config
+
+        self._reliable_topics = configs
+
+    @property
+    def labels(self) -> typing.List[str]:
+        """Labels for the client to be sent to the cluster."""
+        return self._labels
+
+    @labels.setter
+    def labels(self, value: typing.List[str]) -> None:
+        if not isinstance(value, list):
+            raise TypeError("labels must be a list")
+
+        for label in value:
+            if not isinstance(label, str):
+                raise TypeError("labels must be list of strings")
+
+        self._labels = value
+
+    @property
+    def heartbeat_interval(self) -> float:
+        """Time interval between the heartbeats sent by the client to the
+        member nodes in seconds.
+
+        By default, set to ``5.0``.
+        """
+        return self._heartbeat_interval
+
+    @heartbeat_interval.setter
+    def heartbeat_interval(self, value: float) -> None:
+        if not isinstance(value, number_types):
+            raise TypeError("heartbeat_interval must be a number")
+
+        if value <= 0:
+            raise ValueError("heartbeat_interval must be positive")
+
+        self._heartbeat_interval = value
+
+    @property
+    def heartbeat_timeout(self) -> float:
+        """If there is no message passing between the client and a member
+        within the given time via this property in seconds, the connection
+        will be closed.
+
+        By default, set to ``60.0``.
+        """
+        return self._heartbeat_timeout
+
+    @heartbeat_timeout.setter
+    def heartbeat_timeout(self, value: float) -> None:
+        if not isinstance(value, number_types):
+            raise TypeError("heartbeat_timeout must be a number")
+
+        if value <= 0:
+            raise ValueError("heartbeat_timeout must be positive")
+
+        self._heartbeat_timeout = value
+
+    @property
+    def invocation_timeout(self) -> float:
+        """When an invocation gets an exception because
+
+        - Member throws an exception.
+        - Connection between the client and member is closed.
+        - The client's heartbeat requests are timed out.
+
+        Time passed since invocation started is compared with this property.
+        If the time is already passed, then the exception is delegated to the
+        user. If not, the invocation is retried. Note that, if invocation gets
+        no exception, and it is a long-running one, then it will not get any
+        exception, no matter how small this timeout is set. Time unit is in
+        seconds.
+
+        By default, set to ``120.0``.
+        """
+        return self._invocation_timeout
+
+    @invocation_timeout.setter
+    def invocation_timeout(self, value: float) -> None:
+        if not isinstance(value, number_types):
+            raise TypeError("invocation_timeout must be a number")
+
+        if value <= 0:
+            raise ValueError("invocation_timeout must be positive")
+
+        self._invocation_timeout = value
+
+    @property
+    def invocation_retry_pause(self) -> float:
+        """Pause time between each retry cycle of an invocation in seconds.
+
+        By default, set to ``1.0``.
+        """
+        return self._invocation_retry_pause
+
+    @invocation_retry_pause.setter
+    def invocation_retry_pause(self, value: float) -> None:
+        if not isinstance(value, number_types):
+            raise TypeError("invocation_retry_pause must be a number")
+
+        if value <= 0:
+            raise ValueError("invocation_retry_pause must be positive")
+
+        self._invocation_retry_pause = value
+
+    @property
+    def statistics_enabled(self) -> bool:
+        """When set to ``True``, the client statistics collection is enabled.
+
+        By default, set to ``False``.
+        """
+        return self._statistics_enabled
+
+    @statistics_enabled.setter
+    def statistics_enabled(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError("statistics_enabled must be a boolean")
+
+        self._statistics_enabled = value
+
+    @property
+    def statistics_period(self) -> float:
+        """The period in seconds the statistics run."""
+        return self._statistics_period
+
+    @statistics_period.setter
+    def statistics_period(self, value: float) -> None:
+        if not isinstance(value, number_types):
+            raise TypeError("statistics_period must be a number")
+
+        if value <= 0:
+            raise ValueError("statistics_period must be positive")
+
+        self._statistics_period = value
+
+    @property
+    def shuffle_member_list(self) -> bool:
+        """The client shuffles the given member list to prevent all clients to
+        connect to the same node when this property is set to ``True``.
+
+        When it is set to ``False``, the client tries to connect to the nodes
+        in the given order.
+
+        By default, set to ``True``.
+        """
+        return self._shuffle_member_list
+
+    @shuffle_member_list.setter
+    def shuffle_member_list(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError("shuffle_member_list must be a boolean")
+
+        self._shuffle_member_list = value
+
+    @property
+    def backup_ack_to_client_enabled(self) -> bool:
+        """Enables the client to get backup acknowledgements directly from the
+        member that backups are applied, which reduces number of hops and
+        increases performance for smart clients.
+
+        This option has no effect for unisocket clients.
+
+        By default, set to ``True`` (enabled).
+        """
+        return self._backup_ack_to_client_enabled
+
+    @backup_ack_to_client_enabled.setter
+    def backup_ack_to_client_enabled(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError("backup_ack_to_client_enabled must be a boolean")
+
+        self._backup_ack_to_client_enabled = value
+
+    @property
+    def operation_backup_timeout(self) -> float:
+        """If an operation has backups, defines how long the invocation will
+        wait for acks from the backup replicas in seconds.
+
+        If acks are not received from some backups, there won't be any
+        rollback on other successful replicas.
+
+        By default, set to ``5.0``.
+        """
+        return self._operation_backup_timeout
+
+    @operation_backup_timeout.setter
+    def operation_backup_timeout(self, value: float) -> None:
+        if not isinstance(value, number_types):
+            raise TypeError("operation_backup_timeout must be a number")
+
+        if value <= 0:
+            raise ValueError("operation_backup_timeout must be positive")
+
+        self._operation_backup_timeout = value
+
+    @property
+    def fail_on_indeterminate_operation_state(self) -> bool:
+        """When enabled, if an operation has sync backups and acks are not
+        received from backup replicas in time, or the member which owns
+        primary replica of the target partition leaves the cluster, then the
+        invocation fails with
+        :class:`hazelcast.errors.IndeterminateOperationStateError`.
+
+        However, even if the invocation fails, there will not be any rollback
+        on other successful replicas.
+
+        By default, set to ``False`` (do not fail).
+        """
+        return self._fail_on_indeterminate_operation_state
+
+    @fail_on_indeterminate_operation_state.setter
+    def fail_on_indeterminate_operation_state(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError("fail_on_indeterminate_operation_state must be a boolean")
+
+        self._fail_on_indeterminate_operation_state = value
+
+    @property
+    def creds_username(self) -> typing.Optional[str]:
+        """Username for credentials authentication (Enterprise feature)."""
+        return self._creds_username
+
+    @creds_username.setter
+    def creds_username(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError("creds_password must be a string")
+
+        self._creds_username = value
+
+    @property
+    def creds_password(self) -> typing.Optional[str]:
+        """Password for credentials authentication (Enterprise feature)."""
+        return self._creds_password
+
+    @creds_password.setter
+    def creds_password(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError("creds_password must be a string")
+
+        self._creds_password = value
+
+    @property
+    def token_provider(self) -> typing.Optional[TokenProvider]:
+        """Token provider for custom authentication (Enterprise feature).
+
+        Note that ``token_provider`` setting has priority over credentials
+        settings.
+        """
+        return self._token_provider
+
+    @token_provider.setter
+    def token_provider(self, value: TokenProvider) -> None:
+        token_fun = getattr(value, "token", None)
+        if token_fun is None or not isinstance(token_fun, types.MethodType):
+            raise TypeError("token_provider must be an object with a token method")
+
+        self._token_provider = value
+
+    @property
+    def use_public_ip(self) -> bool:
+        """When set to ``True``, the client uses the public IP addresses
+        reported by members while connecting to them, if available.
+
+        By default, set to ``False``.
+        """
+        return self._use_public_ip
+
+    @use_public_ip.setter
+    def use_public_ip(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError("use_public_ip must be a boolean")
+
+        self._use_public_ip = value
+
+    @classmethod
+    def from_dict(cls, d: typing.Dict[str, typing.Any]) -> "Config":
+        """Constructs a configuration object out of the given dictionary.
+
+        The dictionary items must be valid pairs of configuration option name
+        to its value.
+
+        If a configuration is missing from the dictionary, the default value
+        for it will be used.
+
+        Args:
+            d: Dictionary that describes the configuration.
+
+        Returns:
+            The constructed configuration object.
+        """
+        config = cls()
+        for k, v in d.items():
+            if v is not None:
+                try:
+                    setattr(config, k, v)
+                except AttributeError:
+                    raise InvalidConfigurationError("Unrecognized config option: %s" % k)
+        return config
+
+
+class NearCacheConfig:
+    __slots__ = (
+        "_invalidate_on_change",
+        "_in_memory_format",
+        "_time_to_live",
+        "_max_idle",
+        "_eviction_policy",
+        "_eviction_max_size",
+        "_eviction_sampling_count",
+        "_eviction_sampling_pool_size",
+    )
+
+    def __init__(self):
+        self._invalidate_on_change: bool = True
+        self._in_memory_format: int = InMemoryFormat.BINARY
+        self._time_to_live: typing.Optional[float] = None
+        self._max_idle: typing.Optional[float] = None
+        self._eviction_policy: int = EvictionPolicy.LRU
+        self._eviction_max_size: float = 10000
+        self._eviction_sampling_count: float = 8
+        self._eviction_sampling_pool_size: float = 16
+
+    @property
+    def invalidate_on_change(self) -> bool:
+        """Enables cluster-assisted invalidate on change behavior.
+
+        When set to ``True``, entries are invalidated when they are changed in
+        cluster.
+
+        By default, set to ``True``.
+        """
+        return self._invalidate_on_change
+
+    @invalidate_on_change.setter
+    def invalidate_on_change(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError("invalidate_on_change must be a boolean")
+
+        self._invalidate_on_change = value
+
+    @property
+    def in_memory_format(self) -> int:
+        """Specifies in which format data will be stored in the Near Cache.
+
+        See the :class:`hazelcast.config.InMemoryFormat` for possible values.
+
+        By default, set to ``BINARY``.
+        """
+        return self._in_memory_format
+
+    @in_memory_format.setter
+    def in_memory_format(self, value: typing.Union[int, str]) -> None:
+        self._in_memory_format = try_to_get_enum_value(value, InMemoryFormat)
+
+    @property
+    def time_to_live(self) -> typing.Optional[float]:
+        """Maximum number of seconds that an entry can stay in cache.
+
+        When not set, entries won't be evicted due to expiration.
+        """
+        return self._time_to_live
+
+    @time_to_live.setter
+    def time_to_live(self, value: float) -> None:
+        if not isinstance(value, number_types):
+            raise TypeError("time_to_live must be a number")
+
+        if value < 0:
+            raise ValueError("time_to_live must be non-negative")
+
+        self._time_to_live = value
+
+    @property
+    def max_idle(self) -> typing.Optional[float]:
+        """Maximum number of seconds that an entry can stay in the Near Cache
+        until it is accessed.
+
+        When not set, entries won't be evicted due to inactivity.
+        """
+        return self._max_idle
+
+    @max_idle.setter
+    def max_idle(self, value: float) -> None:
+        if not isinstance(value, number_types):
+            raise TypeError("max_idle must be a number")
+
+        if value < 0:
+            raise ValueError("max_idle must be non-negative")
+
+        self._max_idle = value
+
+    @property
+    def eviction_policy(self) -> int:
+        """Defines eviction policy configuration.
+
+        See the:class:`hazelcast.config.EvictionPolicy` for possible values.
+
+        By default, set to ``LRU``.
+        """
+        return self._eviction_policy
+
+    @eviction_policy.setter
+    def eviction_policy(self, value: typing.Union[int, str]) -> None:
+        self._eviction_policy = try_to_get_enum_value(value, EvictionPolicy)
+
+    @property
+    def eviction_max_size(self) -> float:
+        """Defines maximum number of entries kept in the memory before
+        eviction kicks in.
+
+        By default, set to ``10000``.
+        """
+        return self._eviction_max_size
+
+    @eviction_max_size.setter
+    def eviction_max_size(self, value: float):
+        if not isinstance(value, number_types):
+            raise TypeError("eviction_max_size must be a number")
+
+        if value < 1:
+            raise ValueError("eviction_max_size must be greater than 1")
+
+        self._eviction_max_size = value
+
+    @property
+    def eviction_sampling_count(self) -> float:
+        """Number of random entries that are evaluated to see if some of them
+        are already expired.
+
+        By default, set to ``8``.
+        """
+        return self._eviction_sampling_count
+
+    @eviction_sampling_count.setter
+    def eviction_sampling_count(self, value: float) -> None:
+        if not isinstance(value, number_types):
+            raise TypeError("eviction_sampling_count must be a number")
+
+        if value < 1:
+            raise ValueError("eviction_sampling_count must be greater than 1")
+
+        self._eviction_sampling_count = value
+
+    @property
+    def eviction_sampling_pool_size(self) -> float:
+        """Size of the pool for eviction candidates.
+
+        The pool is kept sorted  according to the eviction policy. By default,
+        set to ``16``.
+        """
+        return self._eviction_sampling_pool_size
+
+    @eviction_sampling_pool_size.setter
+    def eviction_sampling_pool_size(self, value: float) -> None:
+        if not isinstance(value, number_types):
+            raise TypeError("eviction_sampling_pool_size must be a number")
+
+        if value < 1:
+            raise ValueError("eviction_sampling_pool_size must be greater than 1")
+
+        self._eviction_sampling_pool_size = value
+
+    @classmethod
+    def from_dict(cls, d: typing.Dict[str, typing.Any]) -> "NearCacheConfig":
+        """Constructs a configuration object out of the given dictionary.
+
+        The dictionary items must be valid pairs of configuration option name
+        to its value.
+
+        If a configuration is missing from the dictionary, the default value
+        for it will be used.
+
+        Args:
+            d: Dictionary that describes the configuration.
+
+        Returns:
+            The constructed configuration object.
+        """
+        config = cls()
+        for k, v in d.items():
+            try:
+                setattr(config, k, v)
+            except AttributeError:
+                raise InvalidConfigurationError(
+                    "Unrecognized config option for the near cache: %s" % k
+                )
+        return config
+
+
+class FlakeIdGeneratorConfig:
+    __slots__ = ("_prefetch_count", "_prefetch_validity")
+
+    def __init__(self):
+        self._prefetch_count = 100
+        self._prefetch_validity = 600
+
+    @property
+    def prefetch_count(self) -> float:
+        """Defines how many IDs are pre-fetched on the background when a new
+        flake id is requested from the cluster.
+
+        Should be in the range ``1..100000``. By default, set to ``100``.
+        """
+        return self._prefetch_count
+
+    @prefetch_count.setter
+    def prefetch_count(self, value: float) -> None:
+        if not isinstance(value, number_types):
+            raise TypeError("prefetch_count must be a number")
+
+        if not (0 < value <= 100000):
+            raise ValueError("prefetch_count must be in range 1 to 100000")
+
+        self._prefetch_count = value
+
+    @property
+    def prefetch_validity(self) -> float:
+        """Defines for how long the pre-fetched IDs can be used.
+
+        If this time elapsed, a new batch of IDs will be fetched. Time unit is
+        in seconds. By default, set to ``600`` (10 minutes).
+
+        The IDs contain timestamp component, which ensures rough global
+        ordering of IDs. If an ID is assigned to an object that was created
+        much later, it will be much out of order. If you don't care about
+        ordering, set this value to ``0`` for unlimited ID validity.
+        """
+        return self._prefetch_validity
+
+    @prefetch_validity.setter
+    def prefetch_validity(self, value):
+        if not isinstance(value, number_types):
+            raise TypeError("prefetch_validity must be a number")
+
+        if value < 0:
+            raise ValueError("prefetch_validity must be non-negative")
+
+        self._prefetch_validity = value
+
+    @classmethod
+    def from_dict(cls, d: typing.Dict[str, typing.Any]) -> "FlakeIdGeneratorConfig":
+        """Constructs a configuration object out of the given dictionary.
+
+        The dictionary items must be valid pairs of configuration option name
+        to its value.
+
+        If a configuration is missing from the dictionary, the default value
+        for it will be used.
+
+        Args:
+            d: Dictionary that describes the configuration.
+
+        Returns:
+            The constructed configuration object.
+        """
+        config = cls()
+        for k, v in d.items():
+            try:
+                setattr(config, k, v)
+            except AttributeError:
+                raise InvalidConfigurationError(
+                    "Unrecognized config option for the flake id generator: %s" % k
+                )
+        return config
+
+
+class ReliableTopicConfig:
+    __slots__ = ("_read_batch_size", "_overload_policy")
+
+    def __init__(self):
+        self._read_batch_size: float = 10
+        self._overload_policy: int = TopicOverloadPolicy.BLOCK
+
+    @property
+    def read_batch_size(self) -> float:
+        """Number of messages the reliable topic will try to read in batch.
+
+        It will get at least one, but if there are more available, then it
+        will try to get more to increase throughput. By default, set to ``10``.
+        """
+        return self._read_batch_size
+
+    @read_batch_size.setter
+    def read_batch_size(self, value: float) -> None:
+        if not isinstance(value, number_types):
+            raise TypeError("read_batch_size must be a number")
+
+        if value <= 0:
+            raise ValueError("read_batch_size must be positive")
+
+        self._read_batch_size = value
+
+    @property
+    def overload_policy(self) -> int:
+        """Policy to handle an overloaded topic.
+
+        By default, set to ``BLOCK``. See the
+        :class:`hazelcast.config.TopicOverloadPolicy` for possible values.
+        """
+        return self._overload_policy
+
+    @overload_policy.setter
+    def overload_policy(self, value: typing.Union[int, str]) -> None:
+        self._overload_policy = try_to_get_enum_value(value, TopicOverloadPolicy)
+
+    @classmethod
+    def from_dict(cls, d: typing.Dict[str, typing.Any]) -> "ReliableTopicConfig":
+        """Constructs a configuration object out of the given dictionary.
+
+        The dictionary items must be valid pairs of configuration option name
+        to its value.
+
+        If a configuration is missing from the dictionary, the default value
+        for it will be used.
+
+        Args:
+            d: Dictionary that describes the configuration.
+
+        Returns:
+            The constructed configuration object.
+        """
+        config = cls()
+        for k, v in d.items():
+            try:
+                setattr(config, k, v)
+            except AttributeError:
+                raise InvalidConfigurationError(
+                    "Unrecognized config option for the reliable topic: %s" % k
+                )
+        return config
+
+
 class BitmapIndexOptions:
     __slots__ = ("_unique_key", "_unique_key_transformation")
 
@@ -288,7 +1922,7 @@ class BitmapIndexOptions:
         options = cls()
         for k, v in d.items():
             try:
-                options.__setattr__(k, v)
+                setattr(options, k, v)
             except AttributeError:
                 raise InvalidConfigurationError(
                     "Unrecognized config option for the bitmap index options: %s" % k
@@ -332,10 +1966,10 @@ class IndexConfig:
 
     @name.setter
     def name(self, value):
-        if isinstance(value, str) or value is None:
-            self._name = value
-        else:
+        if not isinstance(value, str) and value is not None:
             raise TypeError("name must be a string or None")
+
+        self._name = value
 
     @property
     def type(self):
@@ -351,12 +1985,13 @@ class IndexConfig:
 
     @attributes.setter
     def attributes(self, value):
-        if isinstance(value, list):
-            for attribute in value:
-                IndexUtil.validate_attribute(attribute)
-            self._attributes = value
-        else:
+        if not isinstance(value, list):
             raise TypeError("attributes must be a list")
+
+        for attribute in value:
+            IndexUtil.validate_attribute(attribute)
+
+        self._attributes = value
 
     @property
     def bitmap_index_options(self):
@@ -378,7 +2013,7 @@ class IndexConfig:
         for k, v in d.items():
             if v is not None:
                 try:
-                    config.__setattr__(k, v)
+                    setattr(config, k, v)
                 except AttributeError:
                     raise InvalidConfigurationError(
                         "Unrecognized config option for the index config: %s" % k
@@ -508,1101 +2143,3 @@ class IndexUtil:
             return "bitmap"
         else:
             raise ValueError("Unsupported index type %s" % index_type)
-
-
-_DEFAULT_CLUSTER_NAME = "dev"
-_DEFAULT_CONNECTION_TIMEOUT = 5.0
-_DEFAULT_RETRY_INITIAL_BACKOFF = 1.0
-_DEFAULT_RETRY_MAX_BACKOFF = 30.0
-_DEFAULT_RETRY_JITTER = 0.0
-_DEFAULT_RETRY_MULTIPLIER = 1.05
-_DEFAULT_CLUSTER_CONNECT_TIMEOUT = -1
-_DEFAULT_PORTABLE_VERSION = 0
-_DEFAULT_HEARTBEAT_INTERVAL = 5.0
-_DEFAULT_HEARTBEAT_TIMEOUT = 60.0
-_DEFAULT_INVOCATION_TIMEOUT = 120.0
-_DEFAULT_INVOCATION_RETRY_PAUSE = 1.0
-_DEFAULT_STATISTICS_PERIOD = 3.0
-_DEFAULT_OPERATION_BACKUP_TIMEOUT = 5.0
-
-
-class _Config:
-    __slots__ = (
-        "_cluster_members",
-        "_cluster_name",
-        "_client_name",
-        "_connection_timeout",
-        "_socket_options",
-        "_redo_operation",
-        "_smart_routing",
-        "_ssl_enabled",
-        "_ssl_cafile",
-        "_ssl_certfile",
-        "_ssl_keyfile",
-        "_ssl_password",
-        "_ssl_protocol",
-        "_ssl_ciphers",
-        "_ssl_check_hostname",
-        "_cloud_discovery_token",
-        "_async_start",
-        "_reconnect_mode",
-        "_retry_initial_backoff",
-        "_retry_max_backoff",
-        "_retry_jitter",
-        "_retry_multiplier",
-        "_cluster_connect_timeout",
-        "_portable_version",
-        "_data_serializable_factories",
-        "_portable_factories",
-        "_class_definitions",
-        "_check_class_definition_errors",
-        "_is_big_endian",
-        "_default_int_type",
-        "_global_serializer",
-        "_custom_serializers",
-        "_near_caches",
-        "_load_balancer",
-        "_membership_listeners",
-        "_lifecycle_listeners",
-        "_flake_id_generators",
-        "_reliable_topics",
-        "_labels",
-        "_heartbeat_interval",
-        "_heartbeat_timeout",
-        "_invocation_timeout",
-        "_invocation_retry_pause",
-        "_statistics_enabled",
-        "_statistics_period",
-        "_shuffle_member_list",
-        "_backup_ack_to_client_enabled",
-        "_operation_backup_timeout",
-        "_fail_on_indeterminate_operation_state",
-        "_creds_username",
-        "_creds_password",
-        "_token_provider",
-        "_use_public_ip",
-        "_compact_serializers",
-    )
-
-    def __init__(self):
-        self._cluster_members = []
-        self._cluster_name = _DEFAULT_CLUSTER_NAME
-        self._client_name = None
-        self._connection_timeout = _DEFAULT_CONNECTION_TIMEOUT
-        self._socket_options = []
-        self._redo_operation = False
-        self._smart_routing = True
-        self._ssl_enabled = False
-        self._ssl_cafile = None
-        self._ssl_certfile = None
-        self._ssl_keyfile = None
-        self._ssl_password = None
-        self._ssl_protocol = SSLProtocol.TLSv1_2
-        self._ssl_ciphers = None
-        self._ssl_check_hostname = False
-        self._cloud_discovery_token = None
-        self._async_start = False
-        self._reconnect_mode = ReconnectMode.ON
-        self._retry_initial_backoff = _DEFAULT_RETRY_INITIAL_BACKOFF
-        self._retry_max_backoff = _DEFAULT_RETRY_MAX_BACKOFF
-        self._retry_jitter = _DEFAULT_RETRY_JITTER
-        self._retry_multiplier = _DEFAULT_RETRY_MULTIPLIER
-        self._cluster_connect_timeout = _DEFAULT_CLUSTER_CONNECT_TIMEOUT
-        self._portable_version = _DEFAULT_PORTABLE_VERSION
-        self._data_serializable_factories = {}
-        self._portable_factories = {}
-        self._class_definitions = []
-        self._check_class_definition_errors = True
-        self._is_big_endian = True
-        self._default_int_type = IntType.INT
-        self._global_serializer = None
-        self._custom_serializers = {}
-        self._near_caches = {}
-        self._load_balancer = None
-        self._membership_listeners = []
-        self._lifecycle_listeners = []
-        self._flake_id_generators = {}
-        self._reliable_topics = {}
-        self._labels = []
-        self._heartbeat_interval = _DEFAULT_HEARTBEAT_INTERVAL
-        self._heartbeat_timeout = _DEFAULT_HEARTBEAT_TIMEOUT
-        self._invocation_timeout = _DEFAULT_INVOCATION_TIMEOUT
-        self._invocation_retry_pause = _DEFAULT_INVOCATION_RETRY_PAUSE
-        self._statistics_enabled = False
-        self._statistics_period = _DEFAULT_STATISTICS_PERIOD
-        self._shuffle_member_list = True
-        self._backup_ack_to_client_enabled = True
-        self._operation_backup_timeout = _DEFAULT_OPERATION_BACKUP_TIMEOUT
-        self._fail_on_indeterminate_operation_state = False
-        self._creds_username = None
-        self._creds_password = None
-        self._token_provider = None
-        self._use_public_ip = False
-        self._compact_serializers: typing.List[CompactSerializer] = []
-
-    @property
-    def cluster_members(self):
-        return self._cluster_members
-
-    @cluster_members.setter
-    def cluster_members(self, value):
-        if isinstance(value, list):
-            for address in value:
-                if not isinstance(address, str):
-                    raise TypeError("cluster_members must be list of strings")
-
-            self._cluster_members = value
-        else:
-            raise TypeError("cluster_members must be a list")
-
-    @property
-    def cluster_name(self):
-        return self._cluster_name
-
-    @cluster_name.setter
-    def cluster_name(self, value):
-        if isinstance(value, str):
-            self._cluster_name = value
-        else:
-            raise TypeError("cluster_name must be a string")
-
-    @property
-    def client_name(self):
-        return self._client_name
-
-    @client_name.setter
-    def client_name(self, value):
-        if isinstance(value, str):
-            self._client_name = value
-        else:
-            raise TypeError("client_name must be a string")
-
-    @property
-    def connection_timeout(self):
-        return self._connection_timeout
-
-    @connection_timeout.setter
-    def connection_timeout(self, value):
-        if isinstance(value, number_types):
-            if value < 0:
-                raise ValueError("connection_timeout must be non-negative")
-            self._connection_timeout = value
-        else:
-            raise TypeError("connection_timeout must be a number")
-
-    @property
-    def socket_options(self):
-        return self._socket_options
-
-    @socket_options.setter
-    def socket_options(self, value):
-        if isinstance(value, list):
-            try:
-                for _, _, _ in value:
-                    # Must be a tuple of length 3
-                    pass
-
-                self._socket_options = value
-            except ValueError:
-                raise TypeError("socket_options must contain tuples of length 3 as items")
-        else:
-            raise TypeError("socket_options must be a list")
-
-    @property
-    def redo_operation(self):
-        return self._redo_operation
-
-    @redo_operation.setter
-    def redo_operation(self, value):
-        if isinstance(value, bool):
-            self._redo_operation = value
-        else:
-            raise TypeError("redo_operation must be a boolean")
-
-    @property
-    def smart_routing(self):
-        return self._smart_routing
-
-    @smart_routing.setter
-    def smart_routing(self, value):
-        if isinstance(value, bool):
-            self._smart_routing = value
-        else:
-            raise TypeError("smart_routing must be a boolean")
-
-    @property
-    def ssl_enabled(self):
-        return self._ssl_enabled
-
-    @ssl_enabled.setter
-    def ssl_enabled(self, value):
-        if isinstance(value, bool):
-            self._ssl_enabled = value
-        else:
-            raise TypeError("ssl_enabled must be a boolean")
-
-    @property
-    def ssl_cafile(self):
-        return self._ssl_cafile
-
-    @ssl_cafile.setter
-    def ssl_cafile(self, value):
-        if isinstance(value, str):
-            self._ssl_cafile = value
-        else:
-            raise TypeError("ssl_cafile must be a string")
-
-    @property
-    def ssl_certfile(self):
-        return self._ssl_certfile
-
-    @ssl_certfile.setter
-    def ssl_certfile(self, value):
-        if isinstance(value, str):
-            self._ssl_certfile = value
-        else:
-            raise TypeError("ssl_certfile must be a string")
-
-    @property
-    def ssl_keyfile(self):
-        return self._ssl_keyfile
-
-    @ssl_keyfile.setter
-    def ssl_keyfile(self, value):
-        if isinstance(value, str):
-            self._ssl_keyfile = value
-        else:
-            raise TypeError("ssl_keyfile must be a string")
-
-    @property
-    def ssl_password(self):
-        return self._ssl_password
-
-    @ssl_password.setter
-    def ssl_password(self, value):
-        if isinstance(value, (str, bytes, bytearray)) or callable(value):
-            self._ssl_password = value
-        else:
-            raise TypeError("ssl_password must be string, bytes, bytearray or callable")
-
-    @property
-    def ssl_protocol(self):
-        return self._ssl_protocol
-
-    @ssl_protocol.setter
-    def ssl_protocol(self, value):
-        self._ssl_protocol = try_to_get_enum_value(value, SSLProtocol)
-
-    @property
-    def ssl_ciphers(self):
-        return self._ssl_ciphers
-
-    @ssl_ciphers.setter
-    def ssl_ciphers(self, value):
-        if isinstance(value, str):
-            self._ssl_ciphers = value
-        else:
-            raise TypeError("ssl_ciphers must be a string")
-
-    @property
-    def ssl_check_hostname(self) -> bool:
-        return self._ssl_check_hostname
-
-    @ssl_check_hostname.setter
-    def ssl_check_hostname(self, value: bool) -> None:
-        if isinstance(value, bool):
-            self._ssl_check_hostname = value
-        else:
-            raise TypeError("ssl_check_hostname must be a boolean")
-
-    @property
-    def cloud_discovery_token(self):
-        return self._cloud_discovery_token
-
-    @cloud_discovery_token.setter
-    def cloud_discovery_token(self, value):
-        if isinstance(value, str):
-            self._cloud_discovery_token = value
-        else:
-            raise TypeError("cloud_discovery_token must be a string")
-
-    @property
-    def async_start(self):
-        return self._async_start
-
-    @async_start.setter
-    def async_start(self, value):
-        if isinstance(value, bool):
-            self._async_start = value
-        else:
-            raise TypeError("async_start must be a boolean")
-
-    @property
-    def reconnect_mode(self):
-        return self._reconnect_mode
-
-    @reconnect_mode.setter
-    def reconnect_mode(self, value):
-        self._reconnect_mode = try_to_get_enum_value(value, ReconnectMode)
-
-    @property
-    def retry_initial_backoff(self):
-        return self._retry_initial_backoff
-
-    @retry_initial_backoff.setter
-    def retry_initial_backoff(self, value):
-        if isinstance(value, number_types):
-            if value < 0:
-                raise ValueError("retry_initial_backoff must be non-negative")
-            self._retry_initial_backoff = value
-        else:
-            raise TypeError("retry_initial_backoff must be a number")
-
-    @property
-    def retry_max_backoff(self):
-        return self._retry_max_backoff
-
-    @retry_max_backoff.setter
-    def retry_max_backoff(self, value):
-        if isinstance(value, number_types):
-            if value < 0:
-                raise ValueError("retry_max_backoff must be non-negative")
-            self._retry_max_backoff = value
-        else:
-            raise TypeError("retry_max_backoff must be a number")
-
-    @property
-    def retry_jitter(self):
-        return self._retry_jitter
-
-    @retry_jitter.setter
-    def retry_jitter(self, value):
-        if isinstance(value, number_types):
-            if value < 0 or value > 1:
-                raise ValueError("retry_jitter must be in range [0.0, 1.0]")
-            self._retry_jitter = value
-        else:
-            raise TypeError("retry_jitter must be a number")
-
-    @property
-    def retry_multiplier(self):
-        return self._retry_multiplier
-
-    @retry_multiplier.setter
-    def retry_multiplier(self, value):
-        if isinstance(value, number_types):
-            if value < 1:
-                raise ValueError("retry_multiplier must be greater than or equal to 1.0")
-            self._retry_multiplier = value
-        else:
-            raise TypeError("retry_multiplier must be a number")
-
-    @property
-    def cluster_connect_timeout(self):
-        return self._cluster_connect_timeout
-
-    @cluster_connect_timeout.setter
-    def cluster_connect_timeout(self, value):
-        if isinstance(value, number_types):
-            if value < 0 and value != _DEFAULT_CLUSTER_CONNECT_TIMEOUT:
-                raise ValueError(
-                    "cluster_connect_timeout must be non-negative or equal to %s"
-                    % _DEFAULT_CLUSTER_CONNECT_TIMEOUT
-                )
-            self._cluster_connect_timeout = value
-        else:
-            raise TypeError("cluster_connect_timeout must be a number")
-
-    @property
-    def portable_version(self):
-        return self._portable_version
-
-    @portable_version.setter
-    def portable_version(self, value):
-        if isinstance(value, number_types):
-            if value < 0:
-                raise ValueError("portable_version must be non-negative")
-            self._portable_version = value
-        else:
-            raise TypeError("portable_version must be a number")
-
-    @property
-    def data_serializable_factories(self):
-        return self._data_serializable_factories
-
-    @data_serializable_factories.setter
-    def data_serializable_factories(self, value):
-        if isinstance(value, dict):
-            for factory_id, factory in value.items():
-                if not isinstance(factory_id, int):
-                    raise TypeError("Keys of data_serializable_factories must be integers")
-
-                if not isinstance(factory, dict):
-                    raise TypeError("Values of data_serializable_factories must be dict")
-
-                for class_id, clazz in factory.items():
-                    if not isinstance(class_id, int):
-                        raise TypeError(
-                            "Keys of factories of data_serializable_factories must be integers"
-                        )
-
-                    if not (
-                        isinstance(clazz, type) and issubclass(clazz, IdentifiedDataSerializable)
-                    ):
-                        raise TypeError(
-                            "Values of factories of data_serializable_factories must be "
-                            "subclasses of IdentifiedDataSerializable"
-                        )
-
-            self._data_serializable_factories = value
-        else:
-            raise TypeError("data_serializable_factories must be a dict")
-
-    @property
-    def portable_factories(self):
-        return self._portable_factories
-
-    @portable_factories.setter
-    def portable_factories(self, value):
-        if isinstance(value, dict):
-            for factory_id, factory in value.items():
-                if not isinstance(factory_id, int):
-                    raise TypeError("Keys of portable_factories must be integers")
-
-                if not isinstance(factory, dict):
-                    raise TypeError("Values of portable_factories must be dict")
-
-                for class_id, clazz in factory.items():
-                    if not isinstance(class_id, int):
-                        raise TypeError("Keys of factories of portable_factories must be integers")
-
-                    if not (isinstance(clazz, type) and issubclass(clazz, Portable)):
-                        raise TypeError(
-                            "Values of factories of portable_factories must be "
-                            "subclasses of Portable"
-                        )
-
-            self._portable_factories = value
-        else:
-            raise TypeError("portable_factories must be a dict")
-
-    @property
-    def class_definitions(self):
-        return self._class_definitions
-
-    @class_definitions.setter
-    def class_definitions(self, value):
-        if isinstance(value, list):
-            for cd in value:
-                if not isinstance(cd, ClassDefinition):
-                    raise TypeError(
-                        "class_definitions must contain objects of type ClassDefinition"
-                    )
-
-            self._class_definitions = value
-        else:
-            raise TypeError("class_definitions must be a list")
-
-    @property
-    def check_class_definition_errors(self):
-        return self._check_class_definition_errors
-
-    @check_class_definition_errors.setter
-    def check_class_definition_errors(self, value):
-        if isinstance(value, bool):
-            self._check_class_definition_errors = value
-        else:
-            raise TypeError("check_class_definition_errors must be a boolean")
-
-    @property
-    def is_big_endian(self):
-        return self._is_big_endian
-
-    @is_big_endian.setter
-    def is_big_endian(self, value):
-        if isinstance(value, bool):
-            self._is_big_endian = value
-        else:
-            raise TypeError("is_big_endian must be a boolean")
-
-    @property
-    def default_int_type(self):
-        return self._default_int_type
-
-    @default_int_type.setter
-    def default_int_type(self, value):
-        self._default_int_type = try_to_get_enum_value(value, IntType)
-
-    @property
-    def global_serializer(self):
-        return self._global_serializer
-
-    @global_serializer.setter
-    def global_serializer(self, value):
-        if isinstance(value, type) and issubclass(value, StreamSerializer):
-            self._global_serializer = value
-        else:
-            raise TypeError("global_serializer must be a StreamSerializer")
-
-    @property
-    def custom_serializers(self):
-        return self._custom_serializers
-
-    @custom_serializers.setter
-    def custom_serializers(self, value):
-        if isinstance(value, dict):
-            for _type, serializer in value.items():
-                if not isinstance(_type, type):
-                    raise TypeError("Keys of custom_serializers must be types")
-
-                if not (isinstance(serializer, type) and issubclass(serializer, StreamSerializer)):
-                    raise TypeError(
-                        "Values of custom_serializers must be subclasses of StreamSerializer"
-                    )
-
-            self._custom_serializers = value
-        else:
-            raise TypeError("custom_serializers must be a dict")
-
-    @property
-    def near_caches(self):
-        return self._near_caches
-
-    @near_caches.setter
-    def near_caches(self, value):
-        if isinstance(value, dict):
-            configs = dict()
-            for name, config in value.items():
-                if not isinstance(name, str):
-                    raise TypeError("Keys of near_caches must be strings")
-
-                if not isinstance(config, dict):
-                    raise TypeError("Values of near_caches must be dict")
-
-                configs[name] = _NearCacheConfig.from_dict(config)
-
-            self._near_caches = configs
-        else:
-            raise TypeError("near_caches must be a dict")
-
-    @property
-    def load_balancer(self):
-        return self._load_balancer
-
-    @load_balancer.setter
-    def load_balancer(self, value):
-        if isinstance(value, LoadBalancer):
-            self._load_balancer = value
-        else:
-            raise TypeError("load_balancer must be a LoadBalancer")
-
-    @property
-    def membership_listeners(self):
-        return self._membership_listeners
-
-    @membership_listeners.setter
-    def membership_listeners(self, value):
-        if isinstance(value, list):
-            try:
-                for item in value:
-                    try:
-                        added, removed = item
-                    except TypeError:
-                        raise TypeError(
-                            "membership_listeners must contain tuples of length 2 as items"
-                        )
-
-                    if not (callable(added) or callable(removed)):
-                        raise TypeError(
-                            "At least one of the listeners in the tuple most be callable"
-                        )
-
-                self._membership_listeners = value
-            except ValueError:
-                raise TypeError("membership_listeners must contain tuples of length 2 as items")
-        else:
-            raise TypeError("membership_listeners must be a list")
-
-    @property
-    def lifecycle_listeners(self):
-        return self._lifecycle_listeners
-
-    @lifecycle_listeners.setter
-    def lifecycle_listeners(self, value):
-        if isinstance(value, list):
-            for listener in value:
-                if not callable(listener):
-                    raise TypeError("lifecycle_listeners must contain callable items")
-
-            self._lifecycle_listeners = value
-        else:
-            raise TypeError("lifecycle_listeners must be a list")
-
-    @property
-    def flake_id_generators(self):
-        return self._flake_id_generators
-
-    @flake_id_generators.setter
-    def flake_id_generators(self, value):
-        if isinstance(value, dict):
-            configs = dict()
-            for name, config in value.items():
-                if not isinstance(name, str):
-                    raise TypeError("Keys of flake_id_generators must be strings")
-
-                if not isinstance(config, dict):
-                    raise TypeError("Values of flake_id_generators must be dict")
-
-                configs[name] = _FlakeIdGeneratorConfig.from_dict(config)
-
-            self._flake_id_generators = configs
-        else:
-            raise TypeError("flake_id_generators must be a dict")
-
-    @property
-    def reliable_topics(self):
-        return self._reliable_topics
-
-    @reliable_topics.setter
-    def reliable_topics(self, value):
-        if isinstance(value, dict):
-            configs = {}
-            for name, config in value.items():
-                if not isinstance(name, str):
-                    raise TypeError("Keys of reliable_topics must be strings")
-
-                if not isinstance(config, dict):
-                    raise TypeError("Values of reliable_topics must be dict")
-
-                configs[name] = _ReliableTopicConfig.from_dict(config)
-
-            self._reliable_topics = configs
-        else:
-            raise TypeError("reliable_topics must be a dict")
-
-    @property
-    def labels(self):
-        return self._labels
-
-    @labels.setter
-    def labels(self, value):
-        if isinstance(value, list):
-            for label in value:
-                if not isinstance(label, str):
-                    raise TypeError("labels must be list of strings")
-
-            self._labels = value
-        else:
-            raise TypeError("labels must be a list")
-
-    @property
-    def heartbeat_interval(self):
-        return self._heartbeat_interval
-
-    @heartbeat_interval.setter
-    def heartbeat_interval(self, value):
-        if isinstance(value, number_types):
-            if value <= 0:
-                raise ValueError("heartbeat_interval must be positive")
-            self._heartbeat_interval = value
-        else:
-            raise TypeError("heartbeat_interval must be a number")
-
-    @property
-    def heartbeat_timeout(self):
-        return self._heartbeat_timeout
-
-    @heartbeat_timeout.setter
-    def heartbeat_timeout(self, value):
-        if isinstance(value, number_types):
-            if value <= 0:
-                raise ValueError("heartbeat_timeout must be positive")
-            self._heartbeat_timeout = value
-        else:
-            raise TypeError("heartbeat_timeout must be a number")
-
-    @property
-    def invocation_timeout(self):
-        return self._invocation_timeout
-
-    @invocation_timeout.setter
-    def invocation_timeout(self, value):
-        if isinstance(value, number_types):
-            if value <= 0:
-                raise ValueError("invocation_timeout must be positive")
-            self._invocation_timeout = value
-        else:
-            raise TypeError("invocation_timeout must be a number")
-
-    @property
-    def invocation_retry_pause(self):
-        return self._invocation_retry_pause
-
-    @invocation_retry_pause.setter
-    def invocation_retry_pause(self, value):
-        if isinstance(value, number_types):
-            if value <= 0:
-                raise ValueError("invocation_retry_pause must be positive")
-            self._invocation_retry_pause = value
-        else:
-            raise TypeError("invocation_retry_pause must be a number")
-
-    @property
-    def statistics_enabled(self):
-        return self._statistics_enabled
-
-    @statistics_enabled.setter
-    def statistics_enabled(self, value):
-        if isinstance(value, bool):
-            self._statistics_enabled = value
-        else:
-            raise TypeError("statistics_enabled must be a boolean")
-
-    @property
-    def statistics_period(self):
-        return self._statistics_period
-
-    @statistics_period.setter
-    def statistics_period(self, value):
-        if isinstance(value, number_types):
-            if value <= 0:
-                raise ValueError("statistics_period must be positive")
-            self._statistics_period = value
-        else:
-            raise TypeError("statistics_period must be a number")
-
-    @property
-    def shuffle_member_list(self):
-        return self._shuffle_member_list
-
-    @shuffle_member_list.setter
-    def shuffle_member_list(self, value):
-        if isinstance(value, bool):
-            self._shuffle_member_list = value
-        else:
-            raise TypeError("shuffle_member_list must be a boolean")
-
-    @property
-    def backup_ack_to_client_enabled(self):
-        return self._backup_ack_to_client_enabled
-
-    @backup_ack_to_client_enabled.setter
-    def backup_ack_to_client_enabled(self, value):
-        if isinstance(value, bool):
-            self._backup_ack_to_client_enabled = value
-        else:
-            raise TypeError("backup_ack_to_client_enabled must be a boolean")
-
-    @property
-    def operation_backup_timeout(self):
-        return self._operation_backup_timeout
-
-    @operation_backup_timeout.setter
-    def operation_backup_timeout(self, value):
-        if isinstance(value, number_types):
-            if value > 0:
-                self._operation_backup_timeout = value
-            else:
-                raise ValueError("operation_backup_timeout must be positive")
-        else:
-            raise TypeError("operation_backup_timeout must be a number")
-
-    @property
-    def fail_on_indeterminate_operation_state(self):
-        return self._fail_on_indeterminate_operation_state
-
-    @fail_on_indeterminate_operation_state.setter
-    def fail_on_indeterminate_operation_state(self, value):
-        if isinstance(value, bool):
-            self._fail_on_indeterminate_operation_state = value
-        else:
-            raise TypeError("fail_on_indeterminate_operation_state must be a boolean")
-
-    @property
-    def creds_username(self):
-        # type: (_Config) -> str
-        return self._creds_username
-
-    @creds_username.setter
-    def creds_username(self, username):
-        # type: (_Config, str) -> None
-        if not isinstance(username, str):
-            raise TypeError("creds_password must be a string")
-        self._creds_username = username
-
-    @property
-    def creds_password(self):
-        # type: (_Config) -> str
-        return self._creds_password
-
-    @creds_password.setter
-    def creds_password(self, password):
-        # type: (_Config, str) -> None
-        if not isinstance(password, str):
-            raise TypeError("creds_password must be a string")
-        self._creds_password = password
-
-    @property
-    def token_provider(self):
-        # type: (_Config) -> TokenProvider
-        return self._token_provider
-
-    @token_provider.setter
-    def token_provider(self, token_provider):
-        # type: (_Config, TokenProvider) -> None
-        token_fun = getattr(token_provider, "token", None)
-        if token_fun is None or not isinstance(token_fun, types.MethodType):
-            raise TypeError("token_provider must be an object with a token method")
-        self._token_provider = token_provider
-
-    @property
-    def use_public_ip(self):
-        # type: () -> bool
-        return self._use_public_ip
-
-    @use_public_ip.setter
-    def use_public_ip(self, value):
-        # type: (bool) -> None
-        if isinstance(value, bool):
-            self._use_public_ip = value
-        else:
-            raise TypeError("use_public_ip must be a boolean")
-
-    @property
-    def compact_serializers(self) -> typing.List[CompactSerializer]:
-        return self._compact_serializers
-
-    @compact_serializers.setter
-    def compact_serializers(self, value: typing.List[CompactSerializer]) -> None:
-        if isinstance(value, list):
-            for serializer in value:
-                if not isinstance(serializer, CompactSerializer):
-                    raise TypeError("Values of compact_serializers must be CompactSerializer")
-            self._compact_serializers = value
-        else:
-            raise TypeError("compact_serializers must be a dict")
-
-    @classmethod
-    def from_dict(cls, d):
-        config = cls()
-        for k, v in d.items():
-            if v is not None:
-                try:
-                    config.__setattr__(k, v)
-                except AttributeError:
-                    raise InvalidConfigurationError("Unrecognized config option: %s" % k)
-        return config
-
-
-class _NearCacheConfig:
-    __slots__ = (
-        "_invalidate_on_change",
-        "_in_memory_format",
-        "_time_to_live",
-        "_max_idle",
-        "_eviction_policy",
-        "_eviction_max_size",
-        "_eviction_sampling_count",
-        "_eviction_sampling_pool_size",
-    )
-
-    def __init__(self):
-        self._invalidate_on_change = True
-        self._in_memory_format = InMemoryFormat.BINARY
-        self._time_to_live = None
-        self._max_idle = None
-        self._eviction_policy = EvictionPolicy.LRU
-        self._eviction_max_size = 10000
-        self._eviction_sampling_count = 8
-        self._eviction_sampling_pool_size = 16
-
-    @property
-    def invalidate_on_change(self):
-        return self._invalidate_on_change
-
-    @invalidate_on_change.setter
-    def invalidate_on_change(self, value):
-        if isinstance(value, bool):
-            self._invalidate_on_change = value
-        else:
-            raise TypeError("invalidate_on_change must be a boolean")
-
-    @property
-    def in_memory_format(self):
-        return self._in_memory_format
-
-    @in_memory_format.setter
-    def in_memory_format(self, value):
-        self._in_memory_format = try_to_get_enum_value(value, InMemoryFormat)
-
-    @property
-    def time_to_live(self):
-        return self._time_to_live
-
-    @time_to_live.setter
-    def time_to_live(self, value):
-        if isinstance(value, number_types):
-            if value < 0:
-                raise ValueError("time_to_live must be non-negative")
-            self._time_to_live = value
-        else:
-            raise TypeError("time_to_live must be a number")
-
-    @property
-    def max_idle(self):
-        return self._max_idle
-
-    @max_idle.setter
-    def max_idle(self, value):
-        if isinstance(value, number_types):
-            if value < 0:
-                raise ValueError("max_idle must be non-negative")
-            self._max_idle = value
-        else:
-            raise TypeError("max_idle must be a number")
-
-    @property
-    def eviction_policy(self):
-        return self._eviction_policy
-
-    @eviction_policy.setter
-    def eviction_policy(self, value):
-        self._eviction_policy = try_to_get_enum_value(value, EvictionPolicy)
-
-    @property
-    def eviction_max_size(self):
-        return self._eviction_max_size
-
-    @eviction_max_size.setter
-    def eviction_max_size(self, value):
-        if isinstance(value, number_types):
-            if value < 1:
-                raise ValueError("eviction_max_size must be greater than 1")
-            self._eviction_max_size = value
-        else:
-            raise TypeError("eviction_max_size must be a number")
-
-    @property
-    def eviction_sampling_count(self):
-        return self._eviction_sampling_count
-
-    @eviction_sampling_count.setter
-    def eviction_sampling_count(self, value):
-        if isinstance(value, number_types):
-            if value < 1:
-                raise ValueError("eviction_sampling_count must be greater than 1")
-            self._eviction_sampling_count = value
-        else:
-            raise TypeError("eviction_sampling_count must be a number")
-
-    @property
-    def eviction_sampling_pool_size(self):
-        return self._eviction_sampling_pool_size
-
-    @eviction_sampling_pool_size.setter
-    def eviction_sampling_pool_size(self, value):
-        if isinstance(value, number_types):
-            if value < 1:
-                raise ValueError("eviction_sampling_pool_size must be greater than 1")
-            self._eviction_sampling_pool_size = value
-        else:
-            raise TypeError("eviction_sampling_pool_size must be a number")
-
-    @classmethod
-    def from_dict(cls, d):
-        config = cls()
-        for k, v in d.items():
-            try:
-                config.__setattr__(k, v)
-            except AttributeError:
-                raise InvalidConfigurationError(
-                    "Unrecognized config option for the near cache: %s" % k
-                )
-        return config
-
-
-class _FlakeIdGeneratorConfig:
-    __slots__ = ("_prefetch_count", "_prefetch_validity")
-
-    def __init__(self):
-        self._prefetch_count = 100
-        self._prefetch_validity = 600
-
-    @property
-    def prefetch_count(self):
-        return self._prefetch_count
-
-    @prefetch_count.setter
-    def prefetch_count(self, value):
-        if isinstance(value, number_types):
-            if not (0 < value <= 100000):
-                raise ValueError("prefetch_count must be in range 1 to 100000")
-            self._prefetch_count = value
-        else:
-            raise TypeError("prefetch_count must be a number")
-
-    @property
-    def prefetch_validity(self):
-        return self._prefetch_validity
-
-    @prefetch_validity.setter
-    def prefetch_validity(self, value):
-        if isinstance(value, number_types):
-            if value < 0:
-                raise ValueError("prefetch_validity must be non-negative")
-            self._prefetch_validity = value
-        else:
-            raise TypeError("prefetch_validity must be a number")
-
-    @classmethod
-    def from_dict(cls, d):
-        config = cls()
-        for k, v in d.items():
-            try:
-                config.__setattr__(k, v)
-            except AttributeError:
-                raise InvalidConfigurationError(
-                    "Unrecognized config option for the flake id generator: %s" % k
-                )
-        return config
-
-
-class _ReliableTopicConfig:
-    __slots__ = ("_read_batch_size", "_overload_policy")
-
-    def __init__(self):
-        self._read_batch_size = 10
-        self._overload_policy = TopicOverloadPolicy.BLOCK
-
-    @property
-    def read_batch_size(self):
-        return self._read_batch_size
-
-    @read_batch_size.setter
-    def read_batch_size(self, value):
-        if isinstance(value, number_types):
-            if value <= 0:
-                raise ValueError("read_batch_size must be positive")
-            self._read_batch_size = value
-        else:
-            raise TypeError("read_batch_size must be a number")
-
-    @property
-    def overload_policy(self):
-        return self._overload_policy
-
-    @overload_policy.setter
-    def overload_policy(self, value):
-        self._overload_policy = try_to_get_enum_value(value, TopicOverloadPolicy)
-
-    @classmethod
-    def from_dict(cls, d):
-        config = cls()
-        for k, v in d.items():
-            try:
-                config.__setattr__(k, v)
-            except AttributeError:
-                raise InvalidConfigurationError(
-                    "Unrecognized config option for the reliable topic: %s" % k
-                )
-        return config

--- a/hazelcast/proxy/flake_id_generator.py
+++ b/hazelcast/proxy/flake_id_generator.py
@@ -3,7 +3,7 @@ import threading
 import collections
 
 from hazelcast.proxy.base import Proxy, MAX_SIZE
-from hazelcast.config import _FlakeIdGeneratorConfig
+from hazelcast.config import FlakeIdGeneratorConfig
 from hazelcast.util import current_time
 from hazelcast.protocol.codec import flake_id_generator_new_id_batch_codec
 from hazelcast.future import ImmediateFuture, Future
@@ -44,7 +44,7 @@ class FlakeIdGenerator(Proxy["BlockingFlakeIdGenerator"]):
 
         config = context.config.flake_id_generators.get(name, None)
         if config is None:
-            config = _FlakeIdGeneratorConfig()
+            config = FlakeIdGeneratorConfig()
 
         self._auto_batcher = _AutoBatcher(
             config.prefetch_count, config.prefetch_validity, self._new_id_batch

--- a/hazelcast/proxy/reliable_topic.py
+++ b/hazelcast/proxy/reliable_topic.py
@@ -3,7 +3,7 @@ import time
 import typing
 from uuid import uuid4
 
-from hazelcast.config import _ReliableTopicConfig, TopicOverloadPolicy
+from hazelcast.config import ReliableTopicConfig, TopicOverloadPolicy
 from hazelcast.core import MemberInfo, MemberVersion, EndpointQualifier, ProtocolType
 from hazelcast.errors import (
     OperationTimeoutError,
@@ -557,7 +557,7 @@ class ReliableTopic(Proxy["BlockingReliableTopic"], typing.Generic[MessageType])
 
         config = context.config.reliable_topics.get(name, None)
         if config is None:
-            config = _ReliableTopicConfig()
+            config = ReliableTopicConfig()
 
         self._config = config
         self._context = context

--- a/hazelcast/reactor.py
+++ b/hazelcast/reactor.py
@@ -15,7 +15,7 @@ from functools import total_ordering
 from heapq import heappush, heappop
 from threading import get_ident
 
-from hazelcast.config import SSLProtocol, _Config
+from hazelcast.config import SSLProtocol, Config
 from hazelcast.connection import Connection
 from hazelcast.core import Address
 from hazelcast.errors import HazelcastError
@@ -539,7 +539,7 @@ class AsyncoreConnection(Connection, asyncore.dispatcher):
 
             self.socket.setsockopt(level, option_name, value)
 
-    def _wrap_as_ssl_socket(self, config: _Config, hostname: str):
+    def _wrap_as_ssl_socket(self, config: Config, hostname: str):
         ssl_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
 
         protocol = config.ssl_protocol

--- a/hazelcast/serialization/service.py
+++ b/hazelcast/serialization/service.py
@@ -6,7 +6,7 @@ import uuid
 
 import typing
 
-from hazelcast.config import IntType, _Config
+from hazelcast.config import IntType, Config
 from hazelcast.errors import HazelcastInstanceNotActiveError
 from hazelcast.serialization.api import IdentifiedDataSerializable, Portable
 from hazelcast.serialization.compact import (
@@ -320,7 +320,7 @@ class SerializationServiceV1:
 class SerializerRegistry:
     def __init__(
         self,
-        config: _Config,
+        config: Config,
         portable_serializer: PortableSerializer,
         data_serializer: IdentifiedDataSerializer,
         compact_serializer: CompactStreamSerializer,

--- a/tests/integration/backward_compatible/client_test.py
+++ b/tests/integration/backward_compatible/client_test.py
@@ -7,6 +7,13 @@ from hazelcast.lifecycle import LifecycleState
 from tests.hzrc.ttypes import Lang
 from tests.util import get_current_timestamp, compare_client_version, random_string
 
+try:
+    from hazelcast.config import Config
+    from hazelcast.errors import InvalidConfigurationError
+except ImportError:
+    # For backward compatibility tests
+    pass
+
 
 class ClientTest(HazelcastTestCase):
     def test_client_only_listens(self):
@@ -145,3 +152,55 @@ class ClientTcpMetricsTest(SingleMemberTestCase):
         m.set(random_string(), random_string())
 
         self.assertGreater(reactor.bytes_sent, bytes_sent)
+
+
+@unittest.skipIf(
+    compare_client_version("5.1") < 0,
+    "Tests the features added in 5.1 version of the client",
+)
+class ClientConfigurationTest(HazelcastTestCase):
+    rc = None
+    cluster = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.rc = cls.create_rc()
+        cls.cluster = cls.create_cluster(cls.rc, None)
+        cls.cluster.start_member()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.rc.terminateCluster(cls.cluster.id)
+        cls.rc.exit()
+
+    def tearDown(self) -> None:
+        self.shutdown_all_clients()
+
+    def test_keyword_args_configuration(self):
+        client = HazelcastClient(
+            cluster_name=self.cluster.id,
+        )
+        self.clients.append(client)
+        self.assertTrue(client.lifecycle_service.is_running())
+
+    def test_configuration_object(self):
+        config = Config()
+        config.cluster_name = self.cluster.id
+        client = HazelcastClient(config)
+        self.clients.append(client)
+        self.assertTrue(client.lifecycle_service.is_running())
+
+    def test_configuration_object_as_keyword_argument(self):
+        config = Config()
+        config.cluster_name = self.cluster.id
+        client = HazelcastClient(config=config)
+        self.clients.append(client)
+        self.assertTrue(client.lifecycle_service.is_running())
+
+    def test_ambiguous_configuration(self):
+        config = Config()
+        with self.assertRaisesRegex(
+            InvalidConfigurationError,
+            "Ambiguous client configuration is found",
+        ):
+            HazelcastClient(config, cluster_name="a-cluster")

--- a/tests/integration/backward_compatible/client_test.py
+++ b/tests/integration/backward_compatible/client_test.py
@@ -168,31 +168,35 @@ class ClientConfigurationTest(HazelcastTestCase):
         cls.cluster = cls.create_cluster(cls.rc, None)
         cls.cluster.start_member()
 
+    def setUp(self):
+        self.client = None
+
+    def tearDown(self):
+        if self.client:
+            self.client.shutdown()
+
     @classmethod
     def tearDownClass(cls):
         cls.rc.terminateCluster(cls.cluster.id)
         cls.rc.exit()
 
     def test_keyword_args_configuration(self):
-        client = HazelcastClient(
+        self.client = HazelcastClient(
             cluster_name=self.cluster.id,
         )
-        self.assertTrue(client.lifecycle_service.is_running())
-        client.shutdown()
+        self.assertTrue(self.client.lifecycle_service.is_running())
 
     def test_configuration_object(self):
         config = Config()
         config.cluster_name = self.cluster.id
-        client = HazelcastClient(config)
-        self.assertTrue(client.lifecycle_service.is_running())
-        client.shutdown()
+        self.client = HazelcastClient(config)
+        self.assertTrue(self.client.lifecycle_service.is_running())
 
     def test_configuration_object_as_keyword_argument(self):
         config = Config()
         config.cluster_name = self.cluster.id
-        client = HazelcastClient(config=config)
-        self.assertTrue(client.lifecycle_service.is_running())
-        client.shutdown()
+        self.client = HazelcastClient(config=config)
+        self.assertTrue(self.client.lifecycle_service.is_running())
 
     def test_ambiguous_configuration(self):
         config = Config()
@@ -200,4 +204,4 @@ class ClientConfigurationTest(HazelcastTestCase):
             InvalidConfigurationError,
             "Ambiguous client configuration is found",
         ):
-            HazelcastClient(config, cluster_name="a-cluster")
+            self.client = HazelcastClient(config, cluster_name="a-cluster")

--- a/tests/integration/backward_compatible/client_test.py
+++ b/tests/integration/backward_compatible/client_test.py
@@ -173,29 +173,26 @@ class ClientConfigurationTest(HazelcastTestCase):
         cls.rc.terminateCluster(cls.cluster.id)
         cls.rc.exit()
 
-    def tearDown(self) -> None:
-        self.shutdown_all_clients()
-
     def test_keyword_args_configuration(self):
         client = HazelcastClient(
             cluster_name=self.cluster.id,
         )
-        self.clients.append(client)
         self.assertTrue(client.lifecycle_service.is_running())
+        client.shutdown()
 
     def test_configuration_object(self):
         config = Config()
         config.cluster_name = self.cluster.id
         client = HazelcastClient(config)
-        self.clients.append(client)
         self.assertTrue(client.lifecycle_service.is_running())
+        client.shutdown()
 
     def test_configuration_object_as_keyword_argument(self):
         config = Config()
         config.cluster_name = self.cluster.id
         client = HazelcastClient(config=config)
-        self.clients.append(client)
         self.assertTrue(client.lifecycle_service.is_running())
+        client.shutdown()
 
     def test_ambiguous_configuration(self):
         config = Config()

--- a/tests/integration/backward_compatible/client_test.py
+++ b/tests/integration/backward_compatible/client_test.py
@@ -155,8 +155,8 @@ class ClientTcpMetricsTest(SingleMemberTestCase):
 
 
 @unittest.skipIf(
-    compare_client_version("5.1") < 0,
-    "Tests the features added in 5.1 version of the client",
+    compare_client_version("5.2") < 0,
+    "Tests the features added in 5.2 version of the client",
 )
 class ClientConfigurationTest(HazelcastTestCase):
     rc = None

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -31,7 +31,6 @@ from hazelcast.serialization.api import (
     PortableWriter,
     PortableReader,
     CompactSerializer,
-    CompactSerializableClass,
     CompactWriter,
     CompactReader,
 )

--- a/tests/unit/invocation_test.py
+++ b/tests/unit/invocation_test.py
@@ -2,7 +2,7 @@ import unittest
 
 from mock import MagicMock
 
-from hazelcast.config import _Config
+from hazelcast.config import Config
 from hazelcast.errors import IndeterminateOperationStateError
 from hazelcast.invocation import Invocation, InvocationService
 
@@ -22,7 +22,7 @@ class InvocationTest(unittest.TestCase):
         listener_service.register_listener.assert_called_once()
 
     def test_smart_mode_and_disabled_backups(self):
-        config = _Config()
+        config = Config()
         config.backup_ack_to_client_enabled = False
         client, service = self._start_service(config)
         self.assertIsNotNone(service._clean_resources_timer)
@@ -30,7 +30,7 @@ class InvocationTest(unittest.TestCase):
         listener_service.register_listener.assert_not_called()
 
     def test_unisocket_mode_and_enabled_backups(self):
-        config = _Config()
+        config = Config()
         config.smart_routing = False
         client, service = self._start_service(config)
         self.assertIsNotNone(service._clean_resources_timer)
@@ -38,7 +38,7 @@ class InvocationTest(unittest.TestCase):
         listener_service.register_listener.assert_not_called()
 
     def test_unisocket_mode_and_disabled_backups(self):
-        config = _Config()
+        config = Config()
         config.smart_routing = False
         config.backup_ack_to_client_enabled = False
         client, service = self._start_service(config)
@@ -149,7 +149,7 @@ class InvocationTest(unittest.TestCase):
         invocation = Invocation(None, timeout=42)
         self.assertEqual(42, invocation.timeout)
 
-    def _start_service(self, config=_Config()):
+    def _start_service(self, config=Config()):
         c = MagicMock()
         invocation_service = InvocationService(c, config, c._reactor)
         self.service = invocation_service

--- a/tests/unit/near_cache_test.py
+++ b/tests/unit/near_cache_test.py
@@ -1,14 +1,14 @@
 import unittest
 from time import sleep
 
-from hazelcast.config import _Config
+from hazelcast.config import Config
 from hazelcast.near_cache import *
 from hazelcast.serialization import SerializationServiceV1
 
 
 class NearCacheTestCase(unittest.TestCase):
     def setUp(self):
-        self.service = SerializationServiceV1(_Config())
+        self.service = SerializationServiceV1(Config())
 
     def tearDown(self):
         self.service.destroy()

--- a/tests/unit/reactor_test.py
+++ b/tests/unit/reactor_test.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 from mock import MagicMock
 from parameterized import parameterized
 
-from hazelcast.config import _Config
+from hazelcast.config import Config
 from hazelcast.core import Address
 from hazelcast.reactor import (
     AsyncoreReactor,
@@ -307,7 +307,7 @@ class AsyncoreConnectionTest(unittest.TestCase):
 
     def test_socket_options(self):
         self.server = MockServer()
-        config = _Config()
+        config = Config()
         config.socket_options = [(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)]
 
         conn = AsyncoreConnection(
@@ -324,7 +324,7 @@ class AsyncoreConnectionTest(unittest.TestCase):
         # When the SO_RCVBUF option is set, we should try
         # to use that value while trying to read something.
         self.server = MockServer()
-        config = _Config()
+        config = Config()
         size = 64 * 1024
         config.socket_options = [(socket.SOL_SOCKET, socket.SO_RCVBUF, size)]
         conn = AsyncoreConnection(
@@ -341,7 +341,7 @@ class AsyncoreConnectionTest(unittest.TestCase):
         # When the SO_SNDBUF option is set, we should try
         # to use that value while trying to write something.
         self.server = MockServer()
-        config = _Config()
+        config = Config()
         size = 64 * 1024
         config.socket_options = [(socket.SOL_SOCKET, socket.SO_SNDBUF, size)]
         conn = AsyncoreConnection(
@@ -356,7 +356,7 @@ class AsyncoreConnectionTest(unittest.TestCase):
 
     def test_constructor_with_unreachable_addresses(self):
         addr = Address("192.168.0.1", 5701)
-        config = _Config()
+        config = Config()
         start = get_current_timestamp()
         conn = AsyncoreConnection(MagicMock(map=dict()), MagicMock(), None, addr, config, None)
         try:
@@ -368,7 +368,7 @@ class AsyncoreConnectionTest(unittest.TestCase):
 
     def test_resources_cleaned_up_after_immediate_failure(self):
         addr = Address("invalid-address", 5701)
-        config = _Config()
+        config = Config()
         mock_reactor = MagicMock(map={})
         try:
             conn = AsyncoreConnection(mock_reactor, MagicMock(), None, addr, config, None)

--- a/tests/unit/serialization/binary_compatibility/binary_compatibility_test.py
+++ b/tests/unit/serialization/binary_compatibility/binary_compatibility_test.py
@@ -4,7 +4,7 @@ import unittest
 from os import path
 from parameterized import parameterized
 
-from hazelcast.config import IntType, _Config
+from hazelcast.config import IntType, Config
 from hazelcast.serialization import BE_INT, BE_FLOAT, SerializationServiceV1
 from hazelcast.serialization.api import StreamSerializer
 from hazelcast.serialization.input import _ObjectDataInput
@@ -103,7 +103,7 @@ class BinaryCompatibilityTest(unittest.TestCase):
 
     @staticmethod
     def _create_serialization_service(is_big_endian, int_type):
-        config = _Config()
+        config = Config()
         config.custom_serializers = {
             CustomStreamSerializable: CustomStreamSerializer,
             CustomByteArraySerializable: CustomByteArraySerializer,

--- a/tests/unit/serialization/compact_test.py
+++ b/tests/unit/serialization/compact_test.py
@@ -5,7 +5,7 @@ import uuid
 
 from parameterized import parameterized
 
-from hazelcast.config import _Config
+from hazelcast.config import Config
 from hazelcast.errors import HazelcastSerializationError
 from hazelcast.serialization import SerializationServiceV1
 from hazelcast.serialization.api import CompactSerializer, CompactReader, CompactWriter
@@ -257,7 +257,7 @@ class NestedSerializerTest(unittest.TestCase):
             return self._serialize(serialization_service, obj)
 
     def test_missing_serializer(self):
-        config = _Config()
+        config = Config()
         config.compact_serializers = [ParentSerializer()]
         service = SerializationServiceV1(config)
 

--- a/tests/unit/serialization/custom_global_serialization_test.py
+++ b/tests/unit/serialization/custom_global_serialization_test.py
@@ -1,7 +1,7 @@
 import pickle
 import unittest
 
-from hazelcast.config import _Config
+from hazelcast.config import Config
 from hazelcast.serialization.api import StreamSerializer
 from hazelcast.serialization.service import SerializationServiceV1
 
@@ -85,7 +85,7 @@ class TheOtherCustomSerializer(StreamSerializer):
 
 class CustomSerializationTestCase(unittest.TestCase):
     def test_global_encode_decode(self):
-        config = _Config()
+        config = Config()
         config.global_serializer = GlobalSerializer
 
         service = SerializationServiceV1(config)
@@ -97,7 +97,7 @@ class CustomSerializationTestCase(unittest.TestCase):
         self.assertEqual("GLOBAL", obj2.source)
 
     def test_custom_serializer(self):
-        config = _Config()
+        config = Config()
         config.custom_serializers = {CustomClass: CustomSerializer}
 
         service = SerializationServiceV1(config)
@@ -109,7 +109,7 @@ class CustomSerializationTestCase(unittest.TestCase):
         self.assertEqual("CUSTOM", obj2.source)
 
     def test_global_custom_serializer(self):
-        config = _Config()
+        config = Config()
         config.custom_serializers = {CustomClass: CustomSerializer}
         config.global_serializer = GlobalSerializer
 
@@ -122,7 +122,7 @@ class CustomSerializationTestCase(unittest.TestCase):
         self.assertEqual("CUSTOM", obj2.source)
 
     def test_double_register_custom_serializer(self):
-        config = _Config()
+        config = Config()
         config.custom_serializers = {CustomClass: CustomSerializer}
         service = SerializationServiceV1(config)
 

--- a/tests/unit/serialization/identified_test.py
+++ b/tests/unit/serialization/identified_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from hazelcast.config import _Config
+from hazelcast.config import Config
 from hazelcast.serialization import SerializationServiceV1
 from hazelcast.serialization.api import IdentifiedDataSerializable
 
@@ -167,7 +167,7 @@ the_factory = {SerializationV1Identified.CLASS_ID: SerializationV1Identified}
 
 class IdentifiedSerializationTestCase(unittest.TestCase):
     def test_encode_decode(self):
-        config = _Config()
+        config = Config()
         config.data_serializable_factories = {FACTORY_ID: the_factory}
         service = SerializationServiceV1(config)
         obj = create_identified()

--- a/tests/unit/serialization/int_serialization_test.py
+++ b/tests/unit/serialization/int_serialization_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from hazelcast.config import IntType, _Config
+from hazelcast.config import IntType, Config
 from hazelcast.errors import HazelcastSerializationError
 from hazelcast.serialization.serialization_const import (
     CONSTANT_TYPE_BYTE,
@@ -19,7 +19,7 @@ big_int = 0x11223344556677881122334455667788
 
 class IntegerTestCase(unittest.TestCase):
     def test_dynamic_case(self):
-        config = _Config()
+        config = Config()
         config.default_int_type = IntType.VAR
         service = SerializationServiceV1(config)
 
@@ -42,7 +42,7 @@ class IntegerTestCase(unittest.TestCase):
         self.assertEqual(v4, long_val)
 
     def test_byte_case(self):
-        config = _Config()
+        config = Config()
         config.default_int_type = IntType.BYTE
         service = SerializationServiceV1(config)
 
@@ -55,7 +55,7 @@ class IntegerTestCase(unittest.TestCase):
             service.to_data(big_int)
 
     def test_short_case(self):
-        config = _Config()
+        config = Config()
         config.default_int_type = IntType.SHORT
         service = SerializationServiceV1(config)
 
@@ -72,7 +72,7 @@ class IntegerTestCase(unittest.TestCase):
             service.to_data(big_int)
 
     def test_int_case(self):
-        config = _Config()
+        config = Config()
         config.default_int_type = IntType.INT
         service = SerializationServiceV1(config)
 
@@ -93,7 +93,7 @@ class IntegerTestCase(unittest.TestCase):
             service.to_data(big_int)
 
     def test_long_case(self):
-        config = _Config()
+        config = Config()
         config.default_int_type = IntType.LONG
         service = SerializationServiceV1(config)
 

--- a/tests/unit/serialization/morphing_portable_test.py
+++ b/tests/unit/serialization/morphing_portable_test.py
@@ -2,7 +2,7 @@ import datetime
 import decimal
 import unittest
 
-from hazelcast.config import _Config
+from hazelcast.config import Config
 from hazelcast.serialization import SerializationServiceV1
 from hazelcast.serialization.data import DATA_OFFSET
 from hazelcast.serialization.input import _ObjectDataInput
@@ -67,10 +67,10 @@ the_factory_2 = {
 
 class MorphingPortableTestCase(unittest.TestCase):
     def setUp(self):
-        config1 = _Config()
+        config1 = Config()
         config1.portable_factories = {FACTORY_ID: the_factory_1}
 
-        config2 = _Config()
+        config2 = Config()
         config2.portable_factories = {FACTORY_ID: the_factory_2}
 
         self.service1 = SerializationServiceV1(config1)

--- a/tests/unit/serialization/portable_test.py
+++ b/tests/unit/serialization/portable_test.py
@@ -3,7 +3,7 @@ import decimal
 import typing
 import unittest
 
-from hazelcast.config import _Config
+from hazelcast.config import Config
 from hazelcast.errors import HazelcastSerializationError
 from hazelcast.serialization import SerializationServiceV1
 from hazelcast.serialization.api import Portable
@@ -423,7 +423,7 @@ class MyPortable2(Portable):
 
 class PortableSerializationTestCase(unittest.TestCase):
     def test_encode_decode(self):
-        config = _Config()
+        config = Config()
         config.portable_factories = {FACTORY_ID: the_factory}
         service = SerializationServiceV1(config)
         obj = create_portable()
@@ -435,7 +435,7 @@ class PortableSerializationTestCase(unittest.TestCase):
         self.assertEqual(obj.inner_portable.param_int, obj2.nested_field)
 
     def test_encode_decode_2(self):
-        config = _Config()
+        config = Config()
         config.portable_factories = {FACTORY_ID: the_factory}
         service = SerializationServiceV1(config)
         service2 = SerializationServiceV1(config)
@@ -447,7 +447,7 @@ class PortableSerializationTestCase(unittest.TestCase):
         self.assertTrue(obj == obj2)
 
     def test_portable_context(self):
-        config = _Config()
+        config = Config()
         config.portable_factories = {FACTORY_ID: the_factory}
         service = SerializationServiceV1(config)
         obj = create_portable()
@@ -461,7 +461,7 @@ class PortableSerializationTestCase(unittest.TestCase):
         self.assertTrue(class_definition is not None)
 
     def test_portable_null_fields(self):
-        config = _Config()
+        config = Config()
         config.portable_factories = {FACTORY_ID: the_factory}
         service = SerializationServiceV1(config)
         service.to_data(create_portable())
@@ -513,7 +513,7 @@ class PortableSerializationTestCase(unittest.TestCase):
         builder.add_portable_array_field("ap", class_def_inner)
         class_def = builder.build()
 
-        config = _Config()
+        config = Config()
         config.portable_factories = {FACTORY_ID: the_factory}
         config.class_definitions = [
             class_def,
@@ -529,10 +529,10 @@ class PortableSerializationTestCase(unittest.TestCase):
         self.assertTrue(obj == obj2)
 
     def test_portable_read_without_factory(self):
-        config = _Config()
+        config = Config()
         config.portable_factories = {FACTORY_ID: the_factory}
         service = SerializationServiceV1(config)
-        service2 = SerializationServiceV1(_Config())
+        service2 = SerializationServiceV1(Config())
         obj = create_portable()
         self.assertTrue(obj.inner_portable)
 
@@ -541,7 +541,7 @@ class PortableSerializationTestCase(unittest.TestCase):
             service2.to_object(data)
 
     def test_nested_portable_serialization(self):
-        config = _Config()
+        config = Config()
         config.portable_version = 6
         config.portable_factories = {
             1: {
@@ -562,7 +562,7 @@ class PortableSerializationTestCase(unittest.TestCase):
         self.assertEqual(p, ss2.to_object(data))
 
     def test_nested_null_portable_serialization(self):
-        config = _Config()
+        config = Config()
 
         config.portable_factories = {1: {1: Parent, 2: Child}}
 
@@ -583,7 +583,7 @@ class PortableSerializationTestCase(unittest.TestCase):
         self.assertEqual(p, ss.to_object(data))
 
     def test_duplicate_class_definition(self):
-        config = _Config()
+        config = Config()
 
         class_def1 = ClassDefinitionBuilder(1, 1).add_string_field("str_field").build()
         class_def2 = ClassDefinitionBuilder(1, 1).add_int_field("int_field").build()
@@ -594,7 +594,7 @@ class PortableSerializationTestCase(unittest.TestCase):
             SerializationServiceV1(config)
 
     def test_classes_with_same_class_id_in_different_factories(self):
-        config = _Config()
+        config = Config()
         config.portable_factories = {1: {1: MyPortable1}, 2: {1: MyPortable2}}
 
         class_def1 = ClassDefinitionBuilder(1, 1).add_string_field("str_field").build()

--- a/tests/unit/serialization/serialization_test.py
+++ b/tests/unit/serialization/serialization_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from hazelcast.config import _Config
+from hazelcast.config import Config
 from hazelcast.core import Address
 from hazelcast.serialization.data import Data
 from hazelcast.serialization.service import SerializationServiceV1
@@ -8,7 +8,7 @@ from hazelcast.serialization.service import SerializationServiceV1
 
 class SerializationTestCase(unittest.TestCase):
     def setUp(self):
-        self.service = SerializationServiceV1(_Config())
+        self.service = SerializationServiceV1(Config())
 
     def tearDown(self):
         self.service.destroy()

--- a/tests/unit/serialization/serializers_test.py
+++ b/tests/unit/serialization/serializers_test.py
@@ -5,7 +5,7 @@ import unittest
 import uuid
 
 from hazelcast.core import HazelcastJsonValue
-from hazelcast.config import _Config
+from hazelcast.config import Config
 from hazelcast.errors import HazelcastSerializationError
 from hazelcast.serialization import BE_INT
 from hazelcast.predicate import *
@@ -25,7 +25,7 @@ class A:
 
 class SerializersTest(unittest.TestCase):
     def setUp(self):
-        self.service = SerializationServiceV1(_Config())
+        self.service = SerializationServiceV1(Config())
 
     def tearDown(self):
         self.service.destroy()

--- a/tests/unit/serialization/string_test.py
+++ b/tests/unit/serialization/string_test.py
@@ -2,7 +2,7 @@
 import binascii
 import unittest
 
-from hazelcast.config import _Config
+from hazelcast.config import Config
 from hazelcast.serialization.bits import *
 from hazelcast.serialization.data import Data
 from hazelcast.serialization.serialization_const import CONSTANT_TYPE_STRING
@@ -29,7 +29,7 @@ def to_data_byte(inp):
 
 class StringSerializationTestCase(unittest.TestCase):
     def setUp(self):
-        self.service = SerializationServiceV1(_Config())
+        self.service = SerializationServiceV1(Config())
 
     def test_ascii_encode(self):
         data_byte = to_data_byte(TEST_DATA_ASCII)


### PR DESCRIPTION
These were converted into private classes during the 4.0 migration,
as we were only supporting keyword arguments for the client configuration.

However, that led to a poor user experience, as we had to use `**kwargs`,
instead of listing all the configuration elements in the client constructor.
(IDEs become painfully slow once we list all keyword arguments, as there
are too many of them)

The solution to this problem is to make the Config classes public API
and make the client able to use it directly.

```python
config = Config()
config.cluster_name = "dev2"

client = HazelcastClient(config)
```

We provide full type hints for config elements.