### PR TITLE
Fixed test imports for older releases.

### DIFF
--- a/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
+++ b/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
@@ -6,11 +6,7 @@ import unittest
 from hazelcast.errors import NullPointerError, IllegalMonitorStateError
 from hazelcast.predicate import Predicate, paging
 from tests.base import HazelcastTestCase
-from tests.util import (
-    random_string,
-    compare_client_version,
-    compare_server_version_with_rc,
-)
+from tests.util import random_string, compare_client_version, compare_server_version_with_rc
 
 try:
     from hazelcast.serialization.api import (
@@ -238,8 +234,7 @@ OUTER_COMPACT_INSTANCE = OuterCompact(42, INNER_COMPACT_INSTANCE)
 
 
 @unittest.skipIf(
-    compare_client_version("5.1") < 0,
-    "Tests the features added in 5.1 version of the client",
+    compare_client_version("5.1") < 0, "Tests the features added in 5.1 version of the client"
 )
 class CompactCompatibilityBase(HazelcastTestCase):
     rc = None
@@ -766,8 +761,7 @@ class MapCompatibilityTest(CompactCompatibilityBase):
         self.assertIsNone(self.map.replace(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
         self.map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         self.assertEqual(
-            OUTER_COMPACT_INSTANCE,
-            self.map.replace(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE),
+            OUTER_COMPACT_INSTANCE, self.map.replace(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         )
 
     def test_replace_if_same(self):
@@ -1435,8 +1429,7 @@ class TransactionalMapCompactCompatibilityTest(CompactCompatibilityBase):
         with self.transaction:
             transactional_map = self._get_transactional_map()
             self.assertEqual(
-                OUTER_COMPACT_INSTANCE,
-                transactional_map.get_for_update(INNER_COMPACT_INSTANCE),
+                OUTER_COMPACT_INSTANCE, transactional_map.get_for_update(INNER_COMPACT_INSTANCE)
             )
 
     def test_put(self):
@@ -1479,9 +1472,7 @@ class TransactionalMapCompactCompatibilityTest(CompactCompatibilityBase):
             transactional_map = self._get_transactional_map()
             self.assertTrue(
                 transactional_map.replace_if_same(
-                    INNER_COMPACT_INSTANCE,
-                    INNER_COMPACT_INSTANCE,
-                    OUTER_COMPACT_INSTANCE,
+                    INNER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE
                 )
             )
 
@@ -1559,8 +1550,7 @@ class TransactionalMultiMapCompactCompatibilityTest(CompactCompatibilityBase):
         with self.transaction:
             transactional_multi_map = self._get_transactional_multi_map()
             self.assertEqual(
-                [INNER_COMPACT_INSTANCE],
-                transactional_multi_map.get(OUTER_COMPACT_INSTANCE),
+                [INNER_COMPACT_INSTANCE], transactional_multi_map.get(OUTER_COMPACT_INSTANCE)
             )
 
     def test_remove(self):
@@ -1576,8 +1566,7 @@ class TransactionalMultiMapCompactCompatibilityTest(CompactCompatibilityBase):
         with self.transaction:
             transactional_multi_map = self._get_transactional_multi_map()
             self.assertEqual(
-                [INNER_COMPACT_INSTANCE],
-                transactional_multi_map.remove_all(OUTER_COMPACT_INSTANCE),
+                [INNER_COMPACT_INSTANCE], transactional_multi_map.remove_all(OUTER_COMPACT_INSTANCE)
             )
 
     def test_value_count(self):

--- a/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
+++ b/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
@@ -6,7 +6,11 @@ import unittest
 from hazelcast.errors import NullPointerError, IllegalMonitorStateError
 from hazelcast.predicate import Predicate, paging
 from tests.base import HazelcastTestCase
-from tests.util import random_string, compare_client_version, compare_server_version_with_rc
+from tests.util import (
+    random_string,
+    compare_client_version,
+    compare_server_version_with_rc,
+)
 
 try:
     from hazelcast.serialization.api import (
@@ -149,7 +153,9 @@ class CompactReturningMapInterceptor:
     pass
 
 
-class CompactReturningMapInterceptorSerializer(CompactSerializer[CompactReturningMapInterceptor]):
+class CompactReturningMapInterceptorSerializer(
+    CompactSerializer[CompactReturningMapInterceptor]
+):
     def read(self, reader: CompactReader) -> CompactReturningMapInterceptor:
         return CompactReturningMapInterceptor()
 
@@ -159,16 +165,23 @@ class CompactReturningMapInterceptorSerializer(CompactSerializer[CompactReturnin
     def get_type_name(self) -> str:
         return "com.hazelcast.serialization.compact.CompactReturningMapInterceptor"
 
+
 try:
     from hazelcast.aggregator import Aggregator
+
     class CompactReturningAggregator(Aggregator):
         pass
+
+
 except ImportError:
+
     class CompactReturningAggregator:
         pass
 
 
-class CompactReturningAggregatorSerializer(CompactSerializer[CompactReturningAggregator]):
+class CompactReturningAggregatorSerializer(
+    CompactSerializer[CompactReturningAggregator]
+):
     def read(self, reader: CompactReader) -> CompactReturningAggregator:
         return CompactReturningAggregator()
 
@@ -183,7 +196,9 @@ class CompactReturningEntryProcessor:
     pass
 
 
-class CompactReturningEntryProcessorSerializer(CompactSerializer[CompactReturningEntryProcessor]):
+class CompactReturningEntryProcessorSerializer(
+    CompactSerializer[CompactReturningEntryProcessor]
+):
     def read(self, reader: CompactReader) -> CompactReturningEntryProcessor:
         return CompactReturningEntryProcessor()
 
@@ -198,7 +213,9 @@ class CompactReturningProjection:
     pass
 
 
-class CompactReturningProjectionSerializer(CompactSerializer[CompactReturningProjection]):
+class CompactReturningProjectionSerializer(
+    CompactSerializer[CompactReturningProjection]
+):
     def read(self, reader: CompactReader) -> CompactReturningProjection:
         return CompactReturningProjection()
 
@@ -229,7 +246,8 @@ OUTER_COMPACT_INSTANCE = OuterCompact(42, INNER_COMPACT_INSTANCE)
 
 
 @unittest.skipIf(
-    compare_client_version("5.1") < 0, "Tests the features added in 5.1 version of the client"
+    compare_client_version("5.1") < 0,
+    "Tests the features added in 5.1 version of the client",
 )
 class CompactCompatibilityBase(HazelcastTestCase):
     rc = None
@@ -289,7 +307,9 @@ class CompactCompatibilityBase(HazelcastTestCase):
 class AtomicLongCompactCompatibilityTest(CompactCompatibilityBase):
     def setUp(self) -> None:
         super().setUp()
-        self.atomic_long = self.client.cp_subsystem.get_atomic_long(random_string()).blocking()
+        self.atomic_long = self.client.cp_subsystem.get_atomic_long(
+            random_string()
+        ).blocking()
         self.atomic_long.set(41)
 
     def tearDown(self) -> None:
@@ -308,7 +328,9 @@ class AtomicLongCompactCompatibilityTest(CompactCompatibilityBase):
         self.assertEqual(42, self.atomic_long.get())
 
     def test_apply(self):
-        self.assertEqual(OUTER_COMPACT_INSTANCE, self.atomic_long.apply(CompactReturningFunction()))
+        self.assertEqual(
+            OUTER_COMPACT_INSTANCE, self.atomic_long.apply(CompactReturningFunction())
+        )
 
 
 class AtomicReferenceCompactCompatibilityTest(CompactCompatibilityBase):
@@ -324,7 +346,9 @@ class AtomicReferenceCompactCompatibilityTest(CompactCompatibilityBase):
         super().tearDown()
 
     def test_compare_and_set(self):
-        self.assertTrue(self.atomic_reference.compare_and_set(None, OUTER_COMPACT_INSTANCE))
+        self.assertTrue(
+            self.atomic_reference.compare_and_set(None, OUTER_COMPACT_INSTANCE)
+        )
         self.assertEqual(OUTER_COMPACT_INSTANCE, self.atomic_reference.get())
 
     def test_set(self):
@@ -332,8 +356,12 @@ class AtomicReferenceCompactCompatibilityTest(CompactCompatibilityBase):
         self.assertEqual(OUTER_COMPACT_INSTANCE, self.atomic_reference.get())
 
     def test_get_and_set(self):
-        self.assertEqual(None, self.atomic_reference.get_and_set(OUTER_COMPACT_INSTANCE))
-        self.assertEqual(OUTER_COMPACT_INSTANCE, self.atomic_reference.get_and_set(None))
+        self.assertEqual(
+            None, self.atomic_reference.get_and_set(OUTER_COMPACT_INSTANCE)
+        )
+        self.assertEqual(
+            OUTER_COMPACT_INSTANCE, self.atomic_reference.get_and_set(None)
+        )
 
     def test_contains(self):
         self.assertFalse(self.atomic_reference.contains(OUTER_COMPACT_INSTANCE))
@@ -351,7 +379,9 @@ class AtomicReferenceCompactCompatibilityTest(CompactCompatibilityBase):
         )
 
     def test_get_and_alter(self):
-        self.assertEqual(None, self.atomic_reference.get_and_alter(CompactReturningFunction()))
+        self.assertEqual(
+            None, self.atomic_reference.get_and_alter(CompactReturningFunction())
+        )
         self.assertEqual(
             OUTER_COMPACT_INSTANCE,
             self.atomic_reference.get_and_alter(CompactReturningFunction()),
@@ -380,7 +410,9 @@ class ExecutorCompactCompatibilityTest(CompactCompatibilityBase):
     def test_execute_on_key_owner(self):
         self.assertEqual(
             OUTER_COMPACT_INSTANCE,
-            self.executor.execute_on_key_owner(OUTER_COMPACT_INSTANCE, CompactReturningCallable()),
+            self.executor.execute_on_key_owner(
+                OUTER_COMPACT_INSTANCE, CompactReturningCallable()
+            ),
         )
 
     def test_execute_on_member(self):
@@ -422,12 +454,16 @@ class ListCompactCompatibilityTest(CompactCompatibilityBase):
         self.assertEqual(OUTER_COMPACT_INSTANCE, self.list.get(0))
 
     def test_add_all(self):
-        self.assertTrue(self.list.add_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]))
+        self.assertTrue(
+            self.list.add_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE])
+        )
         self.assertEqual(INNER_COMPACT_INSTANCE, self.list.get(0))
         self.assertEqual(OUTER_COMPACT_INSTANCE, self.list.get(1))
 
     def test_add_all_at(self):
-        self.assertTrue(self.list.add_all_at(0, [INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]))
+        self.assertTrue(
+            self.list.add_all_at(0, [INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE])
+        )
         self.assertEqual(INNER_COMPACT_INSTANCE, self.list.get(0))
         self.assertEqual(OUTER_COMPACT_INSTANCE, self.list.get(1))
 
@@ -497,7 +533,9 @@ class ListCompactCompatibilityTest(CompactCompatibilityBase):
     def test_set_at(self):
         self.list.add(42)
         self.assertEqual(42, self.list.set_at(0, OUTER_COMPACT_INSTANCE))
-        self.assertEqual(OUTER_COMPACT_INSTANCE, self.list.set_at(0, INNER_COMPACT_INSTANCE))
+        self.assertEqual(
+            OUTER_COMPACT_INSTANCE, self.list.set_at(0, INNER_COMPACT_INSTANCE)
+        )
 
     def _add_from_another_client(self, value):
         other_client = self.create_client(self.client_config)
@@ -570,7 +608,9 @@ class MapCompatibilityTest(CompactCompatibilityBase):
     def test_aggregate_with_predicate(self):
         self.assertEqual(
             OUTER_COMPACT_INSTANCE,
-            self.map.aggregate(CompactReturningAggregator(), predicate=CompactPredicate()),
+            self.map.aggregate(
+                CompactReturningAggregator(), predicate=CompactPredicate()
+            ),
         )
 
     def test_contains_key(self):
@@ -623,21 +663,27 @@ class MapCompatibilityTest(CompactCompatibilityBase):
         self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
         self.assertEqual(
             [(OUTER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)],
-            self.map.execute_on_entries(CompactReturningEntryProcessor(), CompactPredicate()),
+            self.map.execute_on_entries(
+                CompactReturningEntryProcessor(), CompactPredicate()
+            ),
         )
 
     def test_execute_on_key(self):
         self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
         self.assertEqual(
             OUTER_COMPACT_INSTANCE,
-            self.map.execute_on_key(OUTER_COMPACT_INSTANCE, CompactReturningEntryProcessor()),
+            self.map.execute_on_key(
+                OUTER_COMPACT_INSTANCE, CompactReturningEntryProcessor()
+            ),
         )
 
     def test_execute_on_keys(self):
         self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
         self.assertEqual(
             [(OUTER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)],
-            self.map.execute_on_keys([OUTER_COMPACT_INSTANCE], CompactReturningEntryProcessor()),
+            self.map.execute_on_keys(
+                [OUTER_COMPACT_INSTANCE], CompactReturningEntryProcessor()
+            ),
         )
 
     def test_force_unlock(self):
@@ -732,7 +778,9 @@ class MapCompatibilityTest(CompactCompatibilityBase):
         self.assertEqual(INNER_COMPACT_INSTANCE, self.map.get(OUTER_COMPACT_INSTANCE))
 
     def test_put_if_absent(self):
-        self.assertIsNone(self.map.put_if_absent(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
+        self.assertIsNone(
+            self.map.put_if_absent(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        )
         self.assertEqual(
             OUTER_COMPACT_INSTANCE,
             self.map.put_if_absent(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE),
@@ -745,18 +793,27 @@ class MapCompatibilityTest(CompactCompatibilityBase):
     def test_remove(self):
         self.assertIsNone(self.map.remove(OUTER_COMPACT_INSTANCE))
         self._put_from_another_client(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
-        self.assertEqual(INNER_COMPACT_INSTANCE, self.map.remove(OUTER_COMPACT_INSTANCE))
+        self.assertEqual(
+            INNER_COMPACT_INSTANCE, self.map.remove(OUTER_COMPACT_INSTANCE)
+        )
 
     def test_remove_if_same(self):
-        self.assertFalse(self.map.remove_if_same(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
+        self.assertFalse(
+            self.map.remove_if_same(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        )
         self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
-        self.assertTrue(self.map.remove_if_same(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
+        self.assertTrue(
+            self.map.remove_if_same(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        )
 
     def test_replace(self):
-        self.assertIsNone(self.map.replace(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
+        self.assertIsNone(
+            self.map.replace(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        )
         self.map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         self.assertEqual(
-            OUTER_COMPACT_INSTANCE, self.map.replace(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+            OUTER_COMPACT_INSTANCE,
+            self.map.replace(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE),
         )
 
     def test_replace_if_same(self):
@@ -784,7 +841,9 @@ class MapCompatibilityTest(CompactCompatibilityBase):
         self.assertTrue(self.map.try_lock(OUTER_COMPACT_INSTANCE))
 
     def test_try_put(self):
-        self.assertTrue(self.map.try_put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
+        self.assertTrue(
+            self.map.try_put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        )
 
     def test_try_remove(self):
         self.assertFalse(self.map.try_remove(OUTER_COMPACT_INSTANCE))
@@ -811,7 +870,9 @@ class MapCompatibilityTest(CompactCompatibilityBase):
         # Put an entry from the same client to register these schemas
         # to its local registry, so that the lazy-deserialization works.
         self.map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
-        self.assertEqual([OUTER_COMPACT_INSTANCE], self.map.values(paging(CompactPredicate(), 1)))
+        self.assertEqual(
+            [OUTER_COMPACT_INSTANCE], self.map.values(paging(CompactPredicate(), 1))
+        )
 
     def _put_from_another_client(self, key, value):
         other_client = self.create_client(self.client_config)
@@ -835,7 +896,9 @@ class MapCompatibilityTest(CompactCompatibilityBase):
 class NearCachedMapCompactCompatibilityTest(MapCompatibilityTest):
     def setUp(self) -> None:
         map_name = random_string()
-        self.client_config = copy.deepcopy(NearCachedMapCompactCompatibilityTest.client_config)
+        self.client_config = copy.deepcopy(
+            NearCachedMapCompactCompatibilityTest.client_config
+        )
         self.client_config["near_caches"] = {map_name: {}}
         super().setUp()
         self.map = self.client.get_map(map_name).blocking()
@@ -898,17 +961,23 @@ class MultiMapCompactCompatibilityTest(CompactCompatibilityBase):
 
     def test_contains_entry(self):
         self.assertFalse(
-            self.multi_map.contains_entry(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+            self.multi_map.contains_entry(
+                INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE
+            )
         )
         self.multi_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         self.assertTrue(
-            self.multi_map.contains_entry(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+            self.multi_map.contains_entry(
+                INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE
+            )
         )
 
     def test_get(self):
         self.assertEqual([], self.multi_map.get(OUTER_COMPACT_INSTANCE))
         self.multi_map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
-        self.assertEqual([INNER_COMPACT_INSTANCE], self.multi_map.get(OUTER_COMPACT_INSTANCE))
+        self.assertEqual(
+            [INNER_COMPACT_INSTANCE], self.multi_map.get(OUTER_COMPACT_INSTANCE)
+        )
 
     def test_is_locked(self):
         self.assertFalse(self.multi_map.is_locked(OUTER_COMPACT_INSTANCE))
@@ -926,9 +995,13 @@ class MultiMapCompactCompatibilityTest(CompactCompatibilityBase):
         self.assertTrue(self.multi_map.is_locked(OUTER_COMPACT_INSTANCE))
 
     def test_remove(self):
-        self.assertFalse(self.multi_map.remove(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
+        self.assertFalse(
+            self.multi_map.remove(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        )
         self.multi_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
-        self.assertTrue(self.multi_map.remove(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
+        self.assertTrue(
+            self.multi_map.remove(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        )
 
     def test_remove_all(self):
         self.assertEqual([], self.multi_map.remove_all(OUTER_COMPACT_INSTANCE))
@@ -938,8 +1011,12 @@ class MultiMapCompactCompatibilityTest(CompactCompatibilityBase):
         )
 
     def test_put(self):
-        self.assertTrue(self.multi_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
-        self.assertEqual([OUTER_COMPACT_INSTANCE], self.multi_map.get(INNER_COMPACT_INSTANCE))
+        self.assertTrue(
+            self.multi_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        )
+        self.assertEqual(
+            [OUTER_COMPACT_INSTANCE], self.multi_map.get(INNER_COMPACT_INSTANCE)
+        )
 
     def test_value_count(self):
         self.assertEqual(0, self.multi_map.value_count(OUTER_COMPACT_INSTANCE))
@@ -974,7 +1051,9 @@ class MultiMapCompactCompatibilityTest(CompactCompatibilityBase):
 
     def _put_from_another_client(self, key, value):
         other_client = self.create_client(self.client_config)
-        other_client_multi_map = other_client.get_multi_map(self.multi_map.name).blocking()
+        other_client_multi_map = other_client.get_multi_map(
+            self.multi_map.name
+        ).blocking()
         other_client_multi_map.put(key, value)
 
 
@@ -991,7 +1070,9 @@ class QueueCompactCompatibilityTest(CompactCompatibilityBase):
         self.assertTrue(self.queue.add(OUTER_COMPACT_INSTANCE))
 
     def test_add_all(self):
-        self.assertTrue(self.queue.add_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]))
+        self.assertTrue(
+            self.queue.add_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE])
+        )
 
     def test_add_listener(self):
         events = []
@@ -1107,7 +1188,9 @@ class ReliableTopicCompactCompatibilityTest(CompactCompatibilityBase):
 
         self.reliable_topic.add_listener(listener)
 
-        self.reliable_topic.publish_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE])
+        self.reliable_topic.publish_all(
+            [INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]
+        )
 
         def assertion():
             self.assertEqual(2, len(messages))
@@ -1178,11 +1261,17 @@ class ReplicatedMapCompactCompatibilityTest(CompactCompatibilityBase):
     def test_get(self):
         self.assertIsNone(self.replicated_map.get(OUTER_COMPACT_INSTANCE))
         self.replicated_map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
-        self.assertEqual(INNER_COMPACT_INSTANCE, self.replicated_map.get(OUTER_COMPACT_INSTANCE))
+        self.assertEqual(
+            INNER_COMPACT_INSTANCE, self.replicated_map.get(OUTER_COMPACT_INSTANCE)
+        )
 
     def test_put(self):
-        self.assertIsNone(self.replicated_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
-        self.assertEqual(OUTER_COMPACT_INSTANCE, self.replicated_map.get(INNER_COMPACT_INSTANCE))
+        self.assertIsNone(
+            self.replicated_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        )
+        self.assertEqual(
+            OUTER_COMPACT_INSTANCE, self.replicated_map.get(INNER_COMPACT_INSTANCE)
+        )
         self.assertEqual(
             OUTER_COMPACT_INSTANCE,
             self.replicated_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE),
@@ -1195,13 +1284,19 @@ class ReplicatedMapCompactCompatibilityTest(CompactCompatibilityBase):
                 OUTER_COMPACT_INSTANCE: INNER_COMPACT_INSTANCE,
             }
         )
-        self.assertEqual(OUTER_COMPACT_INSTANCE, self.replicated_map.get(INNER_COMPACT_INSTANCE))
-        self.assertEqual(INNER_COMPACT_INSTANCE, self.replicated_map.get(OUTER_COMPACT_INSTANCE))
+        self.assertEqual(
+            OUTER_COMPACT_INSTANCE, self.replicated_map.get(INNER_COMPACT_INSTANCE)
+        )
+        self.assertEqual(
+            INNER_COMPACT_INSTANCE, self.replicated_map.get(OUTER_COMPACT_INSTANCE)
+        )
 
     def test_remove(self):
         self.assertIsNone(self.replicated_map.remove(OUTER_COMPACT_INSTANCE))
         self.replicated_map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
-        self.assertEqual(INNER_COMPACT_INSTANCE, self.replicated_map.remove(OUTER_COMPACT_INSTANCE))
+        self.assertEqual(
+            INNER_COMPACT_INSTANCE, self.replicated_map.remove(OUTER_COMPACT_INSTANCE)
+        )
 
     def _assert_entry_event(self, events):
         self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
@@ -1259,7 +1354,9 @@ class RingbufferCompactCompatibilityTest(CompactCompatibilityBase):
 
     def _add_from_another_client(self, item):
         other_client = self.create_client(self.client_config)
-        other_client_ringbuffer = other_client.get_ringbuffer(self.ringbuffer.name).blocking()
+        other_client_ringbuffer = other_client.get_ringbuffer(
+            self.ringbuffer.name
+        ).blocking()
         other_client_ringbuffer.add(item)
 
 
@@ -1276,7 +1373,9 @@ class SetCompactCompatibilityTest(CompactCompatibilityBase):
         self.assertTrue(self.set.add(OUTER_COMPACT_INSTANCE))
 
     def test_add_all(self):
-        self.assertTrue(self.set.add_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]))
+        self.assertTrue(
+            self.set.add_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE])
+        )
 
     def test_add_listener(self):
         events = []
@@ -1304,9 +1403,13 @@ class SetCompactCompatibilityTest(CompactCompatibilityBase):
         self.assertTrue(self.set.contains(OUTER_COMPACT_INSTANCE))
 
     def test_contains_all(self):
-        self.assertFalse(self.set.contains_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]))
+        self.assertFalse(
+            self.set.contains_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE])
+        )
         self.set.add_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE])
-        self.assertTrue(self.set.contains_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]))
+        self.assertTrue(
+            self.set.contains_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE])
+        )
 
     def test_remove(self):
         self.assertFalse(self.set.remove(OUTER_COMPACT_INSTANCE))
@@ -1314,9 +1417,13 @@ class SetCompactCompatibilityTest(CompactCompatibilityBase):
         self.assertTrue(self.set.remove(OUTER_COMPACT_INSTANCE))
 
     def test_remove_all(self):
-        self.assertFalse(self.set.remove_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]))
+        self.assertFalse(
+            self.set.remove_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE])
+        )
         self.set.add_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE])
-        self.assertTrue(self.set.remove_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]))
+        self.assertTrue(
+            self.set.remove_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE])
+        )
 
     def test_retain_all(self):
         items = [INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]
@@ -1417,20 +1524,25 @@ class TransactionalMapCompactCompatibilityTest(CompactCompatibilityBase):
         self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         with self.transaction:
             transactional_map = self._get_transactional_map()
-            self.assertEqual(OUTER_COMPACT_INSTANCE, transactional_map.get(INNER_COMPACT_INSTANCE))
+            self.assertEqual(
+                OUTER_COMPACT_INSTANCE, transactional_map.get(INNER_COMPACT_INSTANCE)
+            )
 
     def test_get_for_update(self):
         self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         with self.transaction:
             transactional_map = self._get_transactional_map()
             self.assertEqual(
-                OUTER_COMPACT_INSTANCE, transactional_map.get_for_update(INNER_COMPACT_INSTANCE)
+                OUTER_COMPACT_INSTANCE,
+                transactional_map.get_for_update(INNER_COMPACT_INSTANCE),
             )
 
     def test_put(self):
         with self.transaction:
             transactional_map = self._get_transactional_map()
-            self.assertIsNone(transactional_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
+            self.assertIsNone(
+                transactional_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+            )
 
         self.assertEqual(OUTER_COMPACT_INSTANCE, self.map.get(INNER_COMPACT_INSTANCE))
 
@@ -1438,7 +1550,9 @@ class TransactionalMapCompactCompatibilityTest(CompactCompatibilityBase):
         with self.transaction:
             transactional_map = self._get_transactional_map()
             self.assertIsNone(
-                transactional_map.put_if_absent(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+                transactional_map.put_if_absent(
+                    INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE
+                )
             )
 
         self.assertEqual(OUTER_COMPACT_INSTANCE, self.map.get(INNER_COMPACT_INSTANCE))
@@ -1446,7 +1560,9 @@ class TransactionalMapCompactCompatibilityTest(CompactCompatibilityBase):
     def test_set(self):
         with self.transaction:
             transactional_map = self._get_transactional_map()
-            self.assertIsNone(transactional_map.set(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
+            self.assertIsNone(
+                transactional_map.set(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+            )
 
         self.assertEqual(OUTER_COMPACT_INSTANCE, self.map.get(INNER_COMPACT_INSTANCE))
 
@@ -1456,7 +1572,9 @@ class TransactionalMapCompactCompatibilityTest(CompactCompatibilityBase):
             transactional_map = self._get_transactional_map()
             self.assertEqual(
                 INNER_COMPACT_INSTANCE,
-                transactional_map.replace(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE),
+                transactional_map.replace(
+                    INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE
+                ),
             )
 
         self.assertEqual(OUTER_COMPACT_INSTANCE, self.map.get(INNER_COMPACT_INSTANCE))
@@ -1467,7 +1585,9 @@ class TransactionalMapCompactCompatibilityTest(CompactCompatibilityBase):
             transactional_map = self._get_transactional_map()
             self.assertTrue(
                 transactional_map.replace_if_same(
-                    INNER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE
+                    INNER_COMPACT_INSTANCE,
+                    INNER_COMPACT_INSTANCE,
+                    OUTER_COMPACT_INSTANCE,
                 )
             )
 
@@ -1486,7 +1606,9 @@ class TransactionalMapCompactCompatibilityTest(CompactCompatibilityBase):
         with self.transaction:
             transactional_map = self._get_transactional_map()
             self.assertTrue(
-                transactional_map.remove_if_same(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+                transactional_map.remove_if_same(
+                    INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE
+                )
             )
 
     def test_delete(self):
@@ -1509,7 +1631,9 @@ class TransactionalMapCompactCompatibilityTest(CompactCompatibilityBase):
         self.map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         with self.transaction:
             transactional_map = self._get_transactional_map()
-            self.assertEqual([OUTER_COMPACT_INSTANCE], transactional_map.values(CompactPredicate()))
+            self.assertEqual(
+                [OUTER_COMPACT_INSTANCE], transactional_map.values(CompactPredicate())
+            )
 
     def _get_transactional_map(self):
         return self.transaction.get_map(self.map_name)
@@ -1535,7 +1659,9 @@ class TransactionalMultiMapCompactCompatibilityTest(CompactCompatibilityBase):
         with self.transaction:
             transactional_multi_map = self._get_transactional_multi_map()
             self.assertTrue(
-                transactional_multi_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+                transactional_multi_map.put(
+                    INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE
+                )
             )
 
     def test_get(self):
@@ -1545,7 +1671,8 @@ class TransactionalMultiMapCompactCompatibilityTest(CompactCompatibilityBase):
         with self.transaction:
             transactional_multi_map = self._get_transactional_multi_map()
             self.assertEqual(
-                [INNER_COMPACT_INSTANCE], transactional_multi_map.get(OUTER_COMPACT_INSTANCE)
+                [INNER_COMPACT_INSTANCE],
+                transactional_multi_map.get(OUTER_COMPACT_INSTANCE),
             )
 
     def test_remove(self):
@@ -1553,7 +1680,9 @@ class TransactionalMultiMapCompactCompatibilityTest(CompactCompatibilityBase):
         with self.transaction:
             transactional_multi_map = self._get_transactional_multi_map()
             self.assertTrue(
-                transactional_multi_map.remove(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+                transactional_multi_map.remove(
+                    INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE
+                )
             )
 
     def test_remove_all(self):
@@ -1561,21 +1690,26 @@ class TransactionalMultiMapCompactCompatibilityTest(CompactCompatibilityBase):
         with self.transaction:
             transactional_multi_map = self._get_transactional_multi_map()
             self.assertEqual(
-                [INNER_COMPACT_INSTANCE], transactional_multi_map.remove_all(OUTER_COMPACT_INSTANCE)
+                [INNER_COMPACT_INSTANCE],
+                transactional_multi_map.remove_all(OUTER_COMPACT_INSTANCE),
             )
 
     def test_value_count(self):
         self._put_from_another_client(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
         with self.transaction:
             transactional_multi_map = self._get_transactional_multi_map()
-            self.assertEqual(1, transactional_multi_map.value_count(OUTER_COMPACT_INSTANCE))
+            self.assertEqual(
+                1, transactional_multi_map.value_count(OUTER_COMPACT_INSTANCE)
+            )
 
     def _get_transactional_multi_map(self):
         return self.transaction.get_multi_map(self.multi_map_name)
 
     def _put_from_another_client(self, key, value):
         other_client = self.create_client(self.client_config)
-        other_client_multi_map = other_client.get_multi_map(self.multi_map_name).blocking()
+        other_client_multi_map = other_client.get_multi_map(
+            self.multi_map_name
+        ).blocking()
         other_client_multi_map.put(key, value)
 
 

--- a/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
+++ b/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
@@ -166,7 +166,6 @@ try:
     class CompactReturningAggregator(Aggregator):
         pass
 
-
 except ImportError:
 
     class CompactReturningAggregator:

--- a/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
+++ b/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
@@ -3,7 +3,6 @@ import enum
 import typing
 import unittest
 
-from hazelcast.aggregator import Aggregator
 from hazelcast.errors import NullPointerError, IllegalMonitorStateError
 from hazelcast.predicate import Predicate, paging
 from tests.base import HazelcastTestCase
@@ -160,9 +159,13 @@ class CompactReturningMapInterceptorSerializer(CompactSerializer[CompactReturnin
     def get_type_name(self) -> str:
         return "com.hazelcast.serialization.compact.CompactReturningMapInterceptor"
 
-
-class CompactReturningAggregator(Aggregator):
-    pass
+try:
+    from hazelcast.aggregator import Aggregator
+    class CompactReturningAggregator(Aggregator):
+        pass
+except ImportError:
+    class CompactReturningAggregator:
+        pass
 
 
 class CompactReturningAggregatorSerializer(CompactSerializer[CompactReturningAggregator]):

--- a/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
+++ b/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
@@ -153,9 +153,7 @@ class CompactReturningMapInterceptor:
     pass
 
 
-class CompactReturningMapInterceptorSerializer(
-    CompactSerializer[CompactReturningMapInterceptor]
-):
+class CompactReturningMapInterceptorSerializer(CompactSerializer[CompactReturningMapInterceptor]):
     def read(self, reader: CompactReader) -> CompactReturningMapInterceptor:
         return CompactReturningMapInterceptor()
 
@@ -179,9 +177,7 @@ except ImportError:
         pass
 
 
-class CompactReturningAggregatorSerializer(
-    CompactSerializer[CompactReturningAggregator]
-):
+class CompactReturningAggregatorSerializer(CompactSerializer[CompactReturningAggregator]):
     def read(self, reader: CompactReader) -> CompactReturningAggregator:
         return CompactReturningAggregator()
 
@@ -196,9 +192,7 @@ class CompactReturningEntryProcessor:
     pass
 
 
-class CompactReturningEntryProcessorSerializer(
-    CompactSerializer[CompactReturningEntryProcessor]
-):
+class CompactReturningEntryProcessorSerializer(CompactSerializer[CompactReturningEntryProcessor]):
     def read(self, reader: CompactReader) -> CompactReturningEntryProcessor:
         return CompactReturningEntryProcessor()
 
@@ -213,9 +207,7 @@ class CompactReturningProjection:
     pass
 
 
-class CompactReturningProjectionSerializer(
-    CompactSerializer[CompactReturningProjection]
-):
+class CompactReturningProjectionSerializer(CompactSerializer[CompactReturningProjection]):
     def read(self, reader: CompactReader) -> CompactReturningProjection:
         return CompactReturningProjection()
 
@@ -307,9 +299,7 @@ class CompactCompatibilityBase(HazelcastTestCase):
 class AtomicLongCompactCompatibilityTest(CompactCompatibilityBase):
     def setUp(self) -> None:
         super().setUp()
-        self.atomic_long = self.client.cp_subsystem.get_atomic_long(
-            random_string()
-        ).blocking()
+        self.atomic_long = self.client.cp_subsystem.get_atomic_long(random_string()).blocking()
         self.atomic_long.set(41)
 
     def tearDown(self) -> None:
@@ -328,9 +318,7 @@ class AtomicLongCompactCompatibilityTest(CompactCompatibilityBase):
         self.assertEqual(42, self.atomic_long.get())
 
     def test_apply(self):
-        self.assertEqual(
-            OUTER_COMPACT_INSTANCE, self.atomic_long.apply(CompactReturningFunction())
-        )
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.atomic_long.apply(CompactReturningFunction()))
 
 
 class AtomicReferenceCompactCompatibilityTest(CompactCompatibilityBase):
@@ -346,9 +334,7 @@ class AtomicReferenceCompactCompatibilityTest(CompactCompatibilityBase):
         super().tearDown()
 
     def test_compare_and_set(self):
-        self.assertTrue(
-            self.atomic_reference.compare_and_set(None, OUTER_COMPACT_INSTANCE)
-        )
+        self.assertTrue(self.atomic_reference.compare_and_set(None, OUTER_COMPACT_INSTANCE))
         self.assertEqual(OUTER_COMPACT_INSTANCE, self.atomic_reference.get())
 
     def test_set(self):
@@ -356,12 +342,8 @@ class AtomicReferenceCompactCompatibilityTest(CompactCompatibilityBase):
         self.assertEqual(OUTER_COMPACT_INSTANCE, self.atomic_reference.get())
 
     def test_get_and_set(self):
-        self.assertEqual(
-            None, self.atomic_reference.get_and_set(OUTER_COMPACT_INSTANCE)
-        )
-        self.assertEqual(
-            OUTER_COMPACT_INSTANCE, self.atomic_reference.get_and_set(None)
-        )
+        self.assertEqual(None, self.atomic_reference.get_and_set(OUTER_COMPACT_INSTANCE))
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.atomic_reference.get_and_set(None))
 
     def test_contains(self):
         self.assertFalse(self.atomic_reference.contains(OUTER_COMPACT_INSTANCE))
@@ -379,9 +361,7 @@ class AtomicReferenceCompactCompatibilityTest(CompactCompatibilityBase):
         )
 
     def test_get_and_alter(self):
-        self.assertEqual(
-            None, self.atomic_reference.get_and_alter(CompactReturningFunction())
-        )
+        self.assertEqual(None, self.atomic_reference.get_and_alter(CompactReturningFunction()))
         self.assertEqual(
             OUTER_COMPACT_INSTANCE,
             self.atomic_reference.get_and_alter(CompactReturningFunction()),
@@ -410,9 +390,7 @@ class ExecutorCompactCompatibilityTest(CompactCompatibilityBase):
     def test_execute_on_key_owner(self):
         self.assertEqual(
             OUTER_COMPACT_INSTANCE,
-            self.executor.execute_on_key_owner(
-                OUTER_COMPACT_INSTANCE, CompactReturningCallable()
-            ),
+            self.executor.execute_on_key_owner(OUTER_COMPACT_INSTANCE, CompactReturningCallable()),
         )
 
     def test_execute_on_member(self):
@@ -454,16 +432,12 @@ class ListCompactCompatibilityTest(CompactCompatibilityBase):
         self.assertEqual(OUTER_COMPACT_INSTANCE, self.list.get(0))
 
     def test_add_all(self):
-        self.assertTrue(
-            self.list.add_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE])
-        )
+        self.assertTrue(self.list.add_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]))
         self.assertEqual(INNER_COMPACT_INSTANCE, self.list.get(0))
         self.assertEqual(OUTER_COMPACT_INSTANCE, self.list.get(1))
 
     def test_add_all_at(self):
-        self.assertTrue(
-            self.list.add_all_at(0, [INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE])
-        )
+        self.assertTrue(self.list.add_all_at(0, [INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]))
         self.assertEqual(INNER_COMPACT_INSTANCE, self.list.get(0))
         self.assertEqual(OUTER_COMPACT_INSTANCE, self.list.get(1))
 
@@ -533,9 +507,7 @@ class ListCompactCompatibilityTest(CompactCompatibilityBase):
     def test_set_at(self):
         self.list.add(42)
         self.assertEqual(42, self.list.set_at(0, OUTER_COMPACT_INSTANCE))
-        self.assertEqual(
-            OUTER_COMPACT_INSTANCE, self.list.set_at(0, INNER_COMPACT_INSTANCE)
-        )
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.list.set_at(0, INNER_COMPACT_INSTANCE))
 
     def _add_from_another_client(self, value):
         other_client = self.create_client(self.client_config)
@@ -608,9 +580,7 @@ class MapCompatibilityTest(CompactCompatibilityBase):
     def test_aggregate_with_predicate(self):
         self.assertEqual(
             OUTER_COMPACT_INSTANCE,
-            self.map.aggregate(
-                CompactReturningAggregator(), predicate=CompactPredicate()
-            ),
+            self.map.aggregate(CompactReturningAggregator(), predicate=CompactPredicate()),
         )
 
     def test_contains_key(self):
@@ -663,27 +633,21 @@ class MapCompatibilityTest(CompactCompatibilityBase):
         self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
         self.assertEqual(
             [(OUTER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)],
-            self.map.execute_on_entries(
-                CompactReturningEntryProcessor(), CompactPredicate()
-            ),
+            self.map.execute_on_entries(CompactReturningEntryProcessor(), CompactPredicate()),
         )
 
     def test_execute_on_key(self):
         self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
         self.assertEqual(
             OUTER_COMPACT_INSTANCE,
-            self.map.execute_on_key(
-                OUTER_COMPACT_INSTANCE, CompactReturningEntryProcessor()
-            ),
+            self.map.execute_on_key(OUTER_COMPACT_INSTANCE, CompactReturningEntryProcessor()),
         )
 
     def test_execute_on_keys(self):
         self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
         self.assertEqual(
             [(OUTER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)],
-            self.map.execute_on_keys(
-                [OUTER_COMPACT_INSTANCE], CompactReturningEntryProcessor()
-            ),
+            self.map.execute_on_keys([OUTER_COMPACT_INSTANCE], CompactReturningEntryProcessor()),
         )
 
     def test_force_unlock(self):
@@ -778,9 +742,7 @@ class MapCompatibilityTest(CompactCompatibilityBase):
         self.assertEqual(INNER_COMPACT_INSTANCE, self.map.get(OUTER_COMPACT_INSTANCE))
 
     def test_put_if_absent(self):
-        self.assertIsNone(
-            self.map.put_if_absent(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
-        )
+        self.assertIsNone(self.map.put_if_absent(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
         self.assertEqual(
             OUTER_COMPACT_INSTANCE,
             self.map.put_if_absent(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE),
@@ -793,23 +755,15 @@ class MapCompatibilityTest(CompactCompatibilityBase):
     def test_remove(self):
         self.assertIsNone(self.map.remove(OUTER_COMPACT_INSTANCE))
         self._put_from_another_client(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
-        self.assertEqual(
-            INNER_COMPACT_INSTANCE, self.map.remove(OUTER_COMPACT_INSTANCE)
-        )
+        self.assertEqual(INNER_COMPACT_INSTANCE, self.map.remove(OUTER_COMPACT_INSTANCE))
 
     def test_remove_if_same(self):
-        self.assertFalse(
-            self.map.remove_if_same(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
-        )
+        self.assertFalse(self.map.remove_if_same(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
         self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
-        self.assertTrue(
-            self.map.remove_if_same(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
-        )
+        self.assertTrue(self.map.remove_if_same(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
 
     def test_replace(self):
-        self.assertIsNone(
-            self.map.replace(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
-        )
+        self.assertIsNone(self.map.replace(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
         self.map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         self.assertEqual(
             OUTER_COMPACT_INSTANCE,
@@ -841,9 +795,7 @@ class MapCompatibilityTest(CompactCompatibilityBase):
         self.assertTrue(self.map.try_lock(OUTER_COMPACT_INSTANCE))
 
     def test_try_put(self):
-        self.assertTrue(
-            self.map.try_put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
-        )
+        self.assertTrue(self.map.try_put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
 
     def test_try_remove(self):
         self.assertFalse(self.map.try_remove(OUTER_COMPACT_INSTANCE))
@@ -870,9 +822,7 @@ class MapCompatibilityTest(CompactCompatibilityBase):
         # Put an entry from the same client to register these schemas
         # to its local registry, so that the lazy-deserialization works.
         self.map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
-        self.assertEqual(
-            [OUTER_COMPACT_INSTANCE], self.map.values(paging(CompactPredicate(), 1))
-        )
+        self.assertEqual([OUTER_COMPACT_INSTANCE], self.map.values(paging(CompactPredicate(), 1)))
 
     def _put_from_another_client(self, key, value):
         other_client = self.create_client(self.client_config)
@@ -896,9 +846,7 @@ class MapCompatibilityTest(CompactCompatibilityBase):
 class NearCachedMapCompactCompatibilityTest(MapCompatibilityTest):
     def setUp(self) -> None:
         map_name = random_string()
-        self.client_config = copy.deepcopy(
-            NearCachedMapCompactCompatibilityTest.client_config
-        )
+        self.client_config = copy.deepcopy(NearCachedMapCompactCompatibilityTest.client_config)
         self.client_config["near_caches"] = {map_name: {}}
         super().setUp()
         self.map = self.client.get_map(map_name).blocking()
@@ -961,23 +909,17 @@ class MultiMapCompactCompatibilityTest(CompactCompatibilityBase):
 
     def test_contains_entry(self):
         self.assertFalse(
-            self.multi_map.contains_entry(
-                INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE
-            )
+            self.multi_map.contains_entry(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         )
         self.multi_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         self.assertTrue(
-            self.multi_map.contains_entry(
-                INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE
-            )
+            self.multi_map.contains_entry(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         )
 
     def test_get(self):
         self.assertEqual([], self.multi_map.get(OUTER_COMPACT_INSTANCE))
         self.multi_map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
-        self.assertEqual(
-            [INNER_COMPACT_INSTANCE], self.multi_map.get(OUTER_COMPACT_INSTANCE)
-        )
+        self.assertEqual([INNER_COMPACT_INSTANCE], self.multi_map.get(OUTER_COMPACT_INSTANCE))
 
     def test_is_locked(self):
         self.assertFalse(self.multi_map.is_locked(OUTER_COMPACT_INSTANCE))
@@ -995,13 +937,9 @@ class MultiMapCompactCompatibilityTest(CompactCompatibilityBase):
         self.assertTrue(self.multi_map.is_locked(OUTER_COMPACT_INSTANCE))
 
     def test_remove(self):
-        self.assertFalse(
-            self.multi_map.remove(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
-        )
+        self.assertFalse(self.multi_map.remove(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
         self.multi_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
-        self.assertTrue(
-            self.multi_map.remove(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
-        )
+        self.assertTrue(self.multi_map.remove(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
 
     def test_remove_all(self):
         self.assertEqual([], self.multi_map.remove_all(OUTER_COMPACT_INSTANCE))
@@ -1011,12 +949,8 @@ class MultiMapCompactCompatibilityTest(CompactCompatibilityBase):
         )
 
     def test_put(self):
-        self.assertTrue(
-            self.multi_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
-        )
-        self.assertEqual(
-            [OUTER_COMPACT_INSTANCE], self.multi_map.get(INNER_COMPACT_INSTANCE)
-        )
+        self.assertTrue(self.multi_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
+        self.assertEqual([OUTER_COMPACT_INSTANCE], self.multi_map.get(INNER_COMPACT_INSTANCE))
 
     def test_value_count(self):
         self.assertEqual(0, self.multi_map.value_count(OUTER_COMPACT_INSTANCE))
@@ -1051,9 +985,7 @@ class MultiMapCompactCompatibilityTest(CompactCompatibilityBase):
 
     def _put_from_another_client(self, key, value):
         other_client = self.create_client(self.client_config)
-        other_client_multi_map = other_client.get_multi_map(
-            self.multi_map.name
-        ).blocking()
+        other_client_multi_map = other_client.get_multi_map(self.multi_map.name).blocking()
         other_client_multi_map.put(key, value)
 
 
@@ -1070,9 +1002,7 @@ class QueueCompactCompatibilityTest(CompactCompatibilityBase):
         self.assertTrue(self.queue.add(OUTER_COMPACT_INSTANCE))
 
     def test_add_all(self):
-        self.assertTrue(
-            self.queue.add_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE])
-        )
+        self.assertTrue(self.queue.add_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]))
 
     def test_add_listener(self):
         events = []
@@ -1188,9 +1118,7 @@ class ReliableTopicCompactCompatibilityTest(CompactCompatibilityBase):
 
         self.reliable_topic.add_listener(listener)
 
-        self.reliable_topic.publish_all(
-            [INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]
-        )
+        self.reliable_topic.publish_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE])
 
         def assertion():
             self.assertEqual(2, len(messages))
@@ -1261,17 +1189,11 @@ class ReplicatedMapCompactCompatibilityTest(CompactCompatibilityBase):
     def test_get(self):
         self.assertIsNone(self.replicated_map.get(OUTER_COMPACT_INSTANCE))
         self.replicated_map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
-        self.assertEqual(
-            INNER_COMPACT_INSTANCE, self.replicated_map.get(OUTER_COMPACT_INSTANCE)
-        )
+        self.assertEqual(INNER_COMPACT_INSTANCE, self.replicated_map.get(OUTER_COMPACT_INSTANCE))
 
     def test_put(self):
-        self.assertIsNone(
-            self.replicated_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
-        )
-        self.assertEqual(
-            OUTER_COMPACT_INSTANCE, self.replicated_map.get(INNER_COMPACT_INSTANCE)
-        )
+        self.assertIsNone(self.replicated_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.replicated_map.get(INNER_COMPACT_INSTANCE))
         self.assertEqual(
             OUTER_COMPACT_INSTANCE,
             self.replicated_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE),
@@ -1284,19 +1206,13 @@ class ReplicatedMapCompactCompatibilityTest(CompactCompatibilityBase):
                 OUTER_COMPACT_INSTANCE: INNER_COMPACT_INSTANCE,
             }
         )
-        self.assertEqual(
-            OUTER_COMPACT_INSTANCE, self.replicated_map.get(INNER_COMPACT_INSTANCE)
-        )
-        self.assertEqual(
-            INNER_COMPACT_INSTANCE, self.replicated_map.get(OUTER_COMPACT_INSTANCE)
-        )
+        self.assertEqual(OUTER_COMPACT_INSTANCE, self.replicated_map.get(INNER_COMPACT_INSTANCE))
+        self.assertEqual(INNER_COMPACT_INSTANCE, self.replicated_map.get(OUTER_COMPACT_INSTANCE))
 
     def test_remove(self):
         self.assertIsNone(self.replicated_map.remove(OUTER_COMPACT_INSTANCE))
         self.replicated_map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
-        self.assertEqual(
-            INNER_COMPACT_INSTANCE, self.replicated_map.remove(OUTER_COMPACT_INSTANCE)
-        )
+        self.assertEqual(INNER_COMPACT_INSTANCE, self.replicated_map.remove(OUTER_COMPACT_INSTANCE))
 
     def _assert_entry_event(self, events):
         self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
@@ -1354,9 +1270,7 @@ class RingbufferCompactCompatibilityTest(CompactCompatibilityBase):
 
     def _add_from_another_client(self, item):
         other_client = self.create_client(self.client_config)
-        other_client_ringbuffer = other_client.get_ringbuffer(
-            self.ringbuffer.name
-        ).blocking()
+        other_client_ringbuffer = other_client.get_ringbuffer(self.ringbuffer.name).blocking()
         other_client_ringbuffer.add(item)
 
 
@@ -1373,9 +1287,7 @@ class SetCompactCompatibilityTest(CompactCompatibilityBase):
         self.assertTrue(self.set.add(OUTER_COMPACT_INSTANCE))
 
     def test_add_all(self):
-        self.assertTrue(
-            self.set.add_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE])
-        )
+        self.assertTrue(self.set.add_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]))
 
     def test_add_listener(self):
         events = []
@@ -1403,13 +1315,9 @@ class SetCompactCompatibilityTest(CompactCompatibilityBase):
         self.assertTrue(self.set.contains(OUTER_COMPACT_INSTANCE))
 
     def test_contains_all(self):
-        self.assertFalse(
-            self.set.contains_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE])
-        )
+        self.assertFalse(self.set.contains_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]))
         self.set.add_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE])
-        self.assertTrue(
-            self.set.contains_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE])
-        )
+        self.assertTrue(self.set.contains_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]))
 
     def test_remove(self):
         self.assertFalse(self.set.remove(OUTER_COMPACT_INSTANCE))
@@ -1417,13 +1325,9 @@ class SetCompactCompatibilityTest(CompactCompatibilityBase):
         self.assertTrue(self.set.remove(OUTER_COMPACT_INSTANCE))
 
     def test_remove_all(self):
-        self.assertFalse(
-            self.set.remove_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE])
-        )
+        self.assertFalse(self.set.remove_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]))
         self.set.add_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE])
-        self.assertTrue(
-            self.set.remove_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE])
-        )
+        self.assertTrue(self.set.remove_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]))
 
     def test_retain_all(self):
         items = [INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]
@@ -1524,9 +1428,7 @@ class TransactionalMapCompactCompatibilityTest(CompactCompatibilityBase):
         self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         with self.transaction:
             transactional_map = self._get_transactional_map()
-            self.assertEqual(
-                OUTER_COMPACT_INSTANCE, transactional_map.get(INNER_COMPACT_INSTANCE)
-            )
+            self.assertEqual(OUTER_COMPACT_INSTANCE, transactional_map.get(INNER_COMPACT_INSTANCE))
 
     def test_get_for_update(self):
         self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
@@ -1540,9 +1442,7 @@ class TransactionalMapCompactCompatibilityTest(CompactCompatibilityBase):
     def test_put(self):
         with self.transaction:
             transactional_map = self._get_transactional_map()
-            self.assertIsNone(
-                transactional_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
-            )
+            self.assertIsNone(transactional_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
 
         self.assertEqual(OUTER_COMPACT_INSTANCE, self.map.get(INNER_COMPACT_INSTANCE))
 
@@ -1550,9 +1450,7 @@ class TransactionalMapCompactCompatibilityTest(CompactCompatibilityBase):
         with self.transaction:
             transactional_map = self._get_transactional_map()
             self.assertIsNone(
-                transactional_map.put_if_absent(
-                    INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE
-                )
+                transactional_map.put_if_absent(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
             )
 
         self.assertEqual(OUTER_COMPACT_INSTANCE, self.map.get(INNER_COMPACT_INSTANCE))
@@ -1560,9 +1458,7 @@ class TransactionalMapCompactCompatibilityTest(CompactCompatibilityBase):
     def test_set(self):
         with self.transaction:
             transactional_map = self._get_transactional_map()
-            self.assertIsNone(
-                transactional_map.set(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
-            )
+            self.assertIsNone(transactional_map.set(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
 
         self.assertEqual(OUTER_COMPACT_INSTANCE, self.map.get(INNER_COMPACT_INSTANCE))
 
@@ -1572,9 +1468,7 @@ class TransactionalMapCompactCompatibilityTest(CompactCompatibilityBase):
             transactional_map = self._get_transactional_map()
             self.assertEqual(
                 INNER_COMPACT_INSTANCE,
-                transactional_map.replace(
-                    INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE
-                ),
+                transactional_map.replace(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE),
             )
 
         self.assertEqual(OUTER_COMPACT_INSTANCE, self.map.get(INNER_COMPACT_INSTANCE))
@@ -1606,9 +1500,7 @@ class TransactionalMapCompactCompatibilityTest(CompactCompatibilityBase):
         with self.transaction:
             transactional_map = self._get_transactional_map()
             self.assertTrue(
-                transactional_map.remove_if_same(
-                    INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE
-                )
+                transactional_map.remove_if_same(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
             )
 
     def test_delete(self):
@@ -1631,9 +1523,7 @@ class TransactionalMapCompactCompatibilityTest(CompactCompatibilityBase):
         self.map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         with self.transaction:
             transactional_map = self._get_transactional_map()
-            self.assertEqual(
-                [OUTER_COMPACT_INSTANCE], transactional_map.values(CompactPredicate())
-            )
+            self.assertEqual([OUTER_COMPACT_INSTANCE], transactional_map.values(CompactPredicate()))
 
     def _get_transactional_map(self):
         return self.transaction.get_map(self.map_name)
@@ -1659,9 +1549,7 @@ class TransactionalMultiMapCompactCompatibilityTest(CompactCompatibilityBase):
         with self.transaction:
             transactional_multi_map = self._get_transactional_multi_map()
             self.assertTrue(
-                transactional_multi_map.put(
-                    INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE
-                )
+                transactional_multi_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
             )
 
     def test_get(self):
@@ -1680,9 +1568,7 @@ class TransactionalMultiMapCompactCompatibilityTest(CompactCompatibilityBase):
         with self.transaction:
             transactional_multi_map = self._get_transactional_multi_map()
             self.assertTrue(
-                transactional_multi_map.remove(
-                    INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE
-                )
+                transactional_multi_map.remove(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
             )
 
     def test_remove_all(self):
@@ -1698,18 +1584,14 @@ class TransactionalMultiMapCompactCompatibilityTest(CompactCompatibilityBase):
         self._put_from_another_client(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
         with self.transaction:
             transactional_multi_map = self._get_transactional_multi_map()
-            self.assertEqual(
-                1, transactional_multi_map.value_count(OUTER_COMPACT_INSTANCE)
-            )
+            self.assertEqual(1, transactional_multi_map.value_count(OUTER_COMPACT_INSTANCE))
 
     def _get_transactional_multi_map(self):
         return self.transaction.get_multi_map(self.multi_map_name)
 
     def _put_from_another_client(self, key, value):
         other_client = self.create_client(self.client_config)
-        other_client_multi_map = other_client.get_multi_map(
-            self.multi_map_name
-        ).blocking()
+        other_client_multi_map = other_client.get_multi_map(self.multi_map_name).blocking()
         other_client_multi_map.put(key, value)
 
 

--- a/tests/unit/serialization/binary_compatibility/reference_objects.py
+++ b/tests/unit/serialization/binary_compatibility/reference_objects.py
@@ -4,7 +4,7 @@ import decimal
 import re
 import uuid
 
-from hazelcast import predicate, projection
+from hazelcast import predicate, aggregator, projection
 from hazelcast.serialization.api import Portable, IdentifiedDataSerializable
 from hazelcast.serialization.data import Data
 from hazelcast.util import to_signed
@@ -741,74 +741,69 @@ _non_null_list = [
     REFERENCE_OBJECTS["OffsetDateTime"],
 ]
 
-try:
-    from hazelcast import aggregator
-
-    REFERENCE_OBJECTS.update(
-        {
-            "AnInnerPortable": _inner_portable,
-            "CustomStreamSerializable": _custom_serializable,
-            "CustomByteArraySerializable": _custom_byte_array_serializable,
-            "AnIdentifiedDataSerializable": _identified,
-            "APortable": _portable,
-            "ArrayList": [None, _non_null_list],
-            "LinkedList": [None, _non_null_list],
-            "TruePredicate": predicate.true(),
-            "FalsePredicate": predicate.false(),
-            "SqlPredicate": predicate.sql(_sql_string),
-            "EqualPredicate": predicate.equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
-            "NotEqualPredicate": predicate.not_equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
-            "GreaterLessPredicate": predicate.greater(_sql_string, REFERENCE_OBJECTS["Integer"]),
-            "BetweenPredicate": predicate.between(
-                _sql_string, REFERENCE_OBJECTS["Integer"], REFERENCE_OBJECTS["Integer"]
-            ),
-            "LikePredicate": predicate.like(_sql_string, _sql_string),
-            "ILikePredicate": predicate.ilike(_sql_string, _sql_string),
-            "InPredicate": predicate.in_(
-                _sql_string, REFERENCE_OBJECTS["Integer"], REFERENCE_OBJECTS["Integer"]
-            ),
-            "RegexPredicate": predicate.regex(_sql_string, _sql_string),
-            "AndPredicate": predicate.and_(
-                predicate.sql(_sql_string),
-                predicate.equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
-                predicate.not_equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
-                predicate.greater(_sql_string, REFERENCE_OBJECTS["Integer"]),
-                predicate.greater_or_equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
-            ),
-            "OrPredicate": predicate.or_(
-                predicate.sql(_sql_string),
-                predicate.equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
-                predicate.not_equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
-                predicate.greater(_sql_string, REFERENCE_OBJECTS["Integer"]),
-                predicate.greater_or_equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
-            ),
-            "InstanceOfPredicate": predicate.instance_of(
-                "com.hazelcast.nio.serialization.compatibility.CustomStreamSerializable"
-            ),
-            "DistinctValuesAggregator": aggregator.distinct(_sql_string),
-            "MaxAggregator": aggregator.max_(_sql_string),
-            "MaxByAggregator": aggregator.max_by(_sql_string),
-            "MinAggregator": aggregator.min_(_sql_string),
-            "MinByAggregator": aggregator.min_by(_sql_string),
-            "CountAggregator": aggregator.count(_sql_string),
-            "NumberAverageAggregator": aggregator.number_avg(_sql_string),
-            "IntegerAverageAggregator": aggregator.int_avg(_sql_string),
-            "LongAverageAggregator": aggregator.long_avg(_sql_string),
-            "DoubleAverageAggregator": aggregator.double_avg(_sql_string),
-            "IntegerSumAggregator": aggregator.int_sum(_sql_string),
-            "LongSumAggregator": aggregator.long_sum(_sql_string),
-            "DoubleSumAggregator": aggregator.double_sum(_sql_string),
-            "FixedSumAggregator": aggregator.fixed_point_sum(_sql_string),
-            "FloatingPointSumAggregator": aggregator.floating_point_sum(_sql_string),
-            "SingleAttributeProjection": projection.single_attribute(_sql_string),
-            "MultiAttributeProjection": projection.multi_attribute(
-                _sql_string, _sql_string, _sql_string
-            ),
-            "IdentityProjection": projection.identity(),
-        }
-    )
-except ImportError:
-    pass
+REFERENCE_OBJECTS.update(
+    {
+        "AnInnerPortable": _inner_portable,
+        "CustomStreamSerializable": _custom_serializable,
+        "CustomByteArraySerializable": _custom_byte_array_serializable,
+        "AnIdentifiedDataSerializable": _identified,
+        "APortable": _portable,
+        "ArrayList": [None, _non_null_list],
+        "LinkedList": [None, _non_null_list],
+        "TruePredicate": predicate.true(),
+        "FalsePredicate": predicate.false(),
+        "SqlPredicate": predicate.sql(_sql_string),
+        "EqualPredicate": predicate.equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
+        "NotEqualPredicate": predicate.not_equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
+        "GreaterLessPredicate": predicate.greater(_sql_string, REFERENCE_OBJECTS["Integer"]),
+        "BetweenPredicate": predicate.between(
+            _sql_string, REFERENCE_OBJECTS["Integer"], REFERENCE_OBJECTS["Integer"]
+        ),
+        "LikePredicate": predicate.like(_sql_string, _sql_string),
+        "ILikePredicate": predicate.ilike(_sql_string, _sql_string),
+        "InPredicate": predicate.in_(
+            _sql_string, REFERENCE_OBJECTS["Integer"], REFERENCE_OBJECTS["Integer"]
+        ),
+        "RegexPredicate": predicate.regex(_sql_string, _sql_string),
+        "AndPredicate": predicate.and_(
+            predicate.sql(_sql_string),
+            predicate.equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
+            predicate.not_equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
+            predicate.greater(_sql_string, REFERENCE_OBJECTS["Integer"]),
+            predicate.greater_or_equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
+        ),
+        "OrPredicate": predicate.or_(
+            predicate.sql(_sql_string),
+            predicate.equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
+            predicate.not_equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
+            predicate.greater(_sql_string, REFERENCE_OBJECTS["Integer"]),
+            predicate.greater_or_equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
+        ),
+        "InstanceOfPredicate": predicate.instance_of(
+            "com.hazelcast.nio.serialization.compatibility.CustomStreamSerializable"
+        ),
+        "DistinctValuesAggregator": aggregator.distinct(_sql_string),
+        "MaxAggregator": aggregator.max_(_sql_string),
+        "MaxByAggregator": aggregator.max_by(_sql_string),
+        "MinAggregator": aggregator.min_(_sql_string),
+        "MinByAggregator": aggregator.min_by(_sql_string),
+        "CountAggregator": aggregator.count(_sql_string),
+        "NumberAverageAggregator": aggregator.number_avg(_sql_string),
+        "IntegerAverageAggregator": aggregator.int_avg(_sql_string),
+        "LongAverageAggregator": aggregator.long_avg(_sql_string),
+        "DoubleAverageAggregator": aggregator.double_avg(_sql_string),
+        "IntegerSumAggregator": aggregator.int_sum(_sql_string),
+        "LongSumAggregator": aggregator.long_sum(_sql_string),
+        "DoubleSumAggregator": aggregator.double_sum(_sql_string),
+        "FixedSumAggregator": aggregator.fixed_point_sum(_sql_string),
+        "FloatingPointSumAggregator": aggregator.floating_point_sum(_sql_string),
+        "SingleAttributeProjection": projection.single_attribute(_sql_string),
+        "MultiAttributeProjection": projection.multi_attribute(
+            _sql_string, _sql_string, _sql_string
+        ),
+        "IdentityProjection": projection.identity(),
+    }
+)
 
 _SKIP_ON_SERIALIZE = {
     "Character",

--- a/tests/unit/serialization/binary_compatibility/reference_objects.py
+++ b/tests/unit/serialization/binary_compatibility/reference_objects.py
@@ -4,7 +4,7 @@ import decimal
 import re
 import uuid
 
-from hazelcast import predicate, aggregator, projection
+from hazelcast import predicate, projection
 from hazelcast.serialization.api import Portable, IdentifiedDataSerializable
 from hazelcast.serialization.data import Data
 from hazelcast.util import to_signed
@@ -741,69 +741,74 @@ _non_null_list = [
     REFERENCE_OBJECTS["OffsetDateTime"],
 ]
 
-REFERENCE_OBJECTS.update(
-    {
-        "AnInnerPortable": _inner_portable,
-        "CustomStreamSerializable": _custom_serializable,
-        "CustomByteArraySerializable": _custom_byte_array_serializable,
-        "AnIdentifiedDataSerializable": _identified,
-        "APortable": _portable,
-        "ArrayList": [None, _non_null_list],
-        "LinkedList": [None, _non_null_list],
-        "TruePredicate": predicate.true(),
-        "FalsePredicate": predicate.false(),
-        "SqlPredicate": predicate.sql(_sql_string),
-        "EqualPredicate": predicate.equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
-        "NotEqualPredicate": predicate.not_equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
-        "GreaterLessPredicate": predicate.greater(_sql_string, REFERENCE_OBJECTS["Integer"]),
-        "BetweenPredicate": predicate.between(
-            _sql_string, REFERENCE_OBJECTS["Integer"], REFERENCE_OBJECTS["Integer"]
-        ),
-        "LikePredicate": predicate.like(_sql_string, _sql_string),
-        "ILikePredicate": predicate.ilike(_sql_string, _sql_string),
-        "InPredicate": predicate.in_(
-            _sql_string, REFERENCE_OBJECTS["Integer"], REFERENCE_OBJECTS["Integer"]
-        ),
-        "RegexPredicate": predicate.regex(_sql_string, _sql_string),
-        "AndPredicate": predicate.and_(
-            predicate.sql(_sql_string),
-            predicate.equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
-            predicate.not_equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
-            predicate.greater(_sql_string, REFERENCE_OBJECTS["Integer"]),
-            predicate.greater_or_equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
-        ),
-        "OrPredicate": predicate.or_(
-            predicate.sql(_sql_string),
-            predicate.equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
-            predicate.not_equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
-            predicate.greater(_sql_string, REFERENCE_OBJECTS["Integer"]),
-            predicate.greater_or_equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
-        ),
-        "InstanceOfPredicate": predicate.instance_of(
-            "com.hazelcast.nio.serialization.compatibility.CustomStreamSerializable"
-        ),
-        "DistinctValuesAggregator": aggregator.distinct(_sql_string),
-        "MaxAggregator": aggregator.max_(_sql_string),
-        "MaxByAggregator": aggregator.max_by(_sql_string),
-        "MinAggregator": aggregator.min_(_sql_string),
-        "MinByAggregator": aggregator.min_by(_sql_string),
-        "CountAggregator": aggregator.count(_sql_string),
-        "NumberAverageAggregator": aggregator.number_avg(_sql_string),
-        "IntegerAverageAggregator": aggregator.int_avg(_sql_string),
-        "LongAverageAggregator": aggregator.long_avg(_sql_string),
-        "DoubleAverageAggregator": aggregator.double_avg(_sql_string),
-        "IntegerSumAggregator": aggregator.int_sum(_sql_string),
-        "LongSumAggregator": aggregator.long_sum(_sql_string),
-        "DoubleSumAggregator": aggregator.double_sum(_sql_string),
-        "FixedSumAggregator": aggregator.fixed_point_sum(_sql_string),
-        "FloatingPointSumAggregator": aggregator.floating_point_sum(_sql_string),
-        "SingleAttributeProjection": projection.single_attribute(_sql_string),
-        "MultiAttributeProjection": projection.multi_attribute(
-            _sql_string, _sql_string, _sql_string
-        ),
-        "IdentityProjection": projection.identity(),
-    }
-)
+try:
+    from hazelcast import aggregator
+
+    REFERENCE_OBJECTS.update(
+        {
+            "AnInnerPortable": _inner_portable,
+            "CustomStreamSerializable": _custom_serializable,
+            "CustomByteArraySerializable": _custom_byte_array_serializable,
+            "AnIdentifiedDataSerializable": _identified,
+            "APortable": _portable,
+            "ArrayList": [None, _non_null_list],
+            "LinkedList": [None, _non_null_list],
+            "TruePredicate": predicate.true(),
+            "FalsePredicate": predicate.false(),
+            "SqlPredicate": predicate.sql(_sql_string),
+            "EqualPredicate": predicate.equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
+            "NotEqualPredicate": predicate.not_equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
+            "GreaterLessPredicate": predicate.greater(_sql_string, REFERENCE_OBJECTS["Integer"]),
+            "BetweenPredicate": predicate.between(
+                _sql_string, REFERENCE_OBJECTS["Integer"], REFERENCE_OBJECTS["Integer"]
+            ),
+            "LikePredicate": predicate.like(_sql_string, _sql_string),
+            "ILikePredicate": predicate.ilike(_sql_string, _sql_string),
+            "InPredicate": predicate.in_(
+                _sql_string, REFERENCE_OBJECTS["Integer"], REFERENCE_OBJECTS["Integer"]
+            ),
+            "RegexPredicate": predicate.regex(_sql_string, _sql_string),
+            "AndPredicate": predicate.and_(
+                predicate.sql(_sql_string),
+                predicate.equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
+                predicate.not_equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
+                predicate.greater(_sql_string, REFERENCE_OBJECTS["Integer"]),
+                predicate.greater_or_equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
+            ),
+            "OrPredicate": predicate.or_(
+                predicate.sql(_sql_string),
+                predicate.equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
+                predicate.not_equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
+                predicate.greater(_sql_string, REFERENCE_OBJECTS["Integer"]),
+                predicate.greater_or_equal(_sql_string, REFERENCE_OBJECTS["Integer"]),
+            ),
+            "InstanceOfPredicate": predicate.instance_of(
+                "com.hazelcast.nio.serialization.compatibility.CustomStreamSerializable"
+            ),
+            "DistinctValuesAggregator": aggregator.distinct(_sql_string),
+            "MaxAggregator": aggregator.max_(_sql_string),
+            "MaxByAggregator": aggregator.max_by(_sql_string),
+            "MinAggregator": aggregator.min_(_sql_string),
+            "MinByAggregator": aggregator.min_by(_sql_string),
+            "CountAggregator": aggregator.count(_sql_string),
+            "NumberAverageAggregator": aggregator.number_avg(_sql_string),
+            "IntegerAverageAggregator": aggregator.int_avg(_sql_string),
+            "LongAverageAggregator": aggregator.long_avg(_sql_string),
+            "DoubleAverageAggregator": aggregator.double_avg(_sql_string),
+            "IntegerSumAggregator": aggregator.int_sum(_sql_string),
+            "LongSumAggregator": aggregator.long_sum(_sql_string),
+            "DoubleSumAggregator": aggregator.double_sum(_sql_string),
+            "FixedSumAggregator": aggregator.fixed_point_sum(_sql_string),
+            "FloatingPointSumAggregator": aggregator.floating_point_sum(_sql_string),
+            "SingleAttributeProjection": projection.single_attribute(_sql_string),
+            "MultiAttributeProjection": projection.multi_attribute(
+                _sql_string, _sql_string, _sql_string
+            ),
+            "IdentityProjection": projection.identity(),
+        }
+    )
+except ImportError:
+    pass
 
 _SKIP_ON_SERIALIZE = {
     "Character",


### PR DESCRIPTION
Some test imports causes a problem running the backward compatibility tests on master with older Python client releases. Converted those imports to no-ops.