### PR TITLE
Fix mypy errors

### DIFF
--- a/.github/workflows/test_runner.yml
+++ b/.github/workflows/test_runner.yml
@@ -81,3 +81,19 @@ jobs:
         working-directory: docs
         run: |
           make html SPHINXOPTS="-W --keep-going -b linkcheck"
+  run-mypy:
+    runs-on: ubuntu-latest
+    name: Run mypy to check type annotations
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+      - name: Checkout to code
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          pip install -r requirements-dev.txt
+      - name: Run mypy
+        run: |
+          mypy --show-error-codes hazelcast

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ images <https://hub.docker.com/r/hazelcast/hazelcast/>`__.
 
 .. code:: bash
 
-   docker run -p 5701:5701 hazelcast/hazelcast:5.0
+   docker run -p 5701:5701 hazelcast/hazelcast:5.1
 
 You can also use our ZIP or TAR
 `distributions <https://hazelcast.com/open-source-projects/downloads/>`__.
@@ -204,7 +204,9 @@ If you are planning to contribute:
    dependencies.
 2. Use `black <https://pypi.org/project/black/>`__ to reformat the code
    by running the ``black --config black.toml .`` command.
-3. Make sure that tests are passing by following the steps described
+3. Use `mypy <https://pypi.org/project/mypy/>`__ to check type annotations
+   by running the ``mypy hazelcast`` command.
+4. Make sure that tests are passing by following the steps described
    in the next section.
 
 Testing

--- a/docs/development_and_testing.rst
+++ b/docs/development_and_testing.rst
@@ -21,7 +21,9 @@ If you are planning to contribute:
    dependencies.
 2. Use `black <https://pypi.org/project/black/>`__ to reformat the code
    by running the ``black --config black.toml .`` command.
-3. Make sure that tests are passing by following the steps described
+3. Use `mypy <https://pypi.org/project/mypy/>`__ to check type annotations
+   by running the ``mypy hazelcast`` command.
+4. Make sure that tests are passing by following the steps described
    in the :ref:`development_and_testing:testing` section.
 
 Testing

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -48,7 +48,7 @@ There are following options to start a Hazelcast cluster easily:
 
   .. code:: bash
 
-      docker run -p 5701:5701 hazelcast/hazelcast:5.0
+      docker run -p 5701:5701 hazelcast/hazelcast:5.1
 
 - You can use `Hazelcast CLI
   <https://docs.hazelcast.com/hazelcast/latest/getting-started/install-hazelcast#using-a-package-manager>`__.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,5 @@
- Hazelcast Python Client Code Examples Readme
-=============================
+Hazelcast Python Client Code Examples Readme
+============================================
 
 This folder contains a collection of code samples which you can 
 use to learn how to use Hazelcast features.
@@ -14,7 +14,7 @@ How to try these examples
 * If not, you can use our official Docker images to start a member.
 
     ```bash
-    docker run -p 5701:5701 hazelcast/hazelcast:5.0
+    docker run -p 5701:5701 hazelcast/hazelcast:5.1
     ```
   To see the other ways to start Hazelcast members, see 
   [Working with Hazelcast Clusters](https://hazelcast.readthedocs.io/en/stable/getting_started.html#working-with-hazelcast-clusters)

--- a/hazelcast/cluster.py
+++ b/hazelcast/cluster.py
@@ -278,7 +278,7 @@ class _InternalClusterService:
         for dead_member in dead_members:
             connection = self._connection_manager.get_connection(dead_member.uuid)
             if connection:
-                connection.close(
+                connection.close_connection(
                     None,
                     TargetDisconnectedError(
                         "The client has closed the connection to this member, "

--- a/hazelcast/config.py
+++ b/hazelcast/config.py
@@ -15,7 +15,6 @@ from hazelcast.util import (
     check_not_none,
     number_types,
     LoadBalancer,
-    none_type,
     try_to_get_enum_value,
 )
 
@@ -333,7 +332,7 @@ class IndexConfig:
 
     @name.setter
     def name(self, value):
-        if isinstance(value, (str, none_type)):
+        if isinstance(value, str) or value is None:
             self._name = value
         else:
             raise TypeError("name must be a string or None")

--- a/hazelcast/core.py
+++ b/hazelcast/core.py
@@ -162,7 +162,7 @@ class EndpointQualifier:
 
     __slots__ = ("_protocol_type", "_identifier")
 
-    def __init__(self, protocol_type: int, identifier: str):
+    def __init__(self, protocol_type: int, identifier: typing.Optional[str]):
         self._protocol_type = protocol_type
         self._identifier = identifier
 
@@ -172,7 +172,7 @@ class EndpointQualifier:
         return self._protocol_type
 
     @property
-    def identifier(self) -> str:
+    def identifier(self) -> typing.Optional[str]:
         """Unique identifier for same-protocol-type endpoints."""
         return self._identifier
 
@@ -492,9 +492,15 @@ class MapEntry(typing.Generic[KeyType, ValueType]):
     @property
     def key(self) -> KeyType:
         """Key of the entry."""
-        return self._key
+        # This has the correct type, but due to structure of the identified
+        # data serialization, the constructor must have ``None`` default
+        # values, which upsets the type checker.
+        return self._key  # type: ignore[return-value]
 
     @property
     def value(self) -> ValueType:
         """Value of the entry."""
-        return self._value
+        # This has the correct type, but due to structure of the identified
+        # data serialization, the constructor must have ``None`` default
+        # values, which upsets the type checker.
+        return self._value  # type: ignore[return-value]

--- a/hazelcast/listener.py
+++ b/hazelcast/listener.py
@@ -57,9 +57,9 @@ class ListenerService:
         self._invocation_service = invocation_service
         self._compact_schema_service = compact_schema_service
         self._is_smart = config.smart_routing
-        self._active_registrations = {}  # Dict of user_registration_id, ListenerRegistration
+        self._active_registrations: typing.Dict[str, _ListenerRegistration] = {}
         self._registration_lock = threading.RLock()
-        self._event_handlers = {}
+        self._event_handlers: typing.Dict[int, typing.Callable] = {}
 
     def start(self):
         self._connection_manager.add_listener(self._connection_added, self._connection_removed)

--- a/hazelcast/proxy/__init__.py
+++ b/hazelcast/proxy/__init__.py
@@ -1,5 +1,8 @@
+import typing
+
 from hazelcast.invocation import Invocation
 from hazelcast.protocol.codec import client_create_proxy_codec, client_destroy_proxy_codec
+from hazelcast.proxy.base import Proxy
 from hazelcast.proxy.executor import Executor
 from hazelcast.proxy.list import List
 from hazelcast.proxy.map import create_map_proxy
@@ -27,7 +30,7 @@ TOPIC_SERVICE = "hz:impl:topicService"
 PN_COUNTER_SERVICE = "hz:impl:PNCounterService"
 FLAKE_ID_GENERATOR_SERVICE = "hz:impl:flakeIdGeneratorService"
 
-_proxy_init = {
+_proxy_init: typing.Dict[str, typing.Callable[[str, str, typing.Any], Proxy]] = {
     EXECUTOR_SERVICE: Executor,
     LIST_SERVICE: List,
     MAP_SERVICE: create_map_proxy,

--- a/hazelcast/proxy/cp/atomic_reference.py
+++ b/hazelcast/proxy/cp/atomic_reference.py
@@ -54,7 +54,9 @@ class AtomicReference(BaseCPProxy["BlockingAtomicReference"], typing.Generic[Ele
     server-side setting.
     """
 
-    def compare_and_set(self, expect: ElementType, update: ElementType) -> Future[bool]:
+    def compare_and_set(
+        self, expect: typing.Optional[ElementType], update: typing.Optional[ElementType]
+    ) -> Future[bool]:
         """Atomically sets the value to the given updated value
         only if the current value is equal to the expected value.
 
@@ -76,7 +78,7 @@ class AtomicReference(BaseCPProxy["BlockingAtomicReference"], typing.Generic[Ele
         request = codec.encode_request(self._group_id, self._object_name, expected_data, new_data)
         return self._invoke(request, codec.decode_response)
 
-    def get(self) -> Future[ElementType]:
+    def get(self) -> Future[typing.Optional[ElementType]]:
         """Gets the current value.
 
         Returns:
@@ -90,7 +92,7 @@ class AtomicReference(BaseCPProxy["BlockingAtomicReference"], typing.Generic[Ele
 
         return self._invoke(request, handler)
 
-    def set(self, new_value: ElementType) -> Future[None]:
+    def set(self, new_value: typing.Optional[ElementType]) -> Future[None]:
         """Atomically sets the given value.
 
         Args:
@@ -105,7 +107,9 @@ class AtomicReference(BaseCPProxy["BlockingAtomicReference"], typing.Generic[Ele
         request = codec.encode_request(self._group_id, self._object_name, new_value_data, False)
         return self._invoke(request)
 
-    def get_and_set(self, new_value: ElementType) -> Future[ElementType]:
+    def get_and_set(
+        self, new_value: typing.Optional[ElementType]
+    ) -> Future[typing.Optional[ElementType]]:
         """Gets the old value and sets the new value.
 
         Args:
@@ -180,7 +184,7 @@ class AtomicReference(BaseCPProxy["BlockingAtomicReference"], typing.Generic[Ele
         request = codec.encode_request(self._group_id, self._object_name, function_data, 0, True)
         return self._invoke(request)
 
-    def alter_and_get(self, function: typing.Any) -> Future[ElementType]:
+    def alter_and_get(self, function: typing.Any) -> Future[typing.Optional[ElementType]]:
         """Alters the currently stored reference by applying a function on it
         and gets the result.
 
@@ -211,7 +215,7 @@ class AtomicReference(BaseCPProxy["BlockingAtomicReference"], typing.Generic[Ele
 
         return self._invoke(request, handler)
 
-    def get_and_alter(self, function: typing.Any) -> Future[ElementType]:
+    def get_and_alter(self, function: typing.Any) -> Future[typing.Optional[ElementType]]:
         """Alters the currently stored reference by applying a function on it
         on and gets the old value.
 
@@ -242,7 +246,7 @@ class AtomicReference(BaseCPProxy["BlockingAtomicReference"], typing.Generic[Ele
 
         return self._invoke(request, handler)
 
-    def apply(self, function: typing.Any) -> Future[ElementType]:
+    def apply(self, function: typing.Any) -> Future[typing.Optional[ElementType]]:
         """Applies a function on the value, the actual stored value will not
         change.
 
@@ -285,26 +289,26 @@ class BlockingAtomicReference(AtomicReference[ElementType]):
 
     def compare_and_set(  # type: ignore[override]
         self,
-        expect: ElementType,
-        update: ElementType,
+        expect: typing.Optional[ElementType],
+        update: typing.Optional[ElementType],
     ) -> bool:
         return self._wrapped.compare_and_set(expect, update).result()
 
     def get(  # type: ignore[override]
         self,
-    ) -> ElementType:
+    ) -> typing.Optional[ElementType]:
         return self._wrapped.get().result()
 
     def set(  # type: ignore[override]
         self,
-        new_value: ElementType,
+        new_value: typing.Optional[ElementType],
     ) -> None:
         return self._wrapped.set(new_value).result()
 
     def get_and_set(  # type: ignore[override]
         self,
-        new_value: ElementType,
-    ) -> ElementType:
+        new_value: typing.Optional[ElementType],
+    ) -> typing.Optional[ElementType]:
         return self._wrapped.get_and_set(new_value).result()
 
     def is_none(  # type: ignore[override]
@@ -332,19 +336,19 @@ class BlockingAtomicReference(AtomicReference[ElementType]):
     def alter_and_get(  # type: ignore[override]
         self,
         function: typing.Any,
-    ) -> ElementType:
+    ) -> typing.Optional[ElementType]:
         return self._wrapped.alter_and_get(function).result()
 
     def get_and_alter(  # type: ignore[override]
         self,
         function: typing.Any,
-    ) -> ElementType:
+    ) -> typing.Optional[ElementType]:
         return self._wrapped.get_and_alter(function).result()
 
     def apply(  # type: ignore[override]
         self,
         function: typing.Any,
-    ) -> ElementType:
+    ) -> typing.Optional[ElementType]:
         return self._wrapped.apply(function).result()
 
     def destroy(  # type: ignore[override]

--- a/hazelcast/proxy/pn_counter.py
+++ b/hazelcast/proxy/pn_counter.py
@@ -54,8 +54,6 @@ class PNCounter(Proxy["BlockingPNCounter"]):
         fail with an NoDataMemberInClusterError.
     """
 
-    _EMPTY_ADDRESS_LIST = []
-
     def __init__(self, service_name, name, context):
         super(PNCounter, self).__init__(service_name, name, context)
         self._observed_clock = VectorClock()
@@ -220,9 +218,7 @@ class PNCounter(Proxy["BlockingPNCounter"]):
 
     def _invoke_internal(self, codec, **kwargs):
         delegated_future = Future()
-        self._set_result_or_error(
-            delegated_future, PNCounter._EMPTY_ADDRESS_LIST, None, codec, **kwargs
-        )
+        self._set_result_or_error(delegated_future, [], None, codec, **kwargs)
         return delegated_future
 
     def _set_result_or_error(
@@ -272,9 +268,6 @@ class PNCounter(Proxy["BlockingPNCounter"]):
                 "choosing different target",
                 target,
             )
-            if excluded_addresses == PNCounter._EMPTY_ADDRESS_LIST:
-                excluded_addresses = []
-
             excluded_addresses.append(target)
             self._set_result_or_error(delegated_future, excluded_addresses, ex, codec, **kwargs)
 

--- a/hazelcast/proxy/reliable_topic.py
+++ b/hazelcast/proxy/reliable_topic.py
@@ -587,6 +587,8 @@ class ReliableTopic(Proxy["BlockingReliableTopic"], typing.Generic[MessageType])
             return self._add_or_overwrite(topic_message)
         elif overload_policy == TopicOverloadPolicy.DISCARD_NEWEST:
             return self._add_or_discard(topic_message)
+        else:
+            raise ValueError(f"Unexpected overload policy is passed {overload_policy}")
 
     def publish_all(self, messages: typing.Sequence[MessageType]) -> Future[None]:
         """Publishes all messages to all subscribers of this topic.
@@ -613,6 +615,8 @@ class ReliableTopic(Proxy["BlockingReliableTopic"], typing.Generic[MessageType])
             return self._add_messages_or_overwrite(topic_messages)
         elif overload_policy == TopicOverloadPolicy.DISCARD_NEWEST:
             return self._add_messages_or_discard(topic_messages)
+        else:
+            raise ValueError(f"Unexpected overload policy is passed {overload_policy}")
 
     def add_listener(
         self,

--- a/hazelcast/serialization/compact.py
+++ b/hazelcast/serialization/compact.py
@@ -149,13 +149,13 @@ class DefaultCompactWriter(CompactWriter):
         self._schema = schema
 
         if schema.var_sized_field_count != 0:
-            self._var_sized_field_positions = [0] * schema.var_sized_field_count
+            self._var_sized_field_positions: typing.List[int] = [0] * schema.var_sized_field_count
             self._data_start_position = out.position() + INT_SIZE_IN_BYTES
 
             # Skip data length (4 bytes) + fix sized fields
             out.write_zero_bytes(schema.fix_sized_fields_length + INT_SIZE_IN_BYTES)
         else:
-            self._var_sized_field_positions = None
+            self._var_sized_field_positions = []
             self._data_start_position = out.position()
 
             # Skip fix sized_fields. No need to write data length when
@@ -589,7 +589,7 @@ class DefaultCompactReader(CompactReader):
             self._data_start_position = inp.position()
             self._var_sized_field_positions_position = self._data_start_position + data_length
             if data_length < PositionReader.UINT8_POSITION_READER_RANGE:
-                self._position_reader = _UINT8_POSITION_READER_INSTANCE
+                self._position_reader: PositionReader = _UINT8_POSITION_READER_INSTANCE
                 end_position = self._var_sized_field_positions_position + var_sized_field_count
             elif data_length < PositionReader.UINT16_POSITION_READER_RANGE:
                 self._position_reader = _UINT16_POSITION_READER_INSTANCE
@@ -621,7 +621,7 @@ class DefaultCompactReader(CompactReader):
         elif kind == FieldKind.NULLABLE_BOOLEAN:
             return self._read_var_sized_field_non_none(field, self._inp.read_boolean)
         else:
-            DefaultCompactReader._raise_mismatched_field_kind_error(
+            raise DefaultCompactReader._create_mismatched_field_kind_error(
                 field_name, kind, FieldKind.BOOLEAN
             )
 
@@ -639,7 +639,7 @@ class DefaultCompactReader(CompactReader):
         elif kind == FieldKind.NULLABLE_BOOLEAN:
             return self._read_var_sized_field(field, self._inp.read_boolean)
         else:
-            DefaultCompactReader._raise_mismatched_field_kind_error(
+            raise DefaultCompactReader._create_mismatched_field_kind_error(
                 field_name, kind, FieldKind.NULLABLE_BOOLEAN
             )
 
@@ -659,7 +659,7 @@ class DefaultCompactReader(CompactReader):
         elif kind == FieldKind.NULLABLE_INT8:
             return self._read_var_sized_field_non_none(field, self._inp.read_byte)
         else:
-            DefaultCompactReader._raise_mismatched_field_kind_error(
+            raise DefaultCompactReader._create_mismatched_field_kind_error(
                 field_name, kind, FieldKind.INT8
             )
 
@@ -677,7 +677,7 @@ class DefaultCompactReader(CompactReader):
         elif kind == FieldKind.NULLABLE_INT8:
             return self._read_var_sized_field(field, self._inp.read_byte)
         else:
-            DefaultCompactReader._raise_mismatched_field_kind_error(
+            raise DefaultCompactReader._create_mismatched_field_kind_error(
                 field_name, kind, FieldKind.NULLABLE_INT8
             )
 
@@ -697,7 +697,7 @@ class DefaultCompactReader(CompactReader):
         elif kind == FieldKind.NULLABLE_INT16:
             return self._read_var_sized_field_non_none(field, self._inp.read_short)
         else:
-            DefaultCompactReader._raise_mismatched_field_kind_error(
+            raise DefaultCompactReader._create_mismatched_field_kind_error(
                 field_name, kind, FieldKind.INT16
             )
 
@@ -715,7 +715,7 @@ class DefaultCompactReader(CompactReader):
         elif kind == FieldKind.NULLABLE_INT16:
             return self._read_var_sized_field(field, self._inp.read_short)
         else:
-            DefaultCompactReader._raise_mismatched_field_kind_error(
+            raise DefaultCompactReader._create_mismatched_field_kind_error(
                 field_name, kind, FieldKind.NULLABLE_INT16
             )
 
@@ -735,7 +735,7 @@ class DefaultCompactReader(CompactReader):
         elif kind == FieldKind.NULLABLE_INT32:
             return self._read_var_sized_field_non_none(field, self._inp.read_int)
         else:
-            DefaultCompactReader._raise_mismatched_field_kind_error(
+            raise DefaultCompactReader._create_mismatched_field_kind_error(
                 field_name, kind, FieldKind.INT32
             )
 
@@ -753,7 +753,7 @@ class DefaultCompactReader(CompactReader):
         elif kind == FieldKind.NULLABLE_INT32:
             return self._read_var_sized_field(field, self._inp.read_int)
         else:
-            DefaultCompactReader._raise_mismatched_field_kind_error(
+            raise DefaultCompactReader._create_mismatched_field_kind_error(
                 field_name, kind, FieldKind.NULLABLE_INT32
             )
 
@@ -773,7 +773,7 @@ class DefaultCompactReader(CompactReader):
         elif kind == FieldKind.NULLABLE_INT64:
             return self._read_var_sized_field_non_none(field, self._inp.read_long)
         else:
-            DefaultCompactReader._raise_mismatched_field_kind_error(
+            raise DefaultCompactReader._create_mismatched_field_kind_error(
                 field_name, kind, FieldKind.INT64
             )
 
@@ -791,7 +791,7 @@ class DefaultCompactReader(CompactReader):
         elif kind == FieldKind.NULLABLE_INT64:
             return self._read_var_sized_field(field, self._inp.read_long)
         else:
-            DefaultCompactReader._raise_mismatched_field_kind_error(
+            raise DefaultCompactReader._create_mismatched_field_kind_error(
                 field_name, kind, FieldKind.NULLABLE_INT64
             )
 
@@ -811,7 +811,7 @@ class DefaultCompactReader(CompactReader):
         elif kind == FieldKind.NULLABLE_FLOAT32:
             return self._read_var_sized_field_non_none(field, self._inp.read_float)
         else:
-            DefaultCompactReader._raise_mismatched_field_kind_error(
+            raise DefaultCompactReader._create_mismatched_field_kind_error(
                 field_name, kind, FieldKind.FLOAT32
             )
 
@@ -829,7 +829,7 @@ class DefaultCompactReader(CompactReader):
         elif kind == FieldKind.NULLABLE_FLOAT32:
             return self._read_var_sized_field(field, self._inp.read_float)
         else:
-            DefaultCompactReader._raise_mismatched_field_kind_error(
+            raise DefaultCompactReader._create_mismatched_field_kind_error(
                 field_name, kind, FieldKind.NULLABLE_FLOAT32
             )
 
@@ -849,7 +849,7 @@ class DefaultCompactReader(CompactReader):
         elif kind == FieldKind.NULLABLE_FLOAT64:
             return self._read_var_sized_field_non_none(field, self._inp.read_double)
         else:
-            DefaultCompactReader._raise_mismatched_field_kind_error(
+            raise DefaultCompactReader._create_mismatched_field_kind_error(
                 field_name, kind, FieldKind.FLOAT64
             )
 
@@ -867,7 +867,7 @@ class DefaultCompactReader(CompactReader):
         elif kind == FieldKind.NULLABLE_FLOAT64:
             return self._read_var_sized_field(field, self._inp.read_double)
         else:
-            DefaultCompactReader._raise_mismatched_field_kind_error(
+            raise DefaultCompactReader._create_mismatched_field_kind_error(
                 field_name, kind, FieldKind.NULLABLE_FLOAT64
             )
 
@@ -973,7 +973,7 @@ class DefaultCompactReader(CompactReader):
                 field, self._inp.read_boolean_array
             )
         else:
-            DefaultCompactReader._raise_mismatched_field_kind_error(
+            raise DefaultCompactReader._create_mismatched_field_kind_error(
                 field_name, kind, FieldKind.ARRAY_OF_BOOLEAN
             )
 
@@ -991,11 +991,12 @@ class DefaultCompactReader(CompactReader):
         field = self._get_field(field_name)
         kind = field.kind
         if kind == FieldKind.ARRAY_OF_BOOLEAN:
-            return self._read_var_sized_field(field, self._read_boolean_bits)
+            # Optional[List[bool]] is compatible with Optional[List[Optional[bool]]]
+            return self._read_var_sized_field(field, self._read_boolean_bits)  # type: ignore[return-value]
         elif kind == FieldKind.ARRAY_OF_NULLABLE_BOOLEAN:
             return self._read_var_sized_item_array(field, self._inp.read_boolean)
         else:
-            DefaultCompactReader._raise_mismatched_field_kind_error(
+            raise DefaultCompactReader._create_mismatched_field_kind_error(
                 field_name, kind, FieldKind.ARRAY_OF_NULLABLE_BOOLEAN
             )
 
@@ -1337,7 +1338,7 @@ class DefaultCompactReader(CompactReader):
     ) -> "FieldDescriptor":
         field = self._get_field(field_name)
         if field.kind != field_kind:
-            DefaultCompactReader._raise_mismatched_field_kind_error(
+            raise DefaultCompactReader._create_mismatched_field_kind_error(
                 field_name, field.kind, field_kind
             )
 
@@ -1350,9 +1351,9 @@ class DefaultCompactReader(CompactReader):
         return ((packed_byte >> bit_position) & 0x01) != 0
 
     @staticmethod
-    def _raise_mismatched_field_kind_error(
+    def _create_mismatched_field_kind_error(
         field_name: str, field_kind: "FieldKind", expected_field_kind: "FieldKind"
-    ) -> typing.NoReturn:
+    ) -> HazelcastSerializationError:
         raise HazelcastSerializationError(
             f"Mismatched field types. "
             f"Expected: {expected_field_kind}, found: {field_kind} for the '{field_name}'."
@@ -1404,7 +1405,7 @@ class DefaultCompactReader(CompactReader):
     def _read_boolean_bits(self) -> typing.List[bool]:
         inp = self._inp
         n = inp.read_int()
-        values = []
+        values: typing.List[bool] = []
         if n == 0:
             return values
 
@@ -1454,7 +1455,7 @@ class DefaultCompactReader(CompactReader):
 
     def _read_var_sized_item_array(
         self, field: "FieldDescriptor", item_reader: typing.Callable[[], T]
-    ) -> typing.Optional[typing.List[T]]:
+    ) -> typing.Optional[typing.List[typing.Optional[T]]]:
         inp = self._inp
         current_position = inp.position()
         try:
@@ -1468,7 +1469,7 @@ class DefaultCompactReader(CompactReader):
             item_count = inp.read_int()
             data_start_position = inp.position()
 
-            values = [None] * item_count
+            values: typing.List[typing.Optional[T]] = [None] * item_count
             position_reader = PositionReader.reader_for(data_length)
             item_positions_position = data_start_position + data_length
             for i in range(item_count):
@@ -1495,7 +1496,7 @@ class DefaultCompactReader(CompactReader):
         elif kind == nullable_fix_sized_item_array_field_kind:
             return self._read_nullable_item_array_as_fix_sized_item_array(field, reader)
         else:
-            DefaultCompactReader._raise_mismatched_field_kind_error(
+            raise DefaultCompactReader._create_mismatched_field_kind_error(
                 field_name, kind, fix_sized_item_array_field_kind
             )
 
@@ -1510,11 +1511,12 @@ class DefaultCompactReader(CompactReader):
         field = self._get_field(field_name)
         kind = field.kind
         if kind == fix_sized_item_array_field_kind:
-            return self._read_var_sized_field(field, fix_sized_item_array_reader)
+            # Optional[List[T]] is compatible with Optional[List[Optional[T]]]
+            return self._read_var_sized_field(field, fix_sized_item_array_reader)  # type: ignore[return-value]
         elif kind == nullable_fix_sized_item_array_field_kind:
             return self._read_var_sized_item_array(field, item_reader)
         else:
-            DefaultCompactReader._raise_mismatched_field_kind_error(
+            raise DefaultCompactReader._create_mismatched_field_kind_error(
                 field_name, kind, fix_sized_item_array_field_kind
             )
 
@@ -1632,7 +1634,9 @@ class SchemaWriter(CompactWriter):
     ) -> None:
         self._add_field(field_name, FieldKind.ARRAY_OF_NULLABLE_BOOLEAN)
 
-    def write_array_of_int8(self, field_name: str, value: typing.Optional[bytearray]) -> None:
+    def write_array_of_int8(
+        self, field_name: str, value: typing.Optional[typing.List[int]]
+    ) -> None:
         self._add_field(field_name, FieldKind.ARRAY_OF_INT8)
 
     def write_array_of_nullable_int8(
@@ -1736,11 +1740,13 @@ class SchemaWriter(CompactWriter):
 class Schema:
     def __init__(self, type_name: str, fields_list: typing.List["FieldDescriptor"]):
         self.type_name = type_name
-        self.fields = Schema._dict_to_key_ordered_dict({f.name: f for f in fields_list})
+        self.fields: typing.Dict[str, "FieldDescriptor"] = Schema._dict_to_key_ordered_dict(
+            {f.name: f for f in fields_list}
+        )
         self.fields_list = list(self.fields.values())
-        self.schema_id = 0
-        self.var_sized_field_count = 0
-        self.fix_sized_fields_length = 0
+        self.schema_id: int = 0
+        self.var_sized_field_count: int = 0
+        self.fix_sized_fields_length: int = 0
         self._init()
 
     def _init(self):
@@ -2221,7 +2227,7 @@ class ArrayOfNullableFloat64Operations(FieldKindOperations):
     pass
 
 
-FIELD_OPERATIONS: typing.List[FieldKindOperations] = [
+FIELD_OPERATIONS: typing.List[typing.Optional[FieldKindOperations]] = [
     BooleanOperations(),
     ArrayOfBooleanOperations(),
     Int8Operations(),

--- a/hazelcast/serialization/portable/classdef.py
+++ b/hazelcast/serialization/portable/classdef.py
@@ -79,7 +79,9 @@ class ClassDefinition:
     def add_field_def(self, field_def):
         self.field_defs[field_def.field_name] = field_def
 
-    def get_field(self, field_name_or_index: typing.Union[int, str]) -> FieldDefinition:
+    def get_field(
+        self, field_name_or_index: typing.Union[int, str]
+    ) -> typing.Optional[FieldDefinition]:
         if isinstance(field_name_or_index, int):
             index = field_name_or_index
             count = self.get_field_count()
@@ -158,8 +160,8 @@ class ClassDefinitionBuilder:
 
         self._index = 0
         self._done = False
-        self._field_defs = list()
-        self._field_names = set()
+        self._field_defs: typing.List[FieldDefinition] = []
+        self._field_names: typing.Set[str] = set()
 
     def add_portable_field(
         self, field_name: str, class_def: ClassDefinition

--- a/hazelcast/serialization/service.py
+++ b/hazelcast/serialization/service.py
@@ -490,7 +490,7 @@ class SerializerRegistry:
                 self._id_dict[serializer_type_id] = stream_serializer
             return current is None
 
-    def register_from_super_type(self, obj_type, super_type) -> StreamSerializer:
+    def register_from_super_type(self, obj_type, super_type) -> typing.Optional[StreamSerializer]:
         serializer = self._type_dict.get(super_type, None)
         if serializer is not None:
             self.safe_register_serializer(serializer, obj_type)

--- a/hazelcast/statistics.py
+++ b/hazelcast/statistics.py
@@ -9,7 +9,8 @@ from hazelcast.util import current_time_in_millis, to_millis, to_nanos, current_
 from hazelcast import __version__
 
 try:
-    import psutil
+    # psutil does not support type hints
+    import psutil  # type: ignore[import]
 
     _PSUTIL_ENABLED = True
 except ImportError:

--- a/hazelcast/transaction.py
+++ b/hazelcast/transaction.py
@@ -1,6 +1,7 @@
 import logging
 import threading
 import time
+import typing
 import uuid
 
 from hazelcast.errors import TransactionError, IllegalStateError
@@ -96,10 +97,10 @@ class Transaction:
     """
 
     state = _STATE_NOT_STARTED
-    id: uuid.UUID = None
-    start_time: float = None
+    id: typing.Optional[uuid.UUID] = None
+    start_time: typing.Optional[float] = None
     _locals = threading.local()
-    thread_id: int = None
+    thread_id: typing.Optional[int] = None
 
     def __init__(self, context, connection, timeout, durability, transaction_type):
         self._context = context

--- a/hazelcast/util.py
+++ b/hazelcast/util.py
@@ -254,7 +254,6 @@ def try_to_get_enum_value(value, enum_class):
 
 
 number_types = (int, float)
-none_type = type(None)
 
 
 class LoadBalancer:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 black==22.3.0
 Sphinx==4.2.0
 sphinx-rtd-theme==1.0.0
+mypy==0.940

--- a/tests/unit/reactor_test.py
+++ b/tests/unit/reactor_test.py
@@ -364,7 +364,7 @@ class AsyncoreConnectionTest(unittest.TestCase):
             # before connection timeout
             self.assertLess(get_current_timestamp() - start, config.connection_timeout)
         finally:
-            conn.close(None, None)
+            conn.close_connection(None, None)
 
     def test_resources_cleaned_up_after_immediate_failure(self):
         addr = Address("invalid-address", 5701)
@@ -372,7 +372,7 @@ class AsyncoreConnectionTest(unittest.TestCase):
         mock_reactor = MagicMock(map={})
         try:
             conn = AsyncoreConnection(mock_reactor, MagicMock(), None, addr, config, None)
-            conn.close(None, None)
+            conn.close_connection(None, None)
             self.fail("Connection attempt to an invalid address should fail immediately")
         except socket.error:
             # Constructor of the connection should remove itself from the


### PR DESCRIPTION
There were around 60 errors shown in the mypy checks about the various
minor problems across the client code base. This PR corrects
those errors and adds a check for the mypy to PR builder workflow.

Note that, for now, we are only checking the type hints in the
hazelcast directory (client's code base). Tests and examples are not
passing the mypy checks for now. We can improve this incrementally,
and add them in the future.

Also, we are not using the strict flag of the mypy, due to not
type hinting the internals yet. Hopefully, we will have that
in the future.