### PR TITLE
[API-521] Add support for compact serialization to public APIs

### DIFF
--- a/hazelcast/client.py
+++ b/hazelcast/client.py
@@ -379,7 +379,9 @@ class HazelcastClient:
         self._address_provider = self._create_address_provider()
         self._internal_partition_service = _InternalPartitionService(self)
         self._partition_service = PartitionService(
-            self._internal_partition_service, self._serialization_service
+            self._internal_partition_service,
+            self._serialization_service,
+            self._compact_schema_service.send_schema_and_retry,
         )
         self._internal_cluster_service = _InternalClusterService(self, config)
         self._cluster_service = ClusterService(self._internal_cluster_service)
@@ -431,7 +433,10 @@ class HazelcastClient:
             self._compact_schema_service,
         )
         self._internal_sql_service = _InternalSqlService(
-            self._connection_manager, self._serialization_service, self._invocation_service
+            self._connection_manager,
+            self._serialization_service,
+            self._invocation_service,
+            self._compact_schema_service.send_schema_and_retry,
         )
         self._sql_service = SqlService(self._internal_sql_service)
         self._init_context()

--- a/hazelcast/compact.py
+++ b/hazelcast/compact.py
@@ -9,7 +9,11 @@ from hazelcast.protocol.codec import (
     client_send_schema_codec,
     client_send_all_schemas_codec,
 )
-from hazelcast.serialization.compact import CompactStreamSerializer, Schema
+from hazelcast.serialization.compact import (
+    CompactStreamSerializer,
+    Schema,
+    SchemaNotReplicatedError,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -37,13 +41,22 @@ class CompactSchemaService:
         self._invocation_service.invoke(fetch_schema_invocation)
         return fetch_schema_invocation.future
 
-    def send_schema(self, schema: Schema, clazz: typing.Type) -> Future:
+    def send_schema_and_retry(
+        self,
+        error: SchemaNotReplicatedError,
+        func: typing.Callable[..., Future],
+        *args: typing.Any,
+        **kwargs: typing.Any,
+    ) -> Future:
+        schema = error.schema
+        clazz = error.clazz
         request = client_send_schema_codec.encode_request(schema)
         invocation = Invocation(request)
 
         def continuation(future):
             future.result()
             self._compact_serializer.register_sent_schema(schema, clazz)
+            return func(*args, **kwargs)
 
         self._invocation_service.invoke(invocation)
         return invocation.future.continue_with(continuation)

--- a/hazelcast/compact.py
+++ b/hazelcast/compact.py
@@ -55,14 +55,14 @@ class CompactSchemaService:
 
         def continuation(future):
             future.result()
-            self._compact_serializer.register_sent_schema(schema, clazz)
+            self._compact_serializer.register_schema_to_type(schema, clazz)
             return func(*args, **kwargs)
 
         self._invocation_service.invoke(invocation)
         return invocation.future.continue_with(continuation)
 
     def send_all_schemas(self) -> Future:
-        schemas = self._compact_serializer.get_sent_schemas()
+        schemas = self._compact_serializer.get_schemas()
         if not schemas:
             _logger.debug("There is no schema to send to the cluster.")
             return ImmediateFuture(None)
@@ -80,4 +80,4 @@ class CompactSchemaService:
                 f"The schema with the id {schema_id} can not be found in the cluster."
             )
 
-        self._compact_serializer.register_fetched_schema(schema)
+        self._compact_serializer.register_schema_to_id(schema)

--- a/hazelcast/partition.py
+++ b/hazelcast/partition.py
@@ -60,7 +60,7 @@ class PartitionService:
         try:
             key_data = self._serialization_service.to_data(key)
         except SchemaNotReplicatedError as e:
-            self._send_schema_and_retry_fn(e, lambda: ...).result()
+            self._send_schema_and_retry_fn(e, lambda: None).result()
             return self.get_partition_id(key)
 
         return self._service.get_partition_id(key_data)

--- a/hazelcast/partition.py
+++ b/hazelcast/partition.py
@@ -5,6 +5,7 @@ import typing
 
 from hazelcast.errors import ClientOfflineError
 from hazelcast.hash import hash_to_index
+from hazelcast.serialization.compact import SchemaNotReplicatedError
 
 _logger = logging.getLogger(__name__)
 
@@ -27,11 +28,12 @@ class PartitionService:
     owner or the partition id of a key.
     """
 
-    __slots__ = ("_service", "_serialization_service")
+    __slots__ = ("_service", "_serialization_service", "_send_schema_and_retry_fn")
 
-    def __init__(self, internal_partition_service, serialization_service):
+    def __init__(self, internal_partition_service, serialization_service, send_schema_and_retry_fn):
         self._service = internal_partition_service
         self._serialization_service = serialization_service
+        self._send_schema_and_retry_fn = send_schema_and_retry_fn
 
     def get_partition_owner(self, partition_id: int) -> typing.Optional[uuid.UUID]:
         """
@@ -55,7 +57,12 @@ class PartitionService:
         Returns:
             The partition id.
         """
-        key_data = self._serialization_service.to_data(key)
+        try:
+            key_data = self._serialization_service.to_data(key)
+        except SchemaNotReplicatedError as e:
+            self._send_schema_and_retry_fn(e, lambda: ...).result()
+            return self.get_partition_id(key)
+
         return self._service.get_partition_id(key_data)
 
     def get_partition_count(self) -> int:

--- a/hazelcast/proxy/base.py
+++ b/hazelcast/proxy/base.py
@@ -256,35 +256,22 @@ class EntryEvent(typing.Generic[KeyType, ValueType]):
 
 
 class TopicMessage(typing.Generic[MessageType]):
-    """Topic message."""
+    """Topic message.
 
-    __slots__ = ("_name", "_message", "_publish_time", "_member")
+    Attributes:
+        name: Name of the proxy that fired the event.
+        message: The message sent to Topic.
+        publish_time: UNIX time that the event is published as seconds.
+        member: Member that fired the event.
+    """
 
-    def __init__(self, name, message, publish_time, member):
+    __slots__ = ("name", "message", "publish_time", "member")
+
+    def __init__(self, name: str, message: MessageType, publish_time: int, member: MemberInfo):
         self._name = name
         self._message = message
         self._publish_time = publish_time
         self._member = member
-
-    @property
-    def name(self) -> str:
-        """Name of the proxy that fired the event."""
-        return self._name
-
-    @property
-    def publish_time(self) -> int:
-        """UNIX time that the event is published as seconds."""
-        return self._publish_time
-
-    @property
-    def member(self) -> MemberInfo:
-        """Member that fired the event."""
-        return self._member
-
-    @property
-    def message(self) -> MessageType:
-        """The message sent to Topic."""
-        return self._message
 
     def __repr__(self):
         return "TopicMessage(message=%s, publish_time=%s, topic_name=%s, publishing_member=%s)" % (

--- a/hazelcast/proxy/base.py
+++ b/hazelcast/proxy/base.py
@@ -107,10 +107,9 @@ class TransactionalProxy:
         self._to_object = serialization_service.to_object
         self._to_data = serialization_service.to_data
         self._send_schema_and_retry = context.compact_schema_service.send_schema_and_retry
-        self._no_op_func = lambda: None
 
     def _send_schema(self, error):
-        return self._send_schema_and_retry(error, self._no_op_func).result()
+        return self._send_schema_and_retry(error, lambda: None).result()
 
     def _invoke(self, request, response_handler=_no_op_response_handler):
         invocation = Invocation(

--- a/hazelcast/proxy/base.py
+++ b/hazelcast/proxy/base.py
@@ -268,10 +268,10 @@ class TopicMessage(typing.Generic[MessageType]):
     __slots__ = ("name", "message", "publish_time", "member")
 
     def __init__(self, name: str, message: MessageType, publish_time: int, member: MemberInfo):
-        self._name = name
-        self._message = message
-        self._publish_time = publish_time
-        self._member = member
+        self.name = name
+        self.message = message
+        self.publish_time = publish_time
+        self.member = member
 
     def __repr__(self):
         return "TopicMessage(message=%s, publish_time=%s, topic_name=%s, publishing_member=%s)" % (

--- a/hazelcast/proxy/base.py
+++ b/hazelcast/proxy/base.py
@@ -3,11 +3,9 @@ import typing
 import uuid
 
 from hazelcast.core import MemberInfo
-from hazelcast.future import Future
+from hazelcast.types import KeyType, ValueType, ItemType, MessageType, BlockingProxyType
 from hazelcast.invocation import Invocation
 from hazelcast.partition import string_partition_strategy
-from hazelcast.serialization.compact import SchemaNotReplicatedError
-from hazelcast.types import KeyType, ValueType, ItemType, MessageType, BlockingProxyType
 from hazelcast.util import get_attr_name
 
 MAX_SIZE = float("inf")
@@ -33,20 +31,7 @@ class Proxy(typing.Generic[BlockingProxyType], abc.ABC):
         self._register_listener = listener_service.register_listener
         self._deregister_listener = listener_service.deregister_listener
         self._is_smart = context.config.smart_routing
-        self._send_compact_schema = context.compact_schema_service.send_schema
-
-    def _send_schema_and_retry(
-        self,
-        error: SchemaNotReplicatedError,
-        func: typing.Callable[..., Future],
-        *args: typing.Any,
-        **kwargs: typing.Any
-    ) -> Future:
-        def continuation(future):
-            future.result()
-            return func(*args, **kwargs)
-
-        return self._send_compact_schema(error.schema, error.clazz).continue_with(continuation)
+        self._send_schema_and_retry = context.compact_schema_service.send_schema_and_retry
 
     def destroy(self) -> bool:
         """Destroys this proxy.
@@ -121,6 +106,11 @@ class TransactionalProxy:
         serialization_service = context.serialization_service
         self._to_object = serialization_service.to_object
         self._to_data = serialization_service.to_data
+        self._send_schema_and_retry = context.compact_schema_service.send_schema_and_retry
+        self._no_op_func = lambda: None
+
+    def _send_schema(self, error):
+        return self._send_schema_and_retry(error, self._no_op_func).result()
 
     def _invoke(self, request, response_handler=_no_op_response_handler):
         invocation = Invocation(
@@ -206,21 +196,16 @@ class ItemEvent(typing.Generic[ItemType]):
 
     Attributes:
         name: Name of the proxy that fired the event.
+        item: The item related to the event.
         event_type: Type of the event.
         member: Member that fired the event.
     """
 
-    def __init__(self, name: str, item_data, event_type: int, member: MemberInfo, to_object):
+    def __init__(self, name: str, item: ItemEventType, event_type: int, member: MemberInfo):
         self.name = name
-        self._item_data = item_data
+        self.item = item
         self.event_type = event_type
         self.member = member
-        self._to_object = to_object
-
-    @property
-    def item(self) -> ItemType:
-        """The item related to the event."""
-        return self._to_object(self._item_data)
 
 
 class EntryEvent(typing.Generic[KeyType, ValueType]):
@@ -230,47 +215,29 @@ class EntryEvent(typing.Generic[KeyType, ValueType]):
         event_type: Type of the event.
         uuid: UUID of the member that fired the event.
         number_of_affected_entries: Number of affected entries by this event.
+        key: The key of this entry event.
+        value: The value of the entry event.
+        old_value: The old value of the entry event.
+        merging_value: The incoming merging value of the entry event.
     """
 
     def __init__(
         self,
-        to_object,
-        key,
-        value,
-        old_value,
-        merging_value,
+        key: KeyType,
+        value: ValueType,
+        old_value: ValueType,
+        merging_value: ValueType,
         event_type: int,
         member_uuid: uuid.UUID,
         number_of_affected_entries: int,
     ):
-        self._to_object = to_object
-        self._key_data = key
-        self._value_data = value
-        self._old_value_data = old_value
-        self._merging_value_data = merging_value
+        self.key = key
+        self.value = value
+        self.old_value = old_value
+        self.merging_value = merging_value
         self.event_type = event_type
         self.uuid = member_uuid
         self.number_of_affected_entries = number_of_affected_entries
-
-    @property
-    def key(self) -> KeyType:
-        """The key of this entry event."""
-        return self._to_object(self._key_data)
-
-    @property
-    def old_value(self) -> ValueType:
-        """The old value of the entry event."""
-        return self._to_object(self._old_value_data)
-
-    @property
-    def value(self) -> ValueType:
-        """The value of the entry event."""
-        return self._to_object(self._value_data)
-
-    @property
-    def merging_value(self) -> ValueType:
-        """The incoming merging value of the entry event."""
-        return self._to_object(self._merging_value_data)
 
     def __repr__(self):
         return (
@@ -288,21 +255,16 @@ class EntryEvent(typing.Generic[KeyType, ValueType]):
         )
 
 
-_SENTINEL = object()
-
-
 class TopicMessage(typing.Generic[MessageType]):
     """Topic message."""
 
-    __slots__ = ("_name", "_message_data", "_message", "_publish_time", "_member", "_to_object")
+    __slots__ = ("_name", "_message", "_publish_time", "_member")
 
-    def __init__(self, name, message_data, publish_time, member, to_object):
+    def __init__(self, name, message, publish_time, member):
         self._name = name
-        self._message_data = message_data
-        self._message = _SENTINEL
+        self._message = message
         self._publish_time = publish_time
         self._member = member
-        self._to_object = to_object
 
     @property
     def name(self) -> str:
@@ -322,10 +284,6 @@ class TopicMessage(typing.Generic[MessageType]):
     @property
     def message(self) -> MessageType:
         """The message sent to Topic."""
-        if self._message is not _SENTINEL:
-            return self._message
-
-        self._message = self._to_object(self._message_data)
         return self._message
 
     def __repr__(self):

--- a/hazelcast/proxy/cp/__init__.py
+++ b/hazelcast/proxy/cp/__init__.py
@@ -14,7 +14,6 @@ def _no_op_response_handler(_):
 
 class BaseCPProxy(typing.Generic[BlockingProxyType], abc.ABC):
     def __init__(self, context, group_id, service_name, proxy_name, object_name):
-        self._context = context
         self._group_id = group_id
         self._service_name = service_name
         self._proxy_name = proxy_name

--- a/hazelcast/proxy/cp/__init__.py
+++ b/hazelcast/proxy/cp/__init__.py
@@ -23,6 +23,7 @@ class BaseCPProxy(typing.Generic[BlockingProxyType], abc.ABC):
         serialization_service = context.serialization_service
         self._to_data = serialization_service.to_data
         self._to_object = serialization_service.to_object
+        self._send_schema_and_retry = context.compact_schema_service.send_schema_and_retry
 
     def destroy(self) -> Future[None]:
         """Destroys this proxy."""

--- a/hazelcast/proxy/map.py
+++ b/hazelcast/proxy/map.py
@@ -187,21 +187,76 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
         )
 
         if key and predicate:
+            try:
+                key_data = self._to_data(key)
+                predicate_data = self._to_data(predicate)
+            except SchemaNotReplicatedError as e:
+                return self._send_schema_and_retry(
+                    e,
+                    self.add_entry_listener,
+                    include_value,
+                    key,
+                    predicate,
+                    added_func,
+                    removed_func,
+                    updated_func,
+                    evicted_func,
+                    evict_all_func,
+                    clear_all_func,
+                    merged_func,
+                    expired_func,
+                    loaded_func,
+                )
+
             codec = map_add_entry_listener_to_key_with_predicate_codec
-            key_data = self._to_data(key)
-            predicate_data = self._to_data(predicate)
             request = codec.encode_request(
                 self.name, key_data, predicate_data, include_value, flags, self._is_smart
             )
         elif key and not predicate:
+            try:
+                key_data = self._to_data(key)
+            except SchemaNotReplicatedError as e:
+                return self._send_schema_and_retry(
+                    e,
+                    self.add_entry_listener,
+                    include_value,
+                    key,
+                    predicate,
+                    added_func,
+                    removed_func,
+                    updated_func,
+                    evicted_func,
+                    evict_all_func,
+                    clear_all_func,
+                    merged_func,
+                    expired_func,
+                    loaded_func,
+                )
             codec = map_add_entry_listener_to_key_codec
-            key_data = self._to_data(key)
             request = codec.encode_request(
                 self.name, key_data, include_value, flags, self._is_smart
             )
         elif not key and predicate:
+            try:
+                predicate = self._to_data(predicate)
+            except SchemaNotReplicatedError as e:
+                return self._send_schema_and_retry(
+                    e,
+                    self.add_entry_listener,
+                    include_value,
+                    key,
+                    predicate,
+                    added_func,
+                    removed_func,
+                    updated_func,
+                    evicted_func,
+                    evict_all_func,
+                    clear_all_func,
+                    merged_func,
+                    expired_func,
+                    loaded_func,
+                )
             codec = map_add_entry_listener_with_predicate_codec
-            predicate = self._to_data(predicate)
             request = codec.encode_request(
                 self.name, predicate, include_value, flags, self._is_smart
             )
@@ -210,14 +265,19 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
             request = codec.encode_request(self.name, include_value, flags, self._is_smart)
 
         def handle_event_entry(
-            key_, value, old_value, merging_value, event_type, uuid, number_of_affected_entries
+            key_data,
+            value_data,
+            old_value_data,
+            merging_value_data,
+            event_type,
+            uuid,
+            number_of_affected_entries,
         ):
             event = EntryEvent(
-                self._to_object,
-                key_,
-                value,
-                old_value,
-                merging_value,
+                self._to_object(key_data),
+                self._to_object(value_data),
+                self._to_object(old_value_data),
+                self._to_object(merging_value_data),
                 event_type,
                 uuid,
                 number_of_affected_entries,
@@ -330,7 +390,10 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
         Returns:
             Id of registered interceptor.
         """
-        interceptor_data = self._to_data(interceptor)
+        try:
+            interceptor_data = self._to_data(interceptor)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.add_interceptor, interceptor)
 
         request = map_add_interceptor_codec.encode_request(self.name, interceptor_data)
         return self._invoke(request, map_add_interceptor_codec.decode_response)
@@ -349,25 +412,31 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
             The result of the aggregation.
         """
         check_not_none(aggregator, "aggregator can't be none")
-        aggregator_data = self._to_data(aggregator)
 
         if predicate:
             if isinstance(predicate, PagingPredicate):
                 raise AssertionError("Paging predicate is not supported.")
 
-            def handler(message):
-                return self._to_object(map_aggregate_with_predicate_codec.decode_response(message))
+            try:
+                aggregator_data = self._to_data(aggregator)
+                predicate_data = self._to_data(predicate)
+            except SchemaNotReplicatedError as e:
+                return self._send_schema_and_retry(e, self.aggregate, aggregator, predicate)
 
-            predicate_data = self._to_data(predicate)
-            request = map_aggregate_with_predicate_codec.encode_request(
-                self.name, aggregator_data, predicate_data
-            )
-            return self._invoke(request, handler)
+            codec = map_aggregate_with_predicate_codec
+            request = codec.encode_request(self.name, aggregator_data, predicate_data)
+        else:
+            try:
+                aggregator_data = self._to_data(aggregator)
+            except SchemaNotReplicatedError as e:
+                return self._send_schema_and_retry(e, self.aggregate, aggregator, predicate)
+
+            codec = map_aggregate_codec
+            request = map_aggregate_codec.encode_request(self.name, aggregator_data)
 
         def handler(message):
-            return self._to_object(map_aggregate_codec.decode_response(message))
+            return self._to_object(codec.decode_response(message))
 
-        request = map_aggregate_codec.encode_request(self.name, aggregator_data)
         return self._invoke(request, handler)
 
     def clear(self) -> Future[None]:
@@ -394,7 +463,11 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
             ``False`` otherwise.
         """
         check_not_none(key, "key can't be None")
-        key_data = self._to_data(key)
+        try:
+            key_data = self._to_data(key)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.contains_key, key)
+
         return self._contains_key_internal(key_data)
 
     def contains_value(self, value: ValueType) -> Future[bool]:
@@ -409,7 +482,10 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
             ``False`` otherwise.
         """
         check_not_none(value, "value can't be None")
-        value_data = self._to_data(value)
+        try:
+            value_data = self._to_data(value)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.contains_value, value)
 
         request = map_contains_value_codec.encode_request(self.name, value_data)
         return self._invoke(request, map_contains_value_codec.decode_response)
@@ -437,7 +513,11 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
             key: Key of the mapping to be deleted.
         """
         check_not_none(key, "key can't be None")
-        key_data = self._to_data(key)
+        try:
+            key_data = self._to_data(key)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.delete, key)
+
         return self._delete_internal(key_data)
 
     def entry_set(
@@ -457,6 +537,12 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
         """
         if predicate:
             if isinstance(predicate, PagingPredicate):
+                predicate.iteration_type = IterationType.ENTRY
+                try:
+                    holder = PagingPredicateHolder.of(predicate, self._to_data)
+                except SchemaNotReplicatedError as e:
+                    return self._send_schema_and_retry(e, self.entry_set, predicate)
+
                 codec = map_entries_with_paging_predicate_codec
 
                 def handler(message):
@@ -466,16 +552,18 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
                     )
                     return ImmutableLazyDataList(response["response"], self._to_object)
 
-                predicate.iteration_type = IterationType.ENTRY
-                holder = PagingPredicateHolder.of(predicate, self._to_data)
                 request = codec.encode_request(self.name, holder)
             else:
+                try:
+                    predicate_data = self._to_data(predicate)
+                except SchemaNotReplicatedError as e:
+                    return self._send_schema_and_retry(e, self.entry_set, predicate)
+
                 codec = map_entries_with_predicate_codec
 
                 def handler(message):
                     return ImmutableLazyDataList(codec.decode_response(message), self._to_object)
 
-                predicate_data = self._to_data(predicate)
                 request = codec.encode_request(self.name, predicate_data)
         else:
             codec = map_entry_set_codec
@@ -502,7 +590,11 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
             ``True`` if the key is evicted, ``False`` otherwise.
         """
         check_not_none(key, "key can't be None")
-        key_data = self._to_data(key)
+        try:
+            key_data = self._to_data(key)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.evict, key)
+
         return self._evict_internal(key_data)
 
     def evict_all(self) -> Future[None]:
@@ -533,25 +625,35 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
             entry process.
         """
         if predicate:
+            try:
+                entry_processor_data = self._to_data(entry_processor)
+                predicate_data = self._to_data(predicate)
+            except SchemaNotReplicatedError as e:
+                return self._send_schema_and_retry(
+                    e, self.execute_on_entries, entry_processor, predicate
+                )
 
             def handler(message):
                 return ImmutableLazyDataList(
                     map_execute_with_predicate_codec.decode_response(message), self._to_object
                 )
 
-            entry_processor_data = self._to_data(entry_processor)
-            predicate_data = self._to_data(predicate)
             request = map_execute_with_predicate_codec.encode_request(
                 self.name, entry_processor_data, predicate_data
             )
         else:
+            try:
+                entry_processor_data = self._to_data(entry_processor)
+            except SchemaNotReplicatedError as e:
+                return self._send_schema_and_retry(
+                    e, self.execute_on_entries, entry_processor, predicate
+                )
 
             def handler(message):
                 return ImmutableLazyDataList(
                     map_execute_on_all_keys_codec.decode_response(message), self._to_object
                 )
 
-            entry_processor_data = self._to_data(entry_processor)
             request = map_execute_on_all_keys_codec.encode_request(self.name, entry_processor_data)
 
         return self._invoke(request, handler)
@@ -573,8 +675,13 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
             Result of entry process.
         """
         check_not_none(key, "key can't be None")
-        key_data = self._to_data(key)
-        return self._execute_on_key_internal(key_data, entry_processor)
+        try:
+            key_data = self._to_data(key)
+            entry_processor_data = self._to_data(entry_processor)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.execute_on_key, key, entry_processor)
+
+        return self._execute_on_key_internal(key_data, entry_processor_data)
 
     def execute_on_keys(
         self, keys: typing.Sequence[KeyType], entry_processor: typing.Any
@@ -595,20 +702,24 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
             List of map entries which includes the keys and the results of the
             entry process.
         """
-        key_list = []
-        for key in keys:
-            check_not_none(key, "key can't be None")
-            key_list.append(self._to_data(key))
-
         if len(keys) == 0:
             return ImmediateFuture([])
+
+        try:
+            key_list = []
+            for key in keys:
+                check_not_none(key, "key can't be None")
+                key_list.append(self._to_data(key))
+
+            entry_processor_data = self._to_data(entry_processor)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.execute_on_keys, keys, entry_processor)
 
         def handler(message):
             return ImmutableLazyDataList(
                 map_execute_on_keys_codec.decode_response(message), self._to_object
             )
 
-        entry_processor_data = self._to_data(entry_processor)
         request = map_execute_on_keys_codec.encode_request(
             self.name, entry_processor_data, key_list
         )
@@ -635,7 +746,10 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
             key: The key to lock.
         """
         check_not_none(key, "key can't be None")
-        key_data = self._to_data(key)
+        try:
+            key_data = self._to_data(key)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.force_unlock, key)
 
         request = map_force_unlock_codec.encode_request(
             self.name, key_data, self._reference_id_generator.get_and_increment()
@@ -700,14 +814,17 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
         partition_service = self._context.partition_service
         partition_to_keys = {}
 
-        for key in keys:
-            check_not_none(key, "key can't be None")
-            key_data = self._to_data(key)
-            partition_id = partition_service.get_partition_id(key_data)
-            try:
-                partition_to_keys[partition_id][key] = key_data
-            except KeyError:
-                partition_to_keys[partition_id] = {key: key_data}
+        try:
+            for key in keys:
+                check_not_none(key, "key can't be None")
+                key_data = self._to_data(key)
+                partition_id = partition_service.get_partition_id(key_data)
+                try:
+                    partition_to_keys[partition_id][key] = key_data
+                except KeyError:
+                    partition_to_keys[partition_id] = {key: key_data}
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.get_all, keys)
 
         return self._get_all_internal(partition_to_keys)
 
@@ -732,6 +849,10 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
             EntryView of the specified key.
         """
         check_not_none(key, "key can't be None")
+        try:
+            key_data = self._to_data(key)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.get_entry_view, key)
 
         def handler(message):
             response = map_get_entry_view_codec.decode_response(message)
@@ -743,7 +864,6 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
             entry_view.value = self._to_object(entry_view.value)
             return entry_view
 
-        key_data = self._to_data(key)
         request = map_get_entry_view_codec.encode_request(self.name, key_data, thread_id())
         return self._invoke_on_key(request, key_data, handler)
 
@@ -772,7 +892,10 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
             ``True`` if lock is acquired, ``False`` otherwise.
         """
         check_not_none(key, "key can't be None")
-        key_data = self._to_data(key)
+        try:
+            key_data = self._to_data(key)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.is_locked, key)
 
         request = map_is_locked_codec.encode_request(self.name, key_data)
         return self._invoke_on_key(request, key_data, map_is_locked_codec.decode_response)
@@ -793,6 +916,12 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
         """
         if predicate:
             if isinstance(predicate, PagingPredicate):
+                try:
+                    predicate.iteration_type = IterationType.KEY
+                    holder = PagingPredicateHolder.of(predicate, self._to_data)
+                except SchemaNotReplicatedError as e:
+                    return self._send_schema_and_retry(e, self.key_set, predicate)
+
                 codec = map_key_set_with_paging_predicate_codec
 
                 def handler(message):
@@ -802,16 +931,18 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
                     )
                     return ImmutableLazyDataList(response["response"], self._to_object)
 
-                predicate.iteration_type = IterationType.KEY
-                holder = PagingPredicateHolder.of(predicate, self._to_data)
                 request = codec.encode_request(self.name, holder)
             else:
+                try:
+                    predicate_data = self._to_data(predicate)
+                except SchemaNotReplicatedError as e:
+                    return self._send_schema_and_retry(e, self.key_set, predicate)
+
                 codec = map_key_set_with_predicate_codec
 
                 def handler(message):
                     return ImmutableLazyDataList(codec.decode_response(message), self._to_object)
 
-                predicate_data = self._to_data(predicate)
                 request = codec.encode_request(self.name, predicate_data)
         else:
             codec = map_key_set_codec
@@ -836,11 +967,15 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
                 MapLoader.
         """
         if keys:
-            key_data_list = list(map(self._to_data, keys))
+            try:
+                key_data_list = [self._to_data(key) for key in keys]
+            except SchemaNotReplicatedError as e:
+                return self._send_schema_and_retry(e, self.load_all, keys, replace_existing_values)
+
             return self._load_all_internal(key_data_list, replace_existing_values)
-        else:
-            request = map_load_all_codec.encode_request(self.name, replace_existing_values)
-            return self._invoke(request)
+
+        request = map_load_all_codec.encode_request(self.name, replace_existing_values)
+        return self._invoke(request)
 
     def lock(self, key: KeyType, lease_time: float = None) -> Future[None]:
         """Acquires the lock for the specified key infinitely or for the
@@ -874,7 +1009,10 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
             lease_time: Time in seconds to wait before releasing the lock.
         """
         check_not_none(key, "key can't be None")
-        key_data = self._to_data(key)
+        try:
+            key_data = self._to_data(key)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.lock, key, lease_time)
 
         request = map_lock_codec.encode_request(
             self.name,
@@ -902,29 +1040,39 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
             The result of the projection.
         """
         check_not_none(projection, "Projection can't be none")
-        projection_data = self._to_data(projection)
 
         if predicate:
             if isinstance(predicate, PagingPredicate):
                 raise AssertionError("Paging predicate is not supported.")
+
+            try:
+                projection_data = self._to_data(projection)
+                predicate_data = self._to_data(predicate)
+            except SchemaNotReplicatedError as e:
+                return self._send_schema_and_retry(e, self.project, projection, predicate)
 
             def handler(message):
                 return ImmutableLazyDataList(
                     map_project_with_predicate_codec.decode_response(message), self._to_object
                 )
 
-            predicate_data = self._to_data(predicate)
             request = map_project_with_predicate_codec.encode_request(
                 self.name, projection_data, predicate_data
             )
             return self._invoke(request, handler)
+        else:
+            try:
+                projection_data = self._to_data(projection)
+            except SchemaNotReplicatedError as e:
+                return self._send_schema_and_retry(e, self.project, projection, predicate)
 
-        def handler(message):
-            return ImmutableLazyDataList(
-                map_project_codec.decode_response(message), self._to_object
-            )
+            def handler(message):
+                return ImmutableLazyDataList(
+                    map_project_codec.decode_response(message), self._to_object
+                )
 
-        request = map_project_codec.encode_request(self.name, projection_data)
+            request = map_project_codec.encode_request(self.name, projection_data)
+
         return self._invoke(request, handler)
 
     def put(
@@ -987,15 +1135,18 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
         partition_service = self._context.partition_service
         partition_map = {}
 
-        for key, value in map.items():
-            check_not_none(key, "key can't be None")
-            check_not_none(value, "value can't be None")
-            entry = (self._to_data(key), self._to_data(value))
-            partition_id = partition_service.get_partition_id(entry[0])
-            try:
-                partition_map[partition_id].append(entry)
-            except KeyError:
-                partition_map[partition_id] = [entry]
+        try:
+            for key, value in map.items():
+                check_not_none(key, "key can't be None")
+                check_not_none(value, "value can't be None")
+                entry = (self._to_data(key), self._to_data(value))
+                partition_id = partition_service.get_partition_id(entry[0])
+                try:
+                    partition_map[partition_id].append(entry)
+                except KeyError:
+                    partition_map[partition_id] = [entry]
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.put_all, map)
 
         futures = []
         for partition_id, entry_list in partition_map.items():
@@ -1050,8 +1201,12 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
         check_not_none(key, "key can't be None")
         check_not_none(value, "value can't be None")
 
-        key_data = self._to_data(key)
-        value_data = self._to_data(value)
+        try:
+            key_data = self._to_data(key)
+            value_data = self._to_data(value)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.put_if_absent, key, value, ttl, max_idle)
+
         return self._put_if_absent_internal(key_data, value_data, ttl, max_idle)
 
     def put_transient(
@@ -1080,8 +1235,12 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
         check_not_none(key, "key can't be None")
         check_not_none(value, "value can't be None")
 
-        key_data = self._to_data(key)
-        value_data = self._to_data(value)
+        try:
+            key_data = self._to_data(key)
+            value_data = self._to_data(value)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.put_transient, key, value, ttl, max_idle)
+
         return self._put_transient_internal(key_data, value_data, ttl, max_idle)
 
     def remove(self, key: KeyType) -> Future[typing.Optional[ValueType]]:
@@ -1103,7 +1262,11 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
             no mapping for key.
         """
         check_not_none(key, "key can't be None")
-        key_data = self._to_data(key)
+        try:
+            key_data = self._to_data(key)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.remove, key)
+
         return self._remove_internal(key_data)
 
     def remove_if_same(self, key: KeyType, value: ValueType) -> Future[bool]:
@@ -1133,9 +1296,12 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
         """
         check_not_none(key, "key can't be None")
         check_not_none(value, "value can't be None")
+        try:
+            key_data = self._to_data(key)
+            value_data = self._to_data(value)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.remove_if_same, key, value)
 
-        key_data = self._to_data(key)
-        value_data = self._to_data(value)
         return self._remove_if_same_internal_(key_data, value_data)
 
     def remove_entry_listener(self, registration_id: str) -> Future[bool]:
@@ -1196,9 +1362,11 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
         """
         check_not_none(key, "key can't be None")
         check_not_none(value, "value can't be None")
-
-        key_data = self._to_data(key)
-        value_data = self._to_data(value)
+        try:
+            key_data = self._to_data(key)
+            value_data = self._to_data(value)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.replace, key, value)
 
         return self._replace_internal(key_data, value_data)
 
@@ -1234,9 +1402,12 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
         check_not_none(old_value, "old_value can't be None")
         check_not_none(new_value, "new_value can't be None")
 
-        key_data = self._to_data(key)
-        old_value_data = self._to_data(old_value)
-        new_value_data = self._to_data(new_value)
+        try:
+            key_data = self._to_data(key)
+            old_value_data = self._to_data(old_value)
+            new_value_data = self._to_data(new_value)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.replace_if_same, key, old_value, new_value)
 
         return self._replace_if_same_internal(key_data, old_value_data, new_value_data)
 
@@ -1268,8 +1439,12 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
         """
         check_not_none(key, "key can't be None")
         check_not_none(value, "value can't be None")
-        key_data = self._to_data(key)
-        value_data = self._to_data(value)
+        try:
+            key_data = self._to_data(key)
+            value_data = self._to_data(value)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.set, key, value, ttl, max_idle)
+
         return self._set_internal(key_data, value_data, ttl, max_idle)
 
     def set_ttl(self, key: KeyType, ttl: float) -> Future[None]:
@@ -1287,7 +1462,11 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
         """
         check_not_none(key, "key can't be None")
         check_not_none(ttl, "ttl can't be None")
-        key_data = self._to_data(key)
+        try:
+            key_data = self._to_data(key)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.set_ttl, key, ttl)
+
         return self._set_ttl_internal(key_data, ttl)
 
     def size(self) -> Future[int]:
@@ -1325,8 +1504,11 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
             ``True`` if the lock was acquired, ``False`` otherwise.
         """
         check_not_none(key, "key can't be None")
+        try:
+            key_data = self._to_data(key)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.try_lock, key, lease_time, timeout)
 
-        key_data = self._to_data(key)
         request = map_try_lock_codec.encode_request(
             self.name,
             key_data,
@@ -1362,9 +1544,11 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
         """
         check_not_none(key, "key can't be None")
         check_not_none(value, "value can't be None")
-
-        key_data = self._to_data(key)
-        value_data = self._to_data(value)
+        try:
+            key_data = self._to_data(key)
+            value_data = self._to_data(value)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.try_put, key, value, timeout)
 
         return self._try_put_internal(key_data, value_data, timeout)
 
@@ -1383,8 +1567,11 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
             ``True`` if the remove is successful, ``False`` otherwise.
         """
         check_not_none(key, "key can't be None")
+        try:
+            key_data = self._to_data(key)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.try_remove, key, timeout)
 
-        key_data = self._to_data(key)
         return self._try_remove_internal(key_data, timeout)
 
     def unlock(self, key: KeyType) -> Future[None]:
@@ -1398,8 +1585,11 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
             key: The key to lock.
         """
         check_not_none(key, "key can't be None")
+        try:
+            key_data = self._to_data(key)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.unlock, key)
 
-        key_data = self._to_data(key)
         request = map_unlock_codec.encode_request(
             self.name, key_data, thread_id(), self._reference_id_generator.get_and_increment()
         )
@@ -1421,6 +1611,12 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
         """
         if predicate:
             if isinstance(predicate, PagingPredicate):
+                try:
+                    predicate.iteration_type = IterationType.VALUE
+                    holder = PagingPredicateHolder.of(predicate, self._to_data)
+                except SchemaNotReplicatedError as e:
+                    return self._send_schema_and_retry(e, self.values, predicate)
+
                 codec = map_values_with_paging_predicate_codec
 
                 def handler(message):
@@ -1430,16 +1626,18 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
                     )
                     return ImmutableLazyDataList(response["response"], self._to_object)
 
-                predicate.iteration_type = IterationType.VALUE
-                holder = PagingPredicateHolder.of(predicate, self._to_data)
                 request = codec.encode_request(self.name, holder)
             else:
+                try:
+                    predicate_data = self._to_data(predicate)
+                except SchemaNotReplicatedError as e:
+                    return self._send_schema_and_retry(e, self.values, predicate)
+
                 codec = map_values_with_predicate_codec
 
                 def handler(message):
                     return ImmutableLazyDataList(codec.decode_response(message), self._to_object)
 
-                predicate_data = self._to_data(predicate)
                 request = codec.encode_request(self.name, predicate_data)
         else:
             codec = map_values_codec
@@ -1593,11 +1791,10 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
         )
         return self._invoke(request)
 
-    def _execute_on_key_internal(self, key_data, entry_processor):
+    def _execute_on_key_internal(self, key_data, entry_processor_data):
         def handler(message):
             return self._to_object(map_execute_on_key_codec.decode_response(message))
 
-        entry_processor_data = self._to_data(entry_processor)
         request = map_execute_on_key_codec.encode_request(
             self.name, entry_processor_data, key_data, thread_id()
         )
@@ -1760,9 +1957,11 @@ class MapFeatNearCache(Map[KeyType, ValueType]):
             key_data_list, replace_existing_values
         )
 
-    def _execute_on_key_internal(self, key_data, entry_processor):
+    def _execute_on_key_internal(self, key_data, entry_processor_data):
         self._invalidate_cache(key_data)
-        return super(MapFeatNearCache, self)._execute_on_key_internal(key_data, entry_processor)
+        return super(MapFeatNearCache, self)._execute_on_key_internal(
+            key_data, entry_processor_data
+        )
 
     def _evict_internal(self, key_data):
         self._invalidate_cache(key_data)

--- a/hazelcast/proxy/multi_map.py
+++ b/hazelcast/proxy/multi_map.py
@@ -26,6 +26,7 @@ from hazelcast.protocol.codec import (
 )
 from hazelcast.proxy.base import Proxy, EntryEvent, EntryEventType
 from hazelcast.types import ValueType, KeyType
+from hazelcast.serialization.compact import SchemaNotReplicatedError
 from hazelcast.util import check_not_none, thread_id, to_millis, ImmutableLazyDataList
 
 
@@ -66,22 +67,39 @@ class MultiMap(Proxy["BlockingMultiMap"], typing.Generic[KeyType, ValueType]):
             A registration id which is used as a key to remove the listener.
         """
         if key:
+            try:
+                key_data = self._to_data(key)
+            except SchemaNotReplicatedError as e:
+                return self._send_schema_and_retry(
+                    e,
+                    self.add_entry_listener,
+                    include_value,
+                    key,
+                    added_func,
+                    removed_func,
+                    clear_all_func,
+                )
+
             codec = multi_map_add_entry_listener_to_key_codec
-            key_data = self._to_data(key)
             request = codec.encode_request(self.name, key_data, include_value, False)
         else:
             codec = multi_map_add_entry_listener_codec
             request = codec.encode_request(self.name, include_value, False)
 
         def handle_event_entry(
-            key, value, old_value, merging_value, event_type, uuid, number_of_affected_entries
+            key_data,
+            value_data,
+            old_value_data,
+            merging_value_data,
+            event_type,
+            uuid,
+            number_of_affected_entries,
         ):
             event = EntryEvent(
-                self._to_object,
-                key,
-                value,
-                old_value,
-                merging_value,
+                self._to_object(key_data),
+                self._to_object(value_data),
+                self._to_object(old_value_data),
+                self._to_object(merging_value_data),
                 event_type,
                 uuid,
                 number_of_affected_entries,
@@ -116,7 +134,10 @@ class MultiMap(Proxy["BlockingMultiMap"], typing.Generic[KeyType, ValueType]):
             ``False`` otherwise.
         """
         check_not_none(key, "key can't be None")
-        key_data = self._to_data(key)
+        try:
+            key_data = self._to_data(key)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.contains_key, key)
 
         request = multi_map_contains_key_codec.encode_request(self.name, key_data, thread_id())
         return self._invoke_on_key(request, key_data, multi_map_contains_key_codec.decode_response)
@@ -133,7 +154,11 @@ class MultiMap(Proxy["BlockingMultiMap"], typing.Generic[KeyType, ValueType]):
             value, ``False`` otherwise.
         """
         check_not_none(value, "value can't be None")
-        value_data = self._to_data(value)
+        try:
+            value_data = self._to_data(value)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.contains_value, value)
+
         request = multi_map_contains_value_codec.encode_request(self.name, value_data)
         return self._invoke(request, multi_map_contains_value_codec.decode_response)
 
@@ -150,8 +175,11 @@ class MultiMap(Proxy["BlockingMultiMap"], typing.Generic[KeyType, ValueType]):
         """
         check_not_none(key, "key can't be None")
         check_not_none(value, "value can't be None")
-        key_data = self._to_data(key)
-        value_data = self._to_data(value)
+        try:
+            key_data = self._to_data(key)
+            value_data = self._to_data(value)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.contains_entry, key, value)
 
         request = multi_map_contains_entry_codec.encode_request(
             self.name, key_data, value_data, thread_id()
@@ -204,13 +232,16 @@ class MultiMap(Proxy["BlockingMultiMap"], typing.Generic[KeyType, ValueType]):
             The list of the values associated with the specified key.
         """
         check_not_none(key, "key can't be None")
+        try:
+            key_data = self._to_data(key)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.get, key)
 
         def handler(message):
             return ImmutableLazyDataList(
                 multi_map_get_codec.decode_response(message), self._to_object
             )
 
-        key_data = self._to_data(key)
         request = multi_map_get_codec.encode_request(self.name, key_data, thread_id())
         return self._invoke_on_key(request, key_data, handler)
 
@@ -229,7 +260,10 @@ class MultiMap(Proxy["BlockingMultiMap"], typing.Generic[KeyType, ValueType]):
             ``True`` if lock is acquired, ``False`` otherwise.
         """
         check_not_none(key, "key can't be None")
-        key_data = self._to_data(key)
+        try:
+            key_data = self._to_data(key)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.is_locked, key)
 
         request = multi_map_is_locked_codec.encode_request(self.name, key_data)
         return self._invoke_on_key(request, key_data, multi_map_is_locked_codec.decode_response)
@@ -250,7 +284,11 @@ class MultiMap(Proxy["BlockingMultiMap"], typing.Generic[KeyType, ValueType]):
             key: The key to lock.
         """
         check_not_none(key, "key can't be None")
-        key_data = self._to_data(key)
+        try:
+            key_data = self._to_data(key)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.force_unlock, key)
+
         request = multi_map_force_unlock_codec.encode_request(
             self.name, key_data, self._reference_id_generator.get_and_increment()
         )
@@ -299,7 +337,11 @@ class MultiMap(Proxy["BlockingMultiMap"], typing.Generic[KeyType, ValueType]):
             lease_time: Time in seconds to wait before releasing the lock.
         """
         check_not_none(key, "key can't be None")
-        key_data = self._to_data(key)
+        try:
+            key_data = self._to_data(key)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.lock, key, lease_time)
+
         request = multi_map_lock_codec.encode_request(
             self.name,
             key_data,
@@ -327,8 +369,12 @@ class MultiMap(Proxy["BlockingMultiMap"], typing.Generic[KeyType, ValueType]):
         """
         check_not_none(key, "key can't be None")
         check_not_none(key, "value can't be None")
-        key_data = self._to_data(key)
-        value_data = self._to_data(value)
+        try:
+            key_data = self._to_data(key)
+            value_data = self._to_data(value)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.remove, key, value)
+
         request = multi_map_remove_entry_codec.encode_request(
             self.name, key_data, value_data, thread_id()
         )
@@ -360,7 +406,11 @@ class MultiMap(Proxy["BlockingMultiMap"], typing.Generic[KeyType, ValueType]):
                 multi_map_remove_codec.decode_response(message), self._to_object
             )
 
-        key_data = self._to_data(key)
+        try:
+            key_data = self._to_data(key)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.remove_all, key)
+
         request = multi_map_remove_codec.encode_request(self.name, key_data, thread_id())
         return self._invoke_on_key(request, key_data, handler)
 
@@ -382,8 +432,12 @@ class MultiMap(Proxy["BlockingMultiMap"], typing.Generic[KeyType, ValueType]):
         """
         check_not_none(key, "key can't be None")
         check_not_none(value, "value can't be None")
-        key_data = self._to_data(key)
-        value_data = self._to_data(value)
+        try:
+            key_data = self._to_data(key)
+            value_data = self._to_data(value)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.put, key, value)
+
         request = multi_map_put_codec.encode_request(self.name, key_data, value_data, thread_id())
         return self._invoke_on_key(request, key_data, multi_map_put_codec.decode_response)
 
@@ -425,7 +479,11 @@ class MultiMap(Proxy["BlockingMultiMap"], typing.Generic[KeyType, ValueType]):
             The number of values that match the given key in the multimap.
         """
         check_not_none(key, "key can't be None")
-        key_data = self._to_data(key)
+        try:
+            key_data = self._to_data(key)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.value_count, key)
+
         request = multi_map_value_count_codec.encode_request(self.name, key_data, thread_id())
         return self._invoke_on_key(request, key_data, multi_map_value_count_codec.decode_response)
 
@@ -474,7 +532,11 @@ class MultiMap(Proxy["BlockingMultiMap"], typing.Generic[KeyType, ValueType]):
             ``True`` if the lock was acquired, ``False`` otherwise.
         """
         check_not_none(key, "key can't be None")
-        key_data = self._to_data(key)
+        try:
+            key_data = self._to_data(key)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.try_lock, key, lease_time, timeout)
+
         request = multi_map_try_lock_codec.encode_request(
             self.name,
             key_data,
@@ -498,7 +560,11 @@ class MultiMap(Proxy["BlockingMultiMap"], typing.Generic[KeyType, ValueType]):
             key: The key to lock.
         """
         check_not_none(key, "key can't be None")
-        key_data = self._to_data(key)
+        try:
+            key_data = self._to_data(key)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.unlock, key)
+
         request = multi_map_unlock_codec.encode_request(
             self.name, key_data, thread_id(), self._reference_id_generator.get_and_increment()
         )

--- a/hazelcast/proxy/reliable_topic.py
+++ b/hazelcast/proxy/reliable_topic.py
@@ -17,6 +17,7 @@ from hazelcast.errors import (
 from hazelcast.future import ImmediateFuture, Future
 from hazelcast.proxy.base import Proxy, TopicMessage
 from hazelcast.proxy.ringbuffer import OVERFLOW_POLICY_FAIL, OVERFLOW_POLICY_OVERWRITE
+from hazelcast.serialization.compact import SchemaNotReplicatedError
 from hazelcast.serialization.objects import ReliableTopicMessage
 from hazelcast.types import MessageType
 from hazelcast.util import check_not_none
@@ -253,10 +254,9 @@ class _MessageRunner:
 
                     topic_message = TopicMessage(
                         self._topic_name,
-                        message.payload,
+                        self._to_object(message.payload),
                         message.publish_time,
                         member,
-                        self._to_object,
                     )
                     self._listener.on_message(topic_message)
                 except Exception as e:
@@ -571,8 +571,11 @@ class ReliableTopic(Proxy["BlockingReliableTopic"], typing.Generic[MessageType])
             message: The message.
         """
         check_not_none(message, "Message cannot be None")
+        try:
+            payload = self._to_data(message)
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.publish, message)
 
-        payload = self._to_data(message)
         topic_message = ReliableTopicMessage(time.time(), None, payload)
 
         overload_policy = self._config.overload_policy
@@ -592,13 +595,14 @@ class ReliableTopic(Proxy["BlockingReliableTopic"], typing.Generic[MessageType])
             messages: Messages to publish.
         """
         check_not_none(messages, "Messages cannot be None")
-
-        topic_messages = []
-
-        for message in messages:
-            check_not_none(message, "Message cannot be None")
-            payload = self._to_data(message)
-            topic_messages.append(ReliableTopicMessage(time.time(), None, payload))
+        try:
+            topic_messages = []
+            for message in messages:
+                check_not_none(message, "Message cannot be None")
+                payload = self._to_data(message)
+                topic_messages.append(ReliableTopicMessage(time.time(), None, payload))
+        except SchemaNotReplicatedError as e:
+            return self._send_schema_and_retry(e, self.publish_all, messages)
 
         overload_policy = self._config.overload_policy
         if overload_policy == TopicOverloadPolicy.BLOCK:

--- a/hazelcast/proxy/transactional_set.py
+++ b/hazelcast/proxy/transactional_set.py
@@ -7,6 +7,7 @@ from hazelcast.protocol.codec import (
 )
 from hazelcast.proxy.base import TransactionalProxy
 from hazelcast.types import ItemType
+from hazelcast.serialization.compact import SchemaNotReplicatedError
 from hazelcast.util import check_not_none, thread_id
 
 
@@ -24,7 +25,12 @@ class TransactionalSet(TransactionalProxy, typing.Generic[ItemType]):
             ``True`` if item is added successfully, ``False`` otherwise.
         """
         check_not_none(item, "item can't be none")
-        item_data = self._to_data(item)
+        try:
+            item_data = self._to_data(item)
+        except SchemaNotReplicatedError as e:
+            self._send_schema(e)
+            return self.add(item)
+
         request = transactional_set_add_codec.encode_request(
             self.name, self.transaction.id, thread_id(), item_data
         )
@@ -41,7 +47,12 @@ class TransactionalSet(TransactionalProxy, typing.Generic[ItemType]):
             ``True`` if item is remove successfully, ``False`` otherwise.
         """
         check_not_none(item, "item can't be none")
-        item_data = self._to_data(item)
+        try:
+            item_data = self._to_data(item)
+        except SchemaNotReplicatedError as e:
+            self._send_schema(e)
+            return self.remove(item)
+
         request = transactional_set_remove_codec.encode_request(
             self.name, self.transaction.id, thread_id(), item_data
         )

--- a/hazelcast/serialization/compact.py
+++ b/hazelcast/serialization/compact.py
@@ -49,7 +49,14 @@ class CompactStreamSerializer(BaseSerializer):
         schema = self._type_to_schema.get(clazz)
         if not schema:
             schema = CompactStreamSerializer._build_schema(serializer, obj)
-            raise SchemaNotReplicatedError(schema, clazz)
+            # Check if we already fetched the schema from the cluster.
+            if schema.schema_id not in self._id_to_schema:
+                raise SchemaNotReplicatedError(schema, clazz)
+
+            # No need to raise the not replicated error, as we just
+            # fetched it from the cluster. Let's register it to our
+            # local and continue
+            self.register_sent_schema(schema, clazz)
 
         out.write_long(schema.schema_id)
         writer = DefaultCompactWriter(self, out, schema)  # type: ignore
@@ -62,7 +69,12 @@ class CompactStreamSerializer(BaseSerializer):
         if not schema:
             raise SchemaNotFoundError(schema_id)
 
-        serializer = self._type_name_to_serializer[schema.type_name]
+        serializer = self._type_name_to_serializer.get(schema.type_name)
+        if not serializer:
+            raise HazelcastSerializationError(
+                f"No serializer is registered for the type name '{schema.type_name}'"
+            )
+
         reader = DefaultCompactReader(self, inp, schema)  # type: ignore
         return serializer.read(reader)
 
@@ -72,6 +84,11 @@ class CompactStreamSerializer(BaseSerializer):
     def register_fetched_schema(self, schema: "Schema") -> None:
         # This method is only called in the reactor thread,
         # as a callback/continuation.
+        if not schema:
+            raise HazelcastSerializationError(
+                f"No schema with id '{schema.schema_id}' " f"can be found on the cluster."
+            )
+
         schema_id = schema.schema_id
         existing_schema = self._id_to_schema.get(schema_id)
         if not existing_schema:
@@ -88,6 +105,10 @@ class CompactStreamSerializer(BaseSerializer):
     def register_sent_schema(self, schema: "Schema", clazz: typing.Type) -> None:
         # This method is only called in the reactor thread,
         # as a callback/continuation.
+        # Put it to local registry to avoid need to fetch it once
+        # we read a data with the same schema id
+        self.register_fetched_schema(schema)
+
         existing_schema = self._type_to_schema.get(clazz)
         if not existing_schema:
             self._type_to_schema[clazz] = schema
@@ -101,7 +122,7 @@ class CompactStreamSerializer(BaseSerializer):
             )
 
     def get_sent_schemas(self) -> typing.List["Schema"]:
-        return list(self._type_to_schema.values())
+        return list(self._id_to_schema.values())
 
     @staticmethod
     def _build_schema(serializer: CompactSerializer, obj: typing.Any) -> "Schema":

--- a/hazelcast/serialization/compact.py
+++ b/hazelcast/serialization/compact.py
@@ -72,7 +72,7 @@ class CompactStreamSerializer(BaseSerializer):
         serializer = self._type_name_to_serializer.get(schema.type_name)
         if not serializer:
             raise HazelcastSerializationError(
-                f"No serializer is registered for the type name '{schema.type_name}'"
+                f"No compact serializer is registered for the type name '{schema.type_name}'"
             )
 
         reader = DefaultCompactReader(self, inp, schema)  # type: ignore
@@ -86,7 +86,7 @@ class CompactStreamSerializer(BaseSerializer):
         # as a callback/continuation.
         if not schema:
             raise HazelcastSerializationError(
-                f"No schema with id '{schema.schema_id}' " f"can be found on the cluster."
+                f"No schema with id '{schema.schema_id}' can be found on the cluster."
             )
 
         schema_id = schema.schema_id

--- a/hazelcast/sql.py
+++ b/hazelcast/sql.py
@@ -1247,7 +1247,16 @@ class _InternalSqlService:
                     self._serialization_service.to_data(param) for param in statement.parameters
                 ]
             except SchemaNotReplicatedError as e:
-                return self._send_schema_and_retry_fn(e, self.execute, sql, params, kwargs)
+                return self._send_schema_and_retry_fn(
+                    e,
+                    self.execute,
+                    sql,
+                    params,
+                    cursor_buffer_size,
+                    timeout,
+                    expected_result_type,
+                    schema,
+                )
 
             connection = self._get_query_connection()
             # Create a new, unique query id.

--- a/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
+++ b/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
@@ -1,0 +1,1684 @@
+import copy
+
+from hazelcast.aggregator import Aggregator
+from hazelcast.errors import NullPointerError, IllegalMonitorStateError
+from hazelcast.predicate import Predicate, paging
+from hazelcast.serialization.api import (
+    CompactSerializer,
+    CompactWriter,
+    CompactReader,
+    CompactSerializableClass,
+)
+from tests.base import HazelcastTestCase
+from tests.util import random_string
+
+
+class InnerCompact:
+    def __init__(self, string_field: str):
+        self.string_field = string_field
+
+    def __eq__(self, o: object) -> bool:
+        return isinstance(o, InnerCompact) and self.string_field == o.string_field
+
+    def __hash__(self) -> int:
+        return hash(self.string_field)
+
+
+class OuterCompact:
+    def __init__(self, int_field: int, inner_field: InnerCompact):
+        self.int_field = int_field
+        self.inner_field = inner_field
+
+    def __eq__(self, o: object) -> bool:
+        return (
+            isinstance(o, OuterCompact)
+            and self.int_field == o.int_field
+            and self.inner_field == o.inner_field
+        )
+
+    def __hash__(self) -> int:
+        return hash((self.int_field, self.inner_field))
+
+
+class InnerSerializer(CompactSerializer[InnerCompact]):
+    def read(self, reader: CompactReader) -> InnerCompact:
+        return InnerCompact(reader.read_string("stringField"))
+
+    def write(self, writer: CompactWriter, obj: InnerCompact) -> None:
+        writer.write_string("stringField", obj.string_field)
+
+    def get_type_name(self) -> str:
+        return "com.hazelcast.serialization.compact.InnerCompact"
+
+
+class OuterSerializer(CompactSerializer[OuterCompact]):
+    def read(self, reader: CompactReader) -> OuterCompact:
+        return OuterCompact(
+            reader.read_int32("intField"),
+            reader.read_compact("innerField"),
+        )
+
+    def write(self, writer: CompactWriter, obj: OuterCompact) -> None:
+        writer.write_int32("intField", obj.int_field)
+        writer.write_compact("innerField", obj.inner_field)
+
+    def get_type_name(self) -> str:
+        return "com.hazelcast.serialization.compact.OuterCompact"
+
+
+class CompactIncrementFunction:
+    pass
+
+
+class CompactIncrementFunctionSerializer(CompactSerializer[CompactIncrementFunction]):
+    def read(self, reader: CompactReader) -> CompactIncrementFunction:
+        return CompactIncrementFunction()
+
+    def write(self, writer: CompactWriter, obj: CompactIncrementFunction) -> None:
+        pass
+
+    def get_type_name(self) -> str:
+        return "com.hazelcast.serialization.compact.CompactIncrementFunction"
+
+
+class CompactReturningFunction:
+    pass
+
+
+class CompactReturningFunctionSerializer(CompactSerializer[CompactReturningFunction]):
+    def read(self, reader: CompactReader) -> CompactSerializableClass:
+        return CompactReturningFunction()
+
+    def write(self, writer: CompactWriter, obj: CompactSerializableClass) -> None:
+        pass
+
+    def get_type_name(self) -> str:
+        return "com.hazelcast.serialization.compact.CompactReturningFunction"
+
+
+class CompactReturningCallable:
+    pass
+
+
+class CompactReturningCallableSerializer(CompactSerializer[CompactReturningCallable]):
+    def read(self, reader: CompactReader) -> CompactSerializableClass:
+        return CompactReturningCallable()
+
+    def write(self, writer: CompactWriter, obj: CompactSerializableClass) -> None:
+        pass
+
+    def get_type_name(self) -> str:
+        return "com.hazelcast.serialization.compact.CompactReturningCallable"
+
+
+class CompactPredicate(Predicate):
+    pass
+
+
+class CompactPredicateSerializer(CompactSerializer[CompactPredicate]):
+    def read(self, reader: CompactReader) -> CompactPredicate:
+        return CompactPredicate()
+
+    def write(self, writer: CompactWriter, obj: CompactPredicate) -> None:
+        pass
+
+    def get_type_name(self) -> str:
+        return "com.hazelcast.serialization.compact.CompactPredicate"
+
+
+class CompactReturningMapInterceptor:
+    pass
+
+
+class CompactReturningMapInterceptorSerializer(CompactSerializer[CompactReturningMapInterceptor]):
+    def read(self, reader: CompactReader) -> CompactSerializableClass:
+        return CompactReturningMapInterceptor()
+
+    def write(self, writer: CompactWriter, obj: CompactSerializableClass) -> None:
+        pass
+
+    def get_type_name(self) -> str:
+        return "com.hazelcast.serialization.compact.CompactReturningMapInterceptor"
+
+
+class CompactReturningAggregator(Aggregator):
+    pass
+
+
+class CompactReturningAggregatorSerializer(CompactSerializer[CompactReturningAggregator]):
+    def read(self, reader: CompactReader) -> CompactSerializableClass:
+        return CompactReturningAggregator()
+
+    def write(self, writer: CompactWriter, obj: CompactSerializableClass) -> None:
+        pass
+
+    def get_type_name(self) -> str:
+        return "com.hazelcast.serialization.compact.CompactReturningAggregator"
+
+
+class CompactReturningEntryProcessor:
+    pass
+
+
+class CompactReturningEntryProcessorSerializer(CompactSerializer[CompactReturningEntryProcessor]):
+    def read(self, reader: CompactReader) -> CompactReturningEntryProcessor:
+        return CompactReturningEntryProcessor()
+
+    def write(self, writer: CompactWriter, obj: CompactReturningEntryProcessor) -> None:
+        pass
+
+    def get_type_name(self) -> str:
+        return "com.hazelcast.serialization.compact.CompactReturningEntryProcessor"
+
+
+class CompactReturningProjection:
+    pass
+
+
+class CompactReturningProjectionSerializer(CompactSerializer[CompactReturningProjection]):
+    def read(self, reader: CompactReader) -> CompactReturningProjection:
+        return CompactReturningProjection()
+
+    def write(self, writer: CompactWriter, obj: CompactReturningProjection) -> None:
+        pass
+
+    def get_type_name(self) -> str:
+        return "com.hazelcast.serialization.compact.CompactReturningProjection"
+
+
+class CompactFilter:
+    pass
+
+
+class CompactFilterSerializer(CompactSerializer[CompactFilter]):
+    def read(self, reader: CompactReader) -> CompactFilter:
+        return CompactFilter()
+
+    def write(self, writer: CompactWriter, obj: CompactFilter) -> None:
+        pass
+
+    def get_type_name(self) -> str:
+        return "com.hazelcast.serialization.compact.CompactFilter"
+
+
+INNER_COMPACT_INSTANCE = InnerCompact("42")
+OUTER_COMPACT_INSTANCE = OuterCompact(42, INNER_COMPACT_INSTANCE)
+
+
+class CompactCompatibilityBase(HazelcastTestCase):
+    rc = None
+    cluster = None
+    client_config = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.rc = cls.create_rc()
+
+        config = f"""
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+    <serialization>
+        <compact-serialization enabled="true">
+            <registered-classes>
+                <class>
+                    com.hazelcast.serialization.compact.InnerCompact
+                </class>
+                <class>
+                    com.hazelcast.serialization.compact.OuterCompact
+                </class>
+                <class>
+                    com.hazelcast.serialization.compact.CompactIncrementFunction
+                </class>
+                <class>
+                    com.hazelcast.serialization.compact.CompactReturningFunction
+                </class>
+                <class>
+                    com.hazelcast.serialization.compact.CompactReturningCallable
+                </class>
+                <class>
+                    com.hazelcast.serialization.compact.CompactPredicate
+                </class>
+                <class>
+                    com.hazelcast.serialization.compact.CompactReturningMapInterceptor
+                </class>
+                <class>
+                    com.hazelcast.serialization.compact.CompactReturningAggregator
+                </class>
+                <class>
+                    com.hazelcast.serialization.compact.CompactReturningEntryProcessor
+                </class>
+                <class>
+                    com.hazelcast.serialization.compact.CompactReturningProjection
+                </class>
+                <class>
+                    com.hazelcast.serialization.compact.CompactFilter
+                </class>
+            </registered-classes>
+        </compact-serialization>
+    </serialization>
+    <jet enabled="true" />
+</hazelcast>
+        """
+
+        cls.cluster = cls.create_cluster(cls.rc, config)
+        cls.cluster.start_member()
+        cls.client_config = {
+            "cluster_name": cls.cluster.id,
+            "compact_serializers": {
+                InnerCompact: InnerSerializer(),
+                OuterCompact: OuterSerializer(),
+                CompactIncrementFunction: CompactIncrementFunctionSerializer(),
+                CompactReturningFunction: CompactReturningFunctionSerializer(),
+                CompactReturningCallable: CompactReturningCallableSerializer(),
+                CompactPredicate: CompactPredicateSerializer(),
+                CompactReturningMapInterceptor: CompactReturningMapInterceptorSerializer(),
+                CompactReturningAggregator: CompactReturningAggregatorSerializer(),
+                CompactReturningEntryProcessor: CompactReturningEntryProcessorSerializer(),
+                CompactReturningProjection: CompactReturningProjectionSerializer(),
+                CompactFilter: CompactFilterSerializer(),
+            },
+        }
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.rc.terminateCluster(cls.cluster.id)
+        cls.rc.exit()
+
+    def setUp(self) -> None:
+        self.client = self.create_client(self.client_config)
+
+    def tearDown(self) -> None:
+        self.shutdown_all_clients()
+
+
+class AtomicLongCompactCompatibilityTest(CompactCompatibilityBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.atomic_long = self.client.cp_subsystem.get_atomic_long(random_string()).blocking()
+        self.atomic_long.set(41)
+
+    def tearDown(self) -> None:
+        self.atomic_long.destroy()
+        super().tearDown()
+
+    def test_alter(self):
+        self.atomic_long.alter(CompactIncrementFunction())
+        self.assertEqual(42, self.atomic_long.get())
+
+    def test_alter_and_get(self):
+        self.assertEqual(42, self.atomic_long.alter_and_get(CompactIncrementFunction()))
+
+    def test_get_and_alter(self):
+        self.assertEqual(41, self.atomic_long.get_and_alter(CompactIncrementFunction()))
+        self.assertEqual(42, self.atomic_long.get())
+
+    def test_apply(self):
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.atomic_long.apply(CompactReturningFunction()))
+
+
+class AtomicReferenceCompactCompatibilityTest(CompactCompatibilityBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.atomic_reference = self.client.cp_subsystem.get_atomic_reference(
+            random_string()
+        ).blocking()
+        self.atomic_reference.set(None)
+
+    def tearDown(self) -> None:
+        self.atomic_reference.destroy()
+        super().tearDown()
+
+    def test_compare_and_set(self):
+        self.assertTrue(self.atomic_reference.compare_and_set(None, OUTER_COMPACT_INSTANCE))
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.atomic_reference.get())
+
+    def test_set(self):
+        self.atomic_reference.set(OUTER_COMPACT_INSTANCE)
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.atomic_reference.get())
+
+    def test_get_and_set(self):
+        self.assertEqual(None, self.atomic_reference.get_and_set(OUTER_COMPACT_INSTANCE))
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.atomic_reference.get_and_set(None))
+
+    def test_contains(self):
+        self.assertFalse(self.atomic_reference.contains(OUTER_COMPACT_INSTANCE))
+        self.atomic_reference.set(OUTER_COMPACT_INSTANCE)
+        self.assertTrue(self.atomic_reference.contains(OUTER_COMPACT_INSTANCE))
+
+    def test_alter(self):
+        self.atomic_reference.alter(CompactReturningFunction())
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.atomic_reference.get())
+
+    def test_alter_and_get(self):
+        self.assertEqual(
+            OUTER_COMPACT_INSTANCE,
+            self.atomic_reference.alter_and_get(CompactReturningFunction()),
+        )
+
+    def test_get_and_alter(self):
+        self.assertEqual(None, self.atomic_reference.get_and_alter(CompactReturningFunction()))
+        self.assertEqual(
+            OUTER_COMPACT_INSTANCE,
+            self.atomic_reference.get_and_alter(CompactReturningFunction()),
+        )
+
+    def test_apply(self):
+        self.assertEqual(
+            OUTER_COMPACT_INSTANCE,
+            self.atomic_reference.apply(CompactReturningFunction()),
+        )
+
+    def test_get(self):
+        self.atomic_reference.set(OUTER_COMPACT_INSTANCE)
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.atomic_reference.get())
+
+
+class ExecutorCompactCompatibilityTest(CompactCompatibilityBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.executor = self.client.get_executor(random_string()).blocking()
+
+    def tearDown(self) -> None:
+        self.executor.destroy()
+        super().tearDown()
+
+    def test_execute_on_key_owner(self):
+        self.assertEqual(
+            OUTER_COMPACT_INSTANCE,
+            self.executor.execute_on_key_owner(OUTER_COMPACT_INSTANCE, CompactReturningCallable()),
+        )
+
+    def test_execute_on_member(self):
+        member = self.client.cluster_service.get_members()[0]
+        self.assertEqual(
+            OUTER_COMPACT_INSTANCE,
+            self.executor.execute_on_member(member, CompactReturningCallable()),
+        )
+
+    def test_execute_on_members(self):
+        member = self.client.cluster_service.get_members()[0]
+        self.assertEqual(
+            OUTER_COMPACT_INSTANCE,
+            self.executor.execute_on_members([member], CompactReturningCallable())[0],
+        )
+
+    def test_execute_on_all_members(self):
+        self.assertEqual(
+            OUTER_COMPACT_INSTANCE,
+            self.executor.execute_on_all_members(CompactReturningCallable())[0],
+        )
+
+
+class ListCompactCompatibilityTest(CompactCompatibilityBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.list = self.client.get_list(random_string()).blocking()
+
+    def tearDown(self) -> None:
+        self.list.destroy()
+        super().tearDown()
+
+    def test_add(self):
+        self.assertTrue(self.list.add(OUTER_COMPACT_INSTANCE))
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.list.get(0))
+
+    def test_add_at(self):
+        self.list.add_at(0, OUTER_COMPACT_INSTANCE)
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.list.get(0))
+
+    def test_add_all(self):
+        self.assertTrue(self.list.add_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]))
+        self.assertEqual(INNER_COMPACT_INSTANCE, self.list.get(0))
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.list.get(1))
+
+    def test_add_all_at(self):
+        self.assertTrue(self.list.add_all_at(0, [INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]))
+        self.assertEqual(INNER_COMPACT_INSTANCE, self.list.get(0))
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.list.get(1))
+
+    def test_add_listener(self):
+        events = []
+
+        def listener(event):
+            events.append(event)
+
+        self.list.add_listener(include_value=True, item_added_func=listener)
+
+        self._add_from_another_client(OUTER_COMPACT_INSTANCE)
+
+        def assertion():
+            self.assertEqual(1, len(events))
+            event = events[0]
+            self.assertEqual(OUTER_COMPACT_INSTANCE, event.item)
+
+        self.assertTrueEventually(assertion)
+
+    def test_contains(self):
+        self.assertFalse(self.list.contains(OUTER_COMPACT_INSTANCE))
+        self.list.add(OUTER_COMPACT_INSTANCE)
+        self.assertTrue(self.list.contains(OUTER_COMPACT_INSTANCE))
+
+    def test_contains_all(self):
+        items = [INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]
+        self.assertFalse(self.list.contains_all(items))
+        self.list.add_all(items)
+        self.assertTrue(self.list.contains_all(items))
+
+    def test_get(self):
+        self._add_from_another_client(OUTER_COMPACT_INSTANCE)
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.list.get(0))
+
+    def test_index_of(self):
+        self.assertEqual(-1, self.list.index_of(OUTER_COMPACT_INSTANCE))
+        self.list.add(OUTER_COMPACT_INSTANCE)
+        self.assertEqual(0, self.list.index_of(OUTER_COMPACT_INSTANCE))
+
+    def test_last_index_of(self):
+        self.assertEqual(-1, self.list.last_index_of(OUTER_COMPACT_INSTANCE))
+        self.list.add(OUTER_COMPACT_INSTANCE)
+        self.assertEqual(0, self.list.last_index_of(OUTER_COMPACT_INSTANCE))
+
+    def test_remove(self):
+        self.assertFalse(self.list.remove(OUTER_COMPACT_INSTANCE))
+        self.list.add(OUTER_COMPACT_INSTANCE)
+        self.assertTrue(self.list.remove(OUTER_COMPACT_INSTANCE))
+
+    def test_remove_at(self):
+        self._add_from_another_client(OUTER_COMPACT_INSTANCE)
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.list.remove_at(0))
+
+    def test_remove_all(self):
+        items = [INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]
+        self.assertFalse(self.list.remove_all(items))
+        self.list.add_all(items)
+        self.assertTrue(self.list.remove_all(items))
+
+    def test_retain_all(self):
+        items = [INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]
+        self.assertFalse(self.list.retain_all(items))
+        self.list.add_all(items + ["x"])
+        self.assertTrue(self.list.retain_all(items))
+
+    def test_set_at(self):
+        self.list.add(42)
+        self.assertEqual(42, self.list.set_at(0, OUTER_COMPACT_INSTANCE))
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.list.set_at(0, INNER_COMPACT_INSTANCE))
+
+    def _add_from_another_client(self, value):
+        other_client = self.create_client(self.client_config)
+        other_client_list = other_client.get_list(self.list.name).blocking()
+        other_client_list.add(value)
+
+
+class MapCompatibilityTest(CompactCompatibilityBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.map = self.client.get_map(random_string()).blocking()
+
+    def tearDown(self) -> None:
+        self.map.destroy()
+        super().tearDown()
+
+    def test_add_entry_listener_with_key_and_predicate(self):
+        events = []
+
+        def listener(event):
+            events.append(event)
+
+        self.map.add_entry_listener(
+            include_value=True,
+            key=INNER_COMPACT_INSTANCE,
+            predicate=CompactPredicate(),
+            added_func=listener,
+        )
+
+        self._assert_entry_event(events)
+
+    def test_add_entry_listener_with_key(self):
+        events = []
+
+        def listener(event):
+            events.append(event)
+
+        self.map.add_entry_listener(
+            include_value=True,
+            predicate=CompactPredicate(),
+            added_func=listener,
+        )
+
+        self._assert_entry_event(events)
+
+    def test_add_entry_listener_with_predicate(self):
+        events = []
+
+        def listener(event):
+            events.append(event)
+
+        self.map.add_entry_listener(
+            include_value=True,
+            key=INNER_COMPACT_INSTANCE,
+            added_func=listener,
+        )
+
+        self._assert_entry_event(events)
+
+    def test_add_interceptor(self):
+        self.map.add_interceptor(CompactReturningMapInterceptor())
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.map.get("non-existent-key"))
+
+    def test_aggregate(self):
+        self.assertEqual(
+            OUTER_COMPACT_INSTANCE,
+            self.map.aggregate(CompactReturningAggregator()),
+        )
+
+    def test_aggregate_with_predicate(self):
+        self.assertEqual(
+            OUTER_COMPACT_INSTANCE,
+            self.map.aggregate(CompactReturningAggregator(), predicate=CompactPredicate()),
+        )
+
+    def test_contains_key(self):
+        self.assertFalse(self.map.contains_key(OUTER_COMPACT_INSTANCE))
+        self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self.assertTrue(self.map.contains_key(OUTER_COMPACT_INSTANCE))
+
+    def test_contains_value(self):
+        self.assertFalse(self.map.contains_value(OUTER_COMPACT_INSTANCE))
+        self.map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self.assertTrue(self.map.contains_value(OUTER_COMPACT_INSTANCE))
+
+    def test_delete(self):
+        self.map.delete(OUTER_COMPACT_INSTANCE)
+        self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self.map.delete(OUTER_COMPACT_INSTANCE)
+        self.assertIsNone(self.map.get(OUTER_COMPACT_INSTANCE))
+
+    def test_entry_set_with_predicate(self):
+        # Put an entry from the same client to register these schemas
+        # to its local registry, so that the lazy-deserialization works.
+        self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self.assertEqual(
+            [(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)],
+            self.map.entry_set(CompactPredicate()),
+        )
+
+    def test_entry_set_with_paging_predicate(self):
+        # Put an entry from the same client to register these schemas
+        # to its local registry, so that the lazy-deserialization works.
+        self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self.assertEqual(
+            [(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)],
+            self.map.entry_set(paging(CompactPredicate(), 1)),
+        )
+
+    def test_evict(self):
+        self.assertFalse(self.map.evict(OUTER_COMPACT_INSTANCE))
+        self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self.assertTrue(self.map.evict(OUTER_COMPACT_INSTANCE))
+
+    def test_execute_on_entries(self):
+        self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self.assertEqual(
+            [(OUTER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)],
+            self.map.execute_on_entries(CompactReturningEntryProcessor()),
+        )
+
+    def test_execute_on_entries_predicate(self):
+        self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self.assertEqual(
+            [(OUTER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)],
+            self.map.execute_on_entries(CompactReturningEntryProcessor(), CompactPredicate()),
+        )
+
+    def test_execute_on_key(self):
+        self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self.assertEqual(
+            OUTER_COMPACT_INSTANCE,
+            self.map.execute_on_key(OUTER_COMPACT_INSTANCE, CompactReturningEntryProcessor()),
+        )
+
+    def test_execute_on_keys(self):
+        self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self.assertEqual(
+            [(OUTER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)],
+            self.map.execute_on_keys([OUTER_COMPACT_INSTANCE], CompactReturningEntryProcessor()),
+        )
+
+    def test_force_unlock(self):
+        self.map.force_unlock(OUTER_COMPACT_INSTANCE)
+        self.map.lock(OUTER_COMPACT_INSTANCE)
+        self.map.force_unlock(OUTER_COMPACT_INSTANCE)
+        self.assertFalse(self.map.is_locked(OUTER_COMPACT_INSTANCE))
+
+    def test_get(self):
+        self._put_from_another_client(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self.assertEqual(INNER_COMPACT_INSTANCE, self.map.get(OUTER_COMPACT_INSTANCE))
+
+    def test_get_all(self):
+        self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self.assertEqual(
+            {OUTER_COMPACT_INSTANCE: INNER_COMPACT_INSTANCE},
+            self.map.get_all([OUTER_COMPACT_INSTANCE]),
+        )
+
+    def test_get_entry_view(self):
+        self._put_from_another_client(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        entry_view = self.map.get_entry_view(OUTER_COMPACT_INSTANCE)
+        self.assertEqual(OUTER_COMPACT_INSTANCE, entry_view.key)
+        self.assertEqual(INNER_COMPACT_INSTANCE, entry_view.value)
+
+    def test_is_locked(self):
+        self.assertFalse(self.map.is_locked(OUTER_COMPACT_INSTANCE))
+        self.map.lock(OUTER_COMPACT_INSTANCE)
+        self.assertTrue(self.map.is_locked(OUTER_COMPACT_INSTANCE))
+
+    def test_key_set_with_predicate(self):
+        self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self.assertEqual(
+            [OUTER_COMPACT_INSTANCE],
+            self.map.key_set(CompactPredicate()),
+        )
+
+    def test_key_set_with_paging_predicate(self):
+        self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self.assertEqual(
+            [OUTER_COMPACT_INSTANCE],
+            self.map.key_set(paging(CompactPredicate(), 1)),
+        )
+
+    def test_load_all_with_keys(self):
+        try:
+            self.map.load_all(keys=[INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE])
+        except NullPointerError:
+            # Since there is no loader configured
+            # the server throws this error. In this test,
+            # we only care about sending the serialized
+            # for of the keys to the server. So, we don't
+            # care about what server does with these keys.
+            # It should probably handle this gracefully,
+            # but it is OK.
+            pass
+
+    def test_lock(self):
+        self.map.lock(OUTER_COMPACT_INSTANCE)
+        self.assertTrue(self.map.is_locked(OUTER_COMPACT_INSTANCE))
+
+    def test_project(self):
+        self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self.assertEqual(
+            [OUTER_COMPACT_INSTANCE],
+            self.map.project(CompactReturningProjection()),
+        )
+
+    def test_project_with_predicate(self):
+        self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self.assertEqual(
+            [OUTER_COMPACT_INSTANCE],
+            self.map.project(CompactReturningProjection(), CompactPredicate()),
+        )
+
+    def test_put(self):
+        self.map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.map.get(INNER_COMPACT_INSTANCE))
+
+    def test_put_all(self):
+        self.map.put_all({OUTER_COMPACT_INSTANCE: INNER_COMPACT_INSTANCE})
+        self.assertEqual(INNER_COMPACT_INSTANCE, self.map.get(OUTER_COMPACT_INSTANCE))
+
+    def test_put_if_absent(self):
+        self.assertIsNone(self.map.put_if_absent(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
+        self.assertEqual(
+            OUTER_COMPACT_INSTANCE,
+            self.map.put_if_absent(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE),
+        )
+
+    def test_put_transient(self):
+        self.map.put_transient(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.map.get(INNER_COMPACT_INSTANCE))
+
+    def test_remove(self):
+        self.assertIsNone(self.map.remove(OUTER_COMPACT_INSTANCE))
+        self._put_from_another_client(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self.assertEqual(INNER_COMPACT_INSTANCE, self.map.remove(OUTER_COMPACT_INSTANCE))
+
+    def test_remove_if_same(self):
+        self.assertFalse(self.map.remove_if_same(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self.assertTrue(self.map.remove_if_same(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
+
+    def test_replace(self):
+        self.assertIsNone(self.map.replace(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
+        self.map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self.assertEqual(
+            OUTER_COMPACT_INSTANCE, self.map.replace(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        )
+
+    def test_replace_if_same(self):
+        self.assertFalse(
+            self.map.replace_if_same(
+                INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE
+            )
+        )
+        self.map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self.assertTrue(
+            self.map.replace_if_same(
+                INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE
+            )
+        )
+
+    def test_set(self):
+        self.map.set(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.map.get(INNER_COMPACT_INSTANCE))
+
+    def test_set_ttl(self):
+        self._put_from_another_client(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self.map.set_ttl(OUTER_COMPACT_INSTANCE, 999)
+
+    def test_try_lock(self):
+        self.assertTrue(self.map.try_lock(OUTER_COMPACT_INSTANCE))
+
+    def test_try_put(self):
+        self.assertTrue(self.map.try_put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
+
+    def test_try_remove(self):
+        self.assertFalse(self.map.try_remove(OUTER_COMPACT_INSTANCE))
+        self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self.assertTrue(self.map.try_remove(OUTER_COMPACT_INSTANCE))
+
+    def test_unlock(self):
+        try:
+            self.map.unlock(OUTER_COMPACT_INSTANCE)
+        except IllegalMonitorStateError:
+            # Lock is not locked, but we don't care
+            # about it, as we only want to verify
+            # that we can send the serialized form
+            # of key to the server.
+            pass
+
+    def test_values_with_predicate(self):
+        self.map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self.assertEqual([OUTER_COMPACT_INSTANCE], self.map.values(CompactPredicate()))
+
+    def test_values_with_paging_predicate(self):
+        self.map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self.assertEqual([OUTER_COMPACT_INSTANCE], self.map.values(paging(CompactPredicate(), 1)))
+
+    def _put_from_another_client(self, key, value):
+        other_client = self.create_client(self.client_config)
+        other_client_map = other_client.get_map(self.map.name).blocking()
+        other_client_map.put(key, value)
+
+    def _assert_entry_event(self, events):
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+
+        def assertion():
+            self.assertEqual(1, len(events))
+            event = events[0]
+            self.assertEqual(INNER_COMPACT_INSTANCE, event.key)
+            self.assertEqual(OUTER_COMPACT_INSTANCE, event.value)
+            self.assertIsNone(event.old_value)
+            self.assertIsNone(event.merging_value)
+
+        self.assertTrueEventually(assertion)
+
+
+class NearCachedMapCompactCompatibilityTest(MapCompatibilityTest):
+    def setUp(self) -> None:
+        map_name = random_string()
+        self.client_config = copy.deepcopy(NearCachedMapCompactCompatibilityTest.client_config)
+        self.client_config["near_caches"] = {map_name: {}}
+        super().setUp()
+        self.map = self.client.get_map(map_name).blocking()
+
+    def test_get_for_near_cache(self):
+        # Another variant of the test in the superclass, where we lookup a key
+        # which has a value whose schema is not fully sent to the
+        # cluster. The near cache will try to serialize it, but it should
+        # not attempt to send this schema to the cluster, as it is just fetched
+        # from there.
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.map.get(INNER_COMPACT_INSTANCE))
+
+
+class MultiMapCompactCompatibilityTest(CompactCompatibilityBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.multi_map = self.client.get_multi_map(random_string()).blocking()
+
+    def tearDown(self) -> None:
+        self.multi_map.destroy()
+        super().tearDown()
+
+    def test_add_entry_listener(self):
+        events = []
+
+        def listener(event):
+            events.append(event)
+
+        self.multi_map.add_entry_listener(
+            include_value=True,
+            added_func=listener,
+        )
+
+        self._assert_entry_event(events)
+
+    def test_add_entry_listener_with_key(self):
+        events = []
+
+        def listener(event):
+            events.append(event)
+
+        self.multi_map.add_entry_listener(
+            include_value=True,
+            key=INNER_COMPACT_INSTANCE,
+            added_func=listener,
+        )
+
+        self._assert_entry_event(events)
+
+    def test_contains_key(self):
+        self.assertFalse(self.multi_map.contains_key(OUTER_COMPACT_INSTANCE))
+        self.multi_map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self.assertTrue(self.multi_map.contains_key(OUTER_COMPACT_INSTANCE))
+
+    def test_contains_value(self):
+        self.assertFalse(self.multi_map.contains_value(OUTER_COMPACT_INSTANCE))
+        self.multi_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self.assertTrue(self.multi_map.contains_value(OUTER_COMPACT_INSTANCE))
+
+    def test_contains_entry(self):
+        self.assertFalse(
+            self.multi_map.contains_entry(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        )
+        self.multi_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self.assertTrue(
+            self.multi_map.contains_entry(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        )
+
+    def test_get(self):
+        self.assertEqual([], self.multi_map.get(OUTER_COMPACT_INSTANCE))
+        self.multi_map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self.assertEqual([INNER_COMPACT_INSTANCE], self.multi_map.get(OUTER_COMPACT_INSTANCE))
+
+    def test_is_locked(self):
+        self.assertFalse(self.multi_map.is_locked(OUTER_COMPACT_INSTANCE))
+        self.multi_map.lock(OUTER_COMPACT_INSTANCE)
+        self.assertTrue(self.multi_map.is_locked(OUTER_COMPACT_INSTANCE))
+
+    def test_force_unlock(self):
+        self.multi_map.force_unlock(OUTER_COMPACT_INSTANCE)
+        self.multi_map.lock(OUTER_COMPACT_INSTANCE)
+        self.multi_map.force_unlock(OUTER_COMPACT_INSTANCE)
+        self.assertFalse(self.multi_map.is_locked(OUTER_COMPACT_INSTANCE))
+
+    def test_lock(self):
+        self.multi_map.lock(OUTER_COMPACT_INSTANCE)
+        self.assertTrue(self.multi_map.is_locked(OUTER_COMPACT_INSTANCE))
+
+    def test_remove(self):
+        self.assertFalse(self.multi_map.remove(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
+        self.multi_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self.assertTrue(self.multi_map.remove(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
+
+    def test_remove_all(self):
+        self.assertEqual([], self.multi_map.remove_all(OUTER_COMPACT_INSTANCE))
+        self.multi_map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self.assertEqual(
+            [INNER_COMPACT_INSTANCE], self.multi_map.remove_all(OUTER_COMPACT_INSTANCE)
+        )
+
+    def test_put(self):
+        self.assertTrue(self.multi_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
+        self.assertEqual([OUTER_COMPACT_INSTANCE], self.multi_map.get(INNER_COMPACT_INSTANCE))
+
+    def test_value_count(self):
+        self.assertEqual(0, self.multi_map.value_count(OUTER_COMPACT_INSTANCE))
+        self.multi_map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self.assertEqual(1, self.multi_map.value_count(OUTER_COMPACT_INSTANCE))
+
+    def test_try_lock(self):
+        self.assertTrue(self.multi_map.try_lock(OUTER_COMPACT_INSTANCE))
+
+    def test_unlock(self):
+        try:
+            self.multi_map.unlock(OUTER_COMPACT_INSTANCE)
+        except IllegalMonitorStateError:
+            # Lock is not locked, but we don't care
+            # about it, as we only want to verify
+            # that we can send the serialized form
+            # of key to the server.
+            pass
+
+    def _assert_entry_event(self, events):
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+
+        def assertion():
+            self.assertEqual(1, len(events))
+            event = events[0]
+            self.assertEqual(INNER_COMPACT_INSTANCE, event.key)
+            self.assertEqual(OUTER_COMPACT_INSTANCE, event.value)
+            self.assertIsNone(event.old_value)
+            self.assertIsNone(event.merging_value)
+
+        self.assertTrueEventually(assertion)
+
+    def _put_from_another_client(self, key, value):
+        other_client = self.create_client(self.client_config)
+        other_client_multi_map = other_client.get_multi_map(self.multi_map.name).blocking()
+        other_client_multi_map.put(key, value)
+
+
+class QueueCompactCompatibilityTest(CompactCompatibilityBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.queue = self.client.get_queue(random_string()).blocking()
+
+    def tearDown(self) -> None:
+        self.queue.destroy()
+        super().tearDown()
+
+    def test_add(self):
+        self.assertTrue(self.queue.add(OUTER_COMPACT_INSTANCE))
+
+    def test_add_all(self):
+        self.assertTrue(self.queue.add_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]))
+
+    def test_add_listener(self):
+        events = []
+
+        def listener(event):
+            events.append(event)
+
+        self.queue.add_listener(
+            include_value=True,
+            item_added_func=listener,
+        )
+
+        self._add_from_another_client(OUTER_COMPACT_INSTANCE)
+
+        def assertion():
+            self.assertEqual(1, len(events))
+            event = events[0]
+            self.assertEqual(OUTER_COMPACT_INSTANCE, event.item)
+
+        self.assertTrueEventually(assertion)
+
+    def test_contains(self):
+        self.assertFalse(self.queue.contains(OUTER_COMPACT_INSTANCE))
+        self.queue.add(OUTER_COMPACT_INSTANCE)
+        self.assertTrue(self.queue.contains(OUTER_COMPACT_INSTANCE))
+
+    def test_contains_all(self):
+        items = [INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]
+        self.assertFalse(self.queue.contains_all(items))
+        self.queue.add_all(items)
+        self.assertTrue(self.queue.contains_all(items))
+
+    def test_drain_to(self):
+        target = []
+        self._add_from_another_client(INNER_COMPACT_INSTANCE)
+        self._add_from_another_client(OUTER_COMPACT_INSTANCE)
+        self.assertEqual(2, self.queue.drain_to(target))
+        self.assertEqual([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE], target)
+
+    def test_offer(self):
+        self.assertTrue(self.queue.offer(OUTER_COMPACT_INSTANCE))
+
+    def test_peek(self):
+        self._add_from_another_client(OUTER_COMPACT_INSTANCE)
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.queue.peek())
+
+    def test_poll(self):
+        self._add_from_another_client(OUTER_COMPACT_INSTANCE)
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.queue.poll())
+
+    def test_put(self):
+        self.queue.put(OUTER_COMPACT_INSTANCE)
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.queue.poll())
+
+    def test_remove(self):
+        self.assertFalse(self.queue.remove(OUTER_COMPACT_INSTANCE))
+        self.queue.add(OUTER_COMPACT_INSTANCE)
+        self.assertTrue(self.queue.remove(OUTER_COMPACT_INSTANCE))
+
+    def test_remove_all(self):
+        items = [INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]
+        self.assertFalse(self.queue.remove_all(items))
+        self.queue.add_all(items)
+        self.assertTrue(self.queue.remove_all(items))
+
+    def test_retain_all(self):
+        items = [INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]
+        self.assertFalse(self.queue.retain_all(items))
+        self.queue.add_all(items + ["x"])
+        self.assertTrue(self.queue.retain_all(items))
+
+    def test_take(self):
+        self._add_from_another_client(OUTER_COMPACT_INSTANCE)
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.queue.take())
+
+    def _add_from_another_client(self, item):
+        other_client = self.create_client(self.client_config)
+        other_client_queue = other_client.get_queue(self.queue.name).blocking()
+        other_client_queue.add(item)
+
+
+class ReliableTopicCompactCompatibilityTest(CompactCompatibilityBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.reliable_topic = self.client.get_reliable_topic(random_string()).blocking()
+
+    def tearDown(self) -> None:
+        self.reliable_topic.destroy()
+        super().tearDown()
+
+    def test_publish(self):
+        messages = []
+
+        def listener(message):
+            messages.append(message)
+
+        self.reliable_topic.add_listener(listener)
+
+        self.reliable_topic.publish(OUTER_COMPACT_INSTANCE)
+
+        def assertion():
+            self.assertEqual(1, len(messages))
+            message = messages[0]
+            self.assertEqual(OUTER_COMPACT_INSTANCE, message.message)
+
+        self.assertTrueEventually(assertion)
+
+    def test_publish_all(self):
+        messages = []
+
+        def listener(message):
+            messages.append(message)
+
+        self.reliable_topic.add_listener(listener)
+
+        self.reliable_topic.publish_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE])
+
+        def assertion():
+            self.assertEqual(2, len(messages))
+            self.assertEqual(INNER_COMPACT_INSTANCE, messages[0].message)
+            self.assertEqual(OUTER_COMPACT_INSTANCE, messages[1].message)
+
+        self.assertTrueEventually(assertion)
+
+
+class ReplicatedMapCompactCompatibilityTest(CompactCompatibilityBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.replicated_map = self.client.get_replicated_map(random_string()).blocking()
+
+    def tearDown(self) -> None:
+        self.replicated_map.destroy()
+        super().tearDown()
+
+    def test_add_entry_listener(self):
+        events = []
+
+        def listener(event):
+            events.append(event)
+
+        self.replicated_map.add_entry_listener(
+            added_func=listener,
+        )
+
+        self._assert_entry_event(events)
+
+    def test_add_entry_listener_with_key(self):
+        events = []
+
+        def listener(event):
+            events.append(event)
+
+        self.replicated_map.add_entry_listener(
+            key=INNER_COMPACT_INSTANCE,
+            added_func=listener,
+        )
+
+        self._assert_entry_event(events)
+
+    def test_add_entry_listener_with_key_and_predicate(self):
+        events = []
+
+        def listener(event):
+            events.append(event)
+
+        self.replicated_map.add_entry_listener(
+            key=INNER_COMPACT_INSTANCE,
+            predicate=CompactPredicate(),
+            added_func=listener,
+        )
+
+        self._assert_entry_event(events)
+
+    def test_contains_key(self):
+        self.assertFalse(self.replicated_map.contains_key(OUTER_COMPACT_INSTANCE))
+        self.replicated_map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self.assertTrue(self.replicated_map.contains_key(OUTER_COMPACT_INSTANCE))
+
+    def test_contains_value(self):
+        self.assertFalse(self.replicated_map.contains_value(OUTER_COMPACT_INSTANCE))
+        self.replicated_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self.assertTrue(self.replicated_map.contains_value(OUTER_COMPACT_INSTANCE))
+
+    def test_get(self):
+        self.assertIsNone(self.replicated_map.get(OUTER_COMPACT_INSTANCE))
+        self.replicated_map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self.assertEqual(INNER_COMPACT_INSTANCE, self.replicated_map.get(OUTER_COMPACT_INSTANCE))
+
+    def test_put(self):
+        self.assertIsNone(self.replicated_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.replicated_map.get(INNER_COMPACT_INSTANCE))
+        self.assertEqual(
+            OUTER_COMPACT_INSTANCE,
+            self.replicated_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE),
+        )
+
+    def test_put_all(self):
+        self.replicated_map.put_all(
+            {
+                INNER_COMPACT_INSTANCE: OUTER_COMPACT_INSTANCE,
+                OUTER_COMPACT_INSTANCE: INNER_COMPACT_INSTANCE,
+            }
+        )
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.replicated_map.get(INNER_COMPACT_INSTANCE))
+        self.assertEqual(INNER_COMPACT_INSTANCE, self.replicated_map.get(OUTER_COMPACT_INSTANCE))
+
+    def test_remove(self):
+        self.assertIsNone(self.replicated_map.remove(OUTER_COMPACT_INSTANCE))
+        self.replicated_map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self.assertEqual(INNER_COMPACT_INSTANCE, self.replicated_map.remove(OUTER_COMPACT_INSTANCE))
+
+    def _assert_entry_event(self, events):
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+
+        def assertion():
+            self.assertEqual(1, len(events))
+            event = events[0]
+            self.assertEqual(INNER_COMPACT_INSTANCE, event.key)
+            self.assertEqual(OUTER_COMPACT_INSTANCE, event.value)
+            self.assertIsNone(event.old_value)
+            self.assertIsNone(event.merging_value)
+
+        self.assertTrueEventually(assertion)
+
+    def _put_from_another_client(self, key, value):
+        other_client = self.create_client(self.client_config)
+        other_client_replicated_map = other_client.get_replicated_map(
+            self.replicated_map.name
+        ).blocking()
+        other_client_replicated_map.put(key, value)
+
+
+class RingbufferCompactCompatibilityTest(CompactCompatibilityBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.ringbuffer = self.client.get_ringbuffer(random_string()).blocking()
+
+    def tearDown(self) -> None:
+        self.ringbuffer.destroy()
+        super().tearDown()
+
+    def test_add(self):
+        self.assertEqual(0, self.ringbuffer.add(OUTER_COMPACT_INSTANCE))
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.ringbuffer.read_one(0))
+
+    def test_add_all(self):
+        self.assertEqual(
+            1, self.ringbuffer.add_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE])
+        )
+        self.assertEqual(INNER_COMPACT_INSTANCE, self.ringbuffer.read_one(0))
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.ringbuffer.read_one(1))
+
+    def test_read_one(self):
+        self._add_from_another_client(OUTER_COMPACT_INSTANCE)
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.ringbuffer.read_one(0))
+
+    def test_read_many_with_filter(self):
+        self.ringbuffer.add(OUTER_COMPACT_INSTANCE)
+        self.assertEqual(
+            [OUTER_COMPACT_INSTANCE],
+            self.ringbuffer.read_many(0, 0, 1, filter=CompactFilter()),
+        )
+
+    def _add_from_another_client(self, item):
+        other_client = self.create_client(self.client_config)
+        other_client_ringbuffer = other_client.get_ringbuffer(self.ringbuffer.name).blocking()
+        other_client_ringbuffer.add(item)
+
+
+class SetCompactCompatibilityTest(CompactCompatibilityBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.set = self.client.get_set(random_string()).blocking()
+
+    def tearDown(self) -> None:
+        self.set.destroy()
+        super().tearDown()
+
+    def test_add(self):
+        self.assertTrue(self.set.add(OUTER_COMPACT_INSTANCE))
+
+    def test_add_all(self):
+        self.assertTrue(self.set.add_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]))
+
+    def test_add_listener(self):
+        events = []
+
+        def listener(event):
+            events.append(event)
+
+        self.set.add_listener(
+            include_value=True,
+            item_added_func=listener,
+        )
+
+        self._add_from_another_client(OUTER_COMPACT_INSTANCE)
+
+        def assertion():
+            self.assertEqual(1, len(events))
+            event = events[0]
+            self.assertEqual(OUTER_COMPACT_INSTANCE, event.item)
+
+        self.assertTrueEventually(assertion)
+
+    def test_contains(self):
+        self.assertFalse(self.set.contains(OUTER_COMPACT_INSTANCE))
+        self.set.add(OUTER_COMPACT_INSTANCE)
+        self.assertTrue(self.set.contains(OUTER_COMPACT_INSTANCE))
+
+    def test_contains_all(self):
+        self.assertFalse(self.set.contains_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]))
+        self.set.add_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE])
+        self.assertTrue(self.set.contains_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]))
+
+    def test_remove(self):
+        self.assertFalse(self.set.remove(OUTER_COMPACT_INSTANCE))
+        self.set.add(OUTER_COMPACT_INSTANCE)
+        self.assertTrue(self.set.remove(OUTER_COMPACT_INSTANCE))
+
+    def test_remove_all(self):
+        self.assertFalse(self.set.remove_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]))
+        self.set.add_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE])
+        self.assertTrue(self.set.remove_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]))
+
+    def test_retain_all(self):
+        items = [INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]
+        self.assertFalse(self.set.retain_all(items))
+        self.set.add_all(items + ["x"])
+        self.assertTrue(self.set.retain_all(items))
+
+    def _add_from_another_client(self, item):
+        other_client = self.create_client(self.client_config)
+        other_client_set = other_client.get_set(self.set.name).blocking()
+        other_client_set.add(item)
+
+
+class TopicCompactCompatibilityTest(CompactCompatibilityBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.topic = self.client.get_topic(random_string()).blocking()
+
+    def tearDown(self) -> None:
+        self.topic.destroy()
+        super().tearDown()
+
+    def test_add_listener(self):
+        events = []
+
+        def listener(event):
+            events.append(event)
+
+        self.topic.add_listener(on_message=listener)
+
+        self._publish_from_another_client(OUTER_COMPACT_INSTANCE)
+
+        def assertion():
+            self.assertEqual(1, len(events))
+            event = events[0]
+            self.assertEqual(OUTER_COMPACT_INSTANCE, event.message)
+
+        self.assertTrueEventually(assertion)
+
+    def test_publish(self):
+        self.topic.publish(OUTER_COMPACT_INSTANCE)
+
+    def _publish_from_another_client(self, item):
+        other_client = self.create_client(self.client_config)
+        other_client_topic = other_client.get_topic(self.topic.name).blocking()
+        other_client_topic.publish(item)
+
+
+class TransactionalListCompactCompatibilityTest(CompactCompatibilityBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.list_name = random_string()
+        self.transaction = self.client.new_transaction()
+        self.list = self.client.get_list(self.list_name).blocking()
+
+    def tearDown(self) -> None:
+        self.list.destroy()
+        super().tearDown()
+
+    def test_add(self):
+        with self.transaction:
+            transactional_list = self._get_transactional_list()
+            self.assertTrue(transactional_list.add(OUTER_COMPACT_INSTANCE))
+
+    def test_remove(self):
+        self._add_from_another_client(OUTER_COMPACT_INSTANCE)
+        with self.transaction:
+            transactional_list = self._get_transactional_list()
+            self.assertTrue(transactional_list.remove(OUTER_COMPACT_INSTANCE))
+
+    def _get_transactional_list(self):
+        return self.transaction.get_list(self.list_name)
+
+    def _add_from_another_client(self, item):
+        other_client = self.create_client(self.client_config)
+        other_client_list = other_client.get_list(self.list_name).blocking()
+        other_client_list.add(item)
+
+
+class TransactionalMapCompactCompatibilityTest(CompactCompatibilityBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.map_name = random_string()
+        self.transaction = self.client.new_transaction()
+        self.map = self.client.get_map(self.map_name).blocking()
+
+    def tearDown(self) -> None:
+        self.map.destroy()
+        super().tearDown()
+
+    def test_contains_key(self):
+        self._put_from_another_client(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        with self.transaction:
+            transactional_map = self._get_transactional_map()
+            self.assertTrue(transactional_map.contains_key(OUTER_COMPACT_INSTANCE))
+
+    def test_get(self):
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        with self.transaction:
+            transactional_map = self._get_transactional_map()
+            self.assertEqual(OUTER_COMPACT_INSTANCE, transactional_map.get(INNER_COMPACT_INSTANCE))
+
+    def test_get_for_update(self):
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        with self.transaction:
+            transactional_map = self._get_transactional_map()
+            self.assertEqual(
+                OUTER_COMPACT_INSTANCE, transactional_map.get_for_update(INNER_COMPACT_INSTANCE)
+            )
+
+    def test_put(self):
+        with self.transaction:
+            transactional_map = self._get_transactional_map()
+            self.assertIsNone(transactional_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
+
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.map.get(INNER_COMPACT_INSTANCE))
+
+    def test_put_if_absent(self):
+        with self.transaction:
+            transactional_map = self._get_transactional_map()
+            self.assertIsNone(
+                transactional_map.put_if_absent(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+            )
+
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.map.get(INNER_COMPACT_INSTANCE))
+
+    def test_set(self):
+        with self.transaction:
+            transactional_map = self._get_transactional_map()
+            self.assertIsNone(transactional_map.set(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
+
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.map.get(INNER_COMPACT_INSTANCE))
+
+    def test_replace(self):
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        with self.transaction:
+            transactional_map = self._get_transactional_map()
+            self.assertEqual(
+                INNER_COMPACT_INSTANCE,
+                transactional_map.replace(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE),
+            )
+
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.map.get(INNER_COMPACT_INSTANCE))
+
+    def test_replace_if_same(self):
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        with self.transaction:
+            transactional_map = self._get_transactional_map()
+            self.assertTrue(
+                transactional_map.replace_if_same(
+                    INNER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE
+                )
+            )
+
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.map.get(INNER_COMPACT_INSTANCE))
+
+    def test_remove(self):
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        with self.transaction:
+            transactional_map = self._get_transactional_map()
+            self.assertEqual(
+                OUTER_COMPACT_INSTANCE, transactional_map.remove(INNER_COMPACT_INSTANCE)
+            )
+
+    def test_remove_if_same(self):
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        with self.transaction:
+            transactional_map = self._get_transactional_map()
+            self.assertTrue(
+                transactional_map.remove_if_same(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+            )
+
+    def test_delete(self):
+        self._put_from_another_client(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        with self.transaction:
+            transactional_map = self._get_transactional_map()
+            self.assertIsNone(transactional_map.delete(OUTER_COMPACT_INSTANCE))
+
+        self.assertTrue(self.map.is_empty())
+
+    def test_key_set_with_predicate(self):
+        self.map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        with self.transaction:
+            transactional_map = self._get_transactional_map()
+            self.assertEqual(
+                [INNER_COMPACT_INSTANCE], transactional_map.key_set(CompactPredicate())
+            )
+
+    def test_values_with_predicate(self):
+        self.map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        with self.transaction:
+            transactional_map = self._get_transactional_map()
+            self.assertEqual([OUTER_COMPACT_INSTANCE], transactional_map.values(CompactPredicate()))
+
+    def _get_transactional_map(self):
+        return self.transaction.get_map(self.map_name)
+
+    def _put_from_another_client(self, key, value):
+        other_client = self.create_client(self.client_config)
+        other_client_map = other_client.get_map(self.map_name).blocking()
+        other_client_map.put(key, value)
+
+
+class TransactionalMultiMapCompactCompatibilityTest(CompactCompatibilityBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.multi_map_name = random_string()
+        self.transaction = self.client.new_transaction()
+        self.multi_map = self.client.get_multi_map(self.multi_map_name).blocking()
+
+    def tearDown(self) -> None:
+        self.multi_map.destroy()
+        super().tearDown()
+
+    def test_put(self):
+        with self.transaction:
+            transactional_multi_map = self._get_transactional_multi_map()
+            self.assertTrue(
+                transactional_multi_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+            )
+
+    def test_get(self):
+        self.multi_map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        with self.transaction:
+            transactional_multi_map = self._get_transactional_multi_map()
+            self.assertEqual(
+                [INNER_COMPACT_INSTANCE], transactional_multi_map.get(OUTER_COMPACT_INSTANCE)
+            )
+
+    def test_remove(self):
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        with self.transaction:
+            transactional_multi_map = self._get_transactional_multi_map()
+            self.assertTrue(
+                transactional_multi_map.remove(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+            )
+
+    def test_remove_all(self):
+        self._put_from_another_client(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        with self.transaction:
+            transactional_multi_map = self._get_transactional_multi_map()
+            self.assertEqual(
+                [INNER_COMPACT_INSTANCE], transactional_multi_map.remove_all(OUTER_COMPACT_INSTANCE)
+            )
+
+    def test_value_count(self):
+        self._put_from_another_client(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        with self.transaction:
+            transactional_multi_map = self._get_transactional_multi_map()
+            self.assertEqual(1, transactional_multi_map.value_count(OUTER_COMPACT_INSTANCE))
+
+    def _get_transactional_multi_map(self):
+        return self.transaction.get_multi_map(self.multi_map_name)
+
+    def _put_from_another_client(self, key, value):
+        other_client = self.create_client(self.client_config)
+        other_client_multi_map = other_client.get_multi_map(self.multi_map_name).blocking()
+        other_client_multi_map.put(key, value)
+
+
+class TransactionalQueueCompactCompatibilityTest(CompactCompatibilityBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.queue_name = random_string()
+        self.transaction = self.client.new_transaction()
+        self.queue = self.client.get_queue(self.queue_name).blocking()
+
+    def tearDown(self) -> None:
+        self.queue.destroy()
+        super().tearDown()
+
+    def test_offer(self):
+        with self.transaction:
+            transactional_queue = self._get_transactional_queue()
+            self.assertTrue(transactional_queue.offer(OUTER_COMPACT_INSTANCE))
+
+    def test_take(self):
+        self._add_from_another_client(OUTER_COMPACT_INSTANCE)
+        with self.transaction:
+            transactional_queue = self._get_transactional_queue()
+            self.assertEqual(OUTER_COMPACT_INSTANCE, transactional_queue.take())
+
+    def test_poll(self):
+        self._add_from_another_client(OUTER_COMPACT_INSTANCE)
+        with self.transaction:
+            transactional_queue = self._get_transactional_queue()
+            self.assertEqual(OUTER_COMPACT_INSTANCE, transactional_queue.poll())
+
+    def test_peek(self):
+        self._add_from_another_client(OUTER_COMPACT_INSTANCE)
+        with self.transaction:
+            transactional_queue = self._get_transactional_queue()
+            self.assertEqual(OUTER_COMPACT_INSTANCE, transactional_queue.peek())
+
+    def _get_transactional_queue(self):
+        return self.transaction.get_queue(self.queue_name)
+
+    def _add_from_another_client(self, item):
+        other_client = self.create_client(self.client_config)
+        other_client_queue = other_client.get_queue(self.queue_name).blocking()
+        other_client_queue.add(item)
+
+
+class TransactionalSetCompactCompatibilityTest(CompactCompatibilityBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.set_name = random_string()
+        self.transaction = self.client.new_transaction()
+        self.set = self.client.get_set(self.set_name).blocking()
+
+    def tearDown(self) -> None:
+        self.set.destroy()
+        super().tearDown()
+
+    def test_add(self):
+        with self.transaction:
+            transactional_set = self._get_transactional_set()
+            self.assertTrue(transactional_set.add(OUTER_COMPACT_INSTANCE))
+
+    def test_remove(self):
+        self._add_from_another_client(OUTER_COMPACT_INSTANCE)
+        with self.transaction:
+            transactional_set = self._get_transactional_set()
+            self.assertTrue(transactional_set.remove(OUTER_COMPACT_INSTANCE))
+
+    def _get_transactional_set(self):
+        return self.transaction.get_set(self.set_name)
+
+    def _add_from_another_client(self, item):
+        other_client = self.create_client(self.client_config)
+        other_client_set = other_client.get_set(self.set_name).blocking()
+        other_client_set.add(item)
+
+
+class SqlCompactCompatibilityTest(CompactCompatibilityBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.map_name = random_string()
+        self.map = self.client.get_map(self.map_name).blocking()
+
+        self.client.sql.execute(
+            f"""
+        CREATE MAPPING "{self.map_name}" (
+            __key INT,
+            stringField VARCHAR
+        )
+        TYPE IMaP 
+        OPTIONS (
+            'keyFormat' = 'int',
+            'valueFormat' = 'compact',
+            'valueCompactTypeName' = 'com.hazelcast.serialization.compact.InnerCompact'
+        )
+        """
+        ).result()
+
+    def tearDown(self) -> None:
+        self.map.destroy()
+        super().tearDown()
+
+    def test_sql(self):
+        self.client.sql.execute(
+            f'INSERT INTO "{self.map_name}" VALUES(?, ?)',
+            1,
+            INNER_COMPACT_INSTANCE.string_field,
+        ).result()
+        self.assertEqual(INNER_COMPACT_INSTANCE, self.map.get(1))
+
+
+class PartitionServiceCompactCompatibilityTest(CompactCompatibilityBase):
+    def test_partition_service(self):
+        self.assertEqual(
+            268,
+            self.client.partition_service.get_partition_id(OUTER_COMPACT_INSTANCE),
+        )

--- a/tests/unit/sql_test.py
+++ b/tests/unit/sql_test.py
@@ -48,7 +48,10 @@ class SqlMockTest(unittest.TestCase):
         invocation_service.invoke.side_effect = invoke
 
         self.internal_service = _InternalSqlService(
-            connection_manager, serialization_service, invocation_service
+            connection_manager,
+            serialization_service,
+            invocation_service,
+            MagicMock(),
         )
         self.service = SqlService(self.internal_service)
         self.result = self.service.execute("SOME QUERY")


### PR DESCRIPTION
For compact serialization to work, we have to control the results
of the serialization. Also, for the responses we got from the server,
we have to eagerly deserialize them, and retry after receiving the
schema from the cluster.

With this PR, we make sure that on each API we support compact serialization,
we check the result of the `to_data` call to see if it throws or not.

If it throws, we try to send the schema to the cluster and retry.

Also, this PR adds tests for all the APIs we support compact serialization.
For now, we didn't implement eager deserialization for the APIs that
return `ImmutableLazyDataList`, so there are no tests for such APIs.

To be able to add those tests, we would need quite a bit of compact
serializable classes written in Java. This PR includes aforementioned
Java code, but they might be moved to the remote controller package so
that it would be accessible to all clients.