### PR TITLE
Make the tests more resilient to timing problems

### DIFF
--- a/tests/integration/backward_compatible/heartbeat_test.py
+++ b/tests/integration/backward_compatible/heartbeat_test.py
@@ -1,3 +1,6 @@
+import threading
+import time
+
 from hazelcast import HazelcastClient
 from hazelcast.core import Address
 from tests.base import HazelcastTestCase
@@ -5,6 +8,8 @@ from tests.util import open_connection_to_address, wait_for_partition_table
 
 
 class HeartbeatTest(HazelcastTestCase):
+    rc = None
+
     @classmethod
     def setUpClass(cls):
         cls.rc = cls.create_rc()
@@ -48,25 +53,57 @@ class HeartbeatTest(HazelcastTestCase):
             connection_added_collector, connection_removed_collector
         )
 
-        self.simulate_heartbeat_lost(self.client, addr, 2)
+        start_simulation = threading.Event()
+        assertion_succeeded = [False]
+        simulation_thread = self.simulate_heartbeat_loss(
+            self.client, addr, 2, start_simulation, assertion_succeeded
+        )
 
         def assert_heartbeat_stopped_and_restored():
-            self.assertEqual(1, len(connection_added_collector.connections))
-            self.assertEqual(1, len(connection_removed_collector.connections))
-            stopped_connection = connection_added_collector.connections[0]
-            restored_connection = connection_removed_collector.connections[0]
-            self.assertEqual(
-                stopped_connection.connected_address, Address(member2.host, member2.port)
-            )
-            self.assertEqual(
-                restored_connection.connected_address, Address(member2.host, member2.port)
-            )
+            self.assertTrue(len(connection_added_collector.connections) >= 1)
+            self.assertTrue(len(connection_removed_collector.connections) >= 1)
 
+            stopped_connection = connection_removed_collector.connections[0]
+            restored_connection = connection_added_collector.connections[0]
+
+            self.assertEqual(
+                stopped_connection.connected_address,
+                Address(member2.host, member2.port),
+            )
+            self.assertEqual(
+                restored_connection.connected_address,
+                Address(member2.host, member2.port),
+            )
+            assertion_succeeded[0] = True
+
+        start_simulation.set()
         self.assertTrueEventually(assert_heartbeat_stopped_and_restored)
+        simulation_thread.join()
 
     @staticmethod
-    def simulate_heartbeat_lost(client, address, timeout):
-        for connection in client._connection_manager.active_connections.values():
-            if connection.remote_address == address:
-                connection.last_read_time -= timeout
-                break
+    def simulate_heartbeat_loss(client, address, timeout, start_simulation, assertion_succeeded):
+        def run():
+            # Wait until the main thread signals we should start the simulation
+            start_simulation.wait()
+
+            # It is possible for client to override the set last_read_time
+            # of the connection, in case of the periodically sent heartbeat
+            # requests getting responses, right after we try to set a new
+            # value to it, before the next iteration of the heartbeat manager.
+            # In this case, the connection won't be closed, and the test would
+            # fail. To avoid it, we will try multiple times.
+            for i in range(10):
+                if assertion_succeeded[0]:
+                    # We have successfully simulated heartbeat loss
+                    return
+
+                for connection in client._connection_manager.active_connections.values():
+                    if connection.remote_address == address:
+                        connection.last_read_time -= timeout
+                        break
+
+                time.sleep((i + 1) * 0.1)
+
+        t = threading.Thread(target=run)
+        t.start()
+        return t

--- a/tests/integration/backward_compatible/heartbeat_test.py
+++ b/tests/integration/backward_compatible/heartbeat_test.py
@@ -53,17 +53,35 @@ class HeartbeatTest(HazelcastTestCase):
             connection_added_collector, connection_removed_collector
         )
 
-        assertion_succeeded = [False]
-        simulation_thread = self.simulate_heartbeat_loss(
-            self.client,
-            addr,
-            2,
-            assertion_succeeded,
-        )
+        assertion_succeeded = False
+
+        def run():
+            nonlocal assertion_succeeded
+            # It is possible for client to override the set last_read_time
+            # of the connection, in case of the periodically sent heartbeat
+            # requests getting responses, right after we try to set a new
+            # value to it, before the next iteration of the heartbeat manager.
+            # In this case, the connection won't be closed, and the test would
+            # fail. To avoid it, we will try multiple times.
+            for i in range(10):
+                if assertion_succeeded:
+                    # We have successfully simulated heartbeat loss
+                    return
+
+                for connection in self.client._connection_manager.active_connections.values():
+                    if connection.remote_address == addr:
+                        connection.last_read_time -= 2
+                        break
+
+                time.sleep((i + 1) * 0.1)
+
+        simulation_thread = threading.Thread(target=run)
+        simulation_thread.start()
 
         def assert_heartbeat_stopped_and_restored():
-            self.assertTrue(len(connection_added_collector.connections) >= 1)
-            self.assertTrue(len(connection_removed_collector.connections) >= 1)
+            nonlocal assertion_succeeded
+            self.assertGreaterEqual(len(connection_added_collector.connections), 1)
+            self.assertGreaterEqual(len(connection_removed_collector.connections), 1)
 
             stopped_connection = connection_removed_collector.connections[0]
             restored_connection = connection_added_collector.connections[0]
@@ -76,32 +94,7 @@ class HeartbeatTest(HazelcastTestCase):
                 restored_connection.connected_address,
                 Address(member2.host, member2.port),
             )
-            assertion_succeeded[0] = True
+            assertion_succeeded = True
 
         self.assertTrueEventually(assert_heartbeat_stopped_and_restored)
         simulation_thread.join()
-
-    @staticmethod
-    def simulate_heartbeat_loss(client, address, timeout, assertion_succeeded):
-        def run():
-            # It is possible for client to override the set last_read_time
-            # of the connection, in case of the periodically sent heartbeat
-            # requests getting responses, right after we try to set a new
-            # value to it, before the next iteration of the heartbeat manager.
-            # In this case, the connection won't be closed, and the test would
-            # fail. To avoid it, we will try multiple times.
-            for i in range(10):
-                if assertion_succeeded[0]:
-                    # We have successfully simulated heartbeat loss
-                    return
-
-                for connection in client._connection_manager.active_connections.values():
-                    if connection.remote_address == address:
-                        connection.last_read_time -= timeout
-                        break
-
-                time.sleep((i + 1) * 0.1)
-
-        t = threading.Thread(target=run)
-        t.start()
-        return t

--- a/tests/integration/backward_compatible/heartbeat_test.py
+++ b/tests/integration/backward_compatible/heartbeat_test.py
@@ -53,10 +53,12 @@ class HeartbeatTest(HazelcastTestCase):
             connection_added_collector, connection_removed_collector
         )
 
-        start_simulation = threading.Event()
         assertion_succeeded = [False]
         simulation_thread = self.simulate_heartbeat_loss(
-            self.client, addr, 2, start_simulation, assertion_succeeded
+            self.client,
+            addr,
+            2,
+            assertion_succeeded,
         )
 
         def assert_heartbeat_stopped_and_restored():
@@ -76,16 +78,12 @@ class HeartbeatTest(HazelcastTestCase):
             )
             assertion_succeeded[0] = True
 
-        start_simulation.set()
         self.assertTrueEventually(assert_heartbeat_stopped_and_restored)
         simulation_thread.join()
 
     @staticmethod
-    def simulate_heartbeat_loss(client, address, timeout, start_simulation, assertion_succeeded):
+    def simulate_heartbeat_loss(client, address, timeout, assertion_succeeded):
         def run():
-            # Wait until the main thread signals we should start the simulation
-            start_simulation.wait()
-
             # It is possible for client to override the set last_read_time
             # of the connection, in case of the periodically sent heartbeat
             # requests getting responses, right after we try to set a new

--- a/tests/integration/backward_compatible/listener_test.py
+++ b/tests/integration/backward_compatible/listener_test.py
@@ -1,3 +1,6 @@
+import threading
+import time
+
 from parameterized import parameterized
 
 from tests.base import HazelcastTestCase
@@ -74,13 +77,40 @@ class ListenerAddMemberTest(HazelcastTestCase):
         self.client_config["smart_routing"] = is_smart
         client = self.create_client(self.client_config)
         random_map = client.get_map(random_string()).blocking()
-        random_map.add_entry_listener(added_func=self.collector)
+        random_map.add_entry_listener(added_func=self.collector, updated_func=self.collector)
         m2 = self.cluster.start_member()
         wait_for_partition_table(client)
         key_m2 = generate_key_owned_by_instance(client, m2.uuid)
-        random_map.put(key_m2, "value")
+
+        start_put = threading.Event()
+        assertion_succeeded = [False]
+
+        def run():
+            # Wait until the main thread signals we should start the map#put
+            start_put.wait()
+
+            # When a new connection is added, we add the existing
+            # listeners to it, but we do it non-blocking. So, it might
+            # be the case that, the listener registration request is
+            # sent to the new member, but not completed yet.
+            # So, we might not get an event for the put. To avoid this,
+            # we will put multiple times.
+            for i in range(10):
+                if assertion_succeeded[0]:
+                    # We have successfully got an event
+                    return
+
+                random_map.put(key_m2, f"value-{i}")
+
+                time.sleep((i + 1) * 0.1)
+
+        put_thread = threading.Thread(target=run)
+        put_thread.start()
 
         def assert_event():
-            self.assertEqual(1, len(self.collector.events))
+            self.assertTrue(len(self.collector.events) >= 1)
+            assertion_succeeded[0] = True
 
+        start_put.set()
         self.assertTrueEventually(assert_event)
+        put_thread.join()

--- a/tests/integration/backward_compatible/listener_test.py
+++ b/tests/integration/backward_compatible/listener_test.py
@@ -82,13 +82,9 @@ class ListenerAddMemberTest(HazelcastTestCase):
         wait_for_partition_table(client)
         key_m2 = generate_key_owned_by_instance(client, m2.uuid)
 
-        start_put = threading.Event()
         assertion_succeeded = [False]
 
         def run():
-            # Wait until the main thread signals we should start the map#put
-            start_put.wait()
-
             # When a new connection is added, we add the existing
             # listeners to it, but we do it non-blocking. So, it might
             # be the case that, the listener registration request is
@@ -111,6 +107,5 @@ class ListenerAddMemberTest(HazelcastTestCase):
             self.assertTrue(len(self.collector.events) >= 1)
             assertion_succeeded[0] = True
 
-        start_put.set()
         self.assertTrueEventually(assert_event)
         put_thread.join()

--- a/tests/integration/backward_compatible/listener_test.py
+++ b/tests/integration/backward_compatible/listener_test.py
@@ -82,9 +82,10 @@ class ListenerAddMemberTest(HazelcastTestCase):
         wait_for_partition_table(client)
         key_m2 = generate_key_owned_by_instance(client, m2.uuid)
 
-        assertion_succeeded = [False]
+        assertion_succeeded = False
 
         def run():
+            nonlocal assertion_succeeded
             # When a new connection is added, we add the existing
             # listeners to it, but we do it non-blocking. So, it might
             # be the case that, the listener registration request is
@@ -92,7 +93,7 @@ class ListenerAddMemberTest(HazelcastTestCase):
             # So, we might not get an event for the put. To avoid this,
             # we will put multiple times.
             for i in range(10):
-                if assertion_succeeded[0]:
+                if assertion_succeeded:
                     # We have successfully got an event
                     return
 
@@ -104,8 +105,9 @@ class ListenerAddMemberTest(HazelcastTestCase):
         put_thread.start()
 
         def assert_event():
-            self.assertTrue(len(self.collector.events) >= 1)
-            assertion_succeeded[0] = True
+            nonlocal assertion_succeeded
+            self.assertGreaterEqual(len(self.collector.events), 1)
+            assertion_succeeded = True
 
         self.assertTrueEventually(assert_event)
         put_thread.join()


### PR DESCRIPTION
We had some test failures on the backward compatibility runs, mainly
due to the fact that, the failing tests were not resilient enough
to timing problems.

In the `HeartbeatTest::test_heartbeat_stopped_and_restored`, it was
possible that the responses coming from the server for the previous
heartbeat requests to override what we wrote as the `last_read_time`.

In the `ListenerAddMemberTest::test_add_member`, it was possible that
the `map#put` would complete before the listener is registered to the
newly added connection.