### PR TITLE
Updated Compact Configuration

### DIFF
--- a/.github/workflows/coverage_runner.yml
+++ b/.github/workflows/coverage_runner.yml
@@ -14,9 +14,6 @@ on:
     branches:
       - master
       - '[45].*.z'
-    types:
-      [opened]
-      
 jobs:
   check_for_membership:
     runs-on: ubuntu-latest

--- a/black.toml
+++ b/black.toml
@@ -8,6 +8,7 @@ exclude = '''
   | \.mypy_cache
   | \.tox
   | \.venv
+  | venv
   | _build
   | buck-out
   | build

--- a/docs/serialization.rst
+++ b/docs/serialization.rst
@@ -146,7 +146,7 @@ Then, a serializer for it can be implemented as below:
 
 .. code:: python
 
-    from hazelcast.serialization.api import CompactSerializer, CompactWriter, CompactReader
+    from hazelcast.serialization.api import CompactSerializer, CompactWriter, CompactReader, CompactSerializableClass
 
     class EmployeeSerializer(CompactSerializer[Employee]):
         def read(self, reader: CompactReader) -> Employee:
@@ -161,14 +161,17 @@ Then, a serializer for it can be implemented as below:
         def get_type_name(self) -> str:
             return "employee"
 
+        def get_class(self) -> CompactSerializableClass:
+            return Employee
+
 The last step is to register the serializer in the client configuration.
 
 .. code:: python
 
     client = HazelcastClient(
-        compact_serializers={
-            Employee: EmployeeSerializer(),
-        }
+        compact_serializers=[
+            EmployeeSerializer(),
+        ]
     )
 
 A schema will be created from the serializer, and a unique schema identifier

--- a/docs/serialization.rst
+++ b/docs/serialization.rst
@@ -1,3 +1,4 @@
+
 Serialization
 =============
 
@@ -149,19 +150,19 @@ Then, a serializer for it can be implemented as below:
     from hazelcast.serialization.api import CompactSerializer, CompactWriter, CompactReader, CompactSerializableClass
 
     class EmployeeSerializer(CompactSerializer[Employee]):
-        def read(self, reader: CompactReader) -> Employee:
+        def read(self, reader: CompactReader):
             name = reader.read_string("name")
             age = reader.read_int32("age")
             return Employee(name, age)
 
-        def write(self, writer: CompactWriter, obj: Employee) -> None:
+        def write(self, writer: CompactWriter, obj: Employee):
             writer.write_string("name", obj.name)
             writer.write_int32("age", obj.age)
 
-        def get_type_name(self) -> str:
+        def get_type_name(self):
             return "employee"
 
-        def get_class(self) -> CompactSerializableClass:
+        def get_class(self):
             return Employee
 
 The last step is to register the serializer in the client configuration.

--- a/docs/serialization.rst
+++ b/docs/serialization.rst
@@ -146,7 +146,7 @@ Then, a serializer for it can be implemented as below:
 
 .. code:: python
 
-    from hazelcast.serialization.api import CompactSerializer, CompactWriter, CompactReader, CompactSerializableClass
+    from hazelcast.serialization.api import CompactSerializer, CompactWriter, CompactReader
 
     class EmployeeSerializer(CompactSerializer[Employee]):
         def read(self, reader: CompactReader):

--- a/docs/serialization.rst
+++ b/docs/serialization.rst
@@ -1,4 +1,3 @@
-
 Serialization
 =============
 

--- a/examples/serialization/compact_serialization_example.py
+++ b/examples/serialization/compact_serialization_example.py
@@ -1,5 +1,10 @@
 from hazelcast import HazelcastClient
-from hazelcast.serialization.api import CompactSerializer, CompactWriter, CompactReader, CompactSerializableClass
+from hazelcast.serialization.api import (
+    CompactSerializer,
+    CompactWriter,
+    CompactReader,
+    CompactSerializableClass,
+)
 
 
 class Address:
@@ -57,9 +62,7 @@ class EmployeeSerializer(CompactSerializer[Employee]):
         return Employee
 
 
-client = HazelcastClient(
-    compact_serializers=[AddressSerializer(), EmployeeSerializer()]
-)
+client = HazelcastClient(compact_serializers=[AddressSerializer(), EmployeeSerializer()])
 
 employees = client.get_map("employees").blocking()
 

--- a/examples/serialization/compact_serialization_example.py
+++ b/examples/serialization/compact_serialization_example.py
@@ -3,7 +3,6 @@ from hazelcast.serialization.api import (
     CompactSerializer,
     CompactWriter,
     CompactReader,
-    CompactSerializableClass,
 )
 
 
@@ -27,38 +26,38 @@ class Employee:
 
 
 class AddressSerializer(CompactSerializer[Address]):
-    def read(self, reader: CompactReader) -> Address:
+    def read(self, reader: CompactReader):
         city = reader.read_string("city")
         street = reader.read_string("street")
         return Address(city, street)
 
-    def write(self, writer: CompactWriter, obj: Address) -> None:
+    def write(self, writer: CompactWriter, obj: Address):
         writer.write_string("city", obj.city)
         writer.write_string("street", obj.street)
 
-    def get_type_name(self) -> str:
+    def get_type_name(self):
         return "Address"
 
-    def get_class(self) -> CompactSerializableClass:
+    def get_class(self):
         return Address
 
 
 class EmployeeSerializer(CompactSerializer[Employee]):
-    def read(self, reader: CompactReader) -> Employee:
+    def read(self, reader: CompactReader):
         name = reader.read_string("name")
         age = reader.read_int32("age")
         address = reader.read_compact("address")
         return Employee(name, age, address)
 
-    def write(self, writer: CompactWriter, obj: Employee) -> None:
+    def write(self, writer: CompactWriter, obj: Employee):
         writer.write_string("name", obj.name)
         writer.write_int32("age", obj.age)
         writer.write_compact("address", obj.address)
 
-    def get_type_name(self) -> str:
+    def get_type_name(self):
         return "Employee"
 
-    def get_class(self) -> CompactSerializableClass:
+    def get_class(self):
         return Employee
 
 

--- a/examples/serialization/compact_serialization_example.py
+++ b/examples/serialization/compact_serialization_example.py
@@ -1,5 +1,5 @@
 from hazelcast import HazelcastClient
-from hazelcast.serialization.api import CompactSerializer, CompactWriter, CompactReader
+from hazelcast.serialization.api import CompactSerializer, CompactWriter, CompactReader, CompactSerializableClass
 
 
 class Address:
@@ -8,7 +8,7 @@ class Address:
         self.street = street
 
     def __repr__(self):
-        return f"Address(city='{self.city}', street='{self.street}'"
+        return f"Address(city='{self.city}', street='{self.street}')"
 
 
 class Employee:
@@ -18,7 +18,7 @@ class Employee:
         self.address = address
 
     def __repr__(self):
-        return f"Employee(name='{self.name}', age={self.age}, address={self.address}"
+        return f"Employee(name='{self.name}', age={self.age}, address={self.address})"
 
 
 class AddressSerializer(CompactSerializer[Address]):
@@ -33,6 +33,9 @@ class AddressSerializer(CompactSerializer[Address]):
 
     def get_type_name(self) -> str:
         return "Address"
+
+    def get_class(self) -> CompactSerializableClass:
+        return Address
 
 
 class EmployeeSerializer(CompactSerializer[Employee]):
@@ -50,12 +53,12 @@ class EmployeeSerializer(CompactSerializer[Employee]):
     def get_type_name(self) -> str:
         return "Employee"
 
+    def get_class(self) -> CompactSerializableClass:
+        return Employee
+
 
 client = HazelcastClient(
-    compact_serializers={
-        Address: AddressSerializer(),
-        Employee: EmployeeSerializer(),
-    }
+    compact_serializers=[AddressSerializer(), EmployeeSerializer()]
 )
 
 employees = client.get_map("employees").blocking()

--- a/examples/sql/sql_compact_example.py
+++ b/examples/sql/sql_compact_example.py
@@ -1,7 +1,7 @@
 import dataclasses
 
 from hazelcast import HazelcastClient
-from hazelcast.serialization.api import CompactSerializer, CompactWriter, CompactReader
+from hazelcast.serialization.api import CompactSerializer, CompactWriter, CompactReader, CompactSerializableClass
 
 
 @dataclasses.dataclass
@@ -23,11 +23,12 @@ class PersonSerializer(CompactSerializer[Person]):
     def get_type_name(self) -> str:
         return "Person"
 
+    def get_class(self) -> CompactSerializableClass:
+        return Person
+
 
 client = HazelcastClient(
-    compact_serializers={
-        Person: PersonSerializer(),
-    }
+    compact_serializers=[PersonSerializer()]
 )
 
 client.sql.execute(

--- a/examples/sql/sql_compact_example.py
+++ b/examples/sql/sql_compact_example.py
@@ -5,7 +5,6 @@ from hazelcast.serialization.api import (
     CompactSerializer,
     CompactWriter,
     CompactReader,
-    CompactSerializableClass,
 )
 
 
@@ -16,19 +15,19 @@ class Person:
 
 
 class PersonSerializer(CompactSerializer[Person]):
-    def read(self, reader: CompactReader) -> Person:
+    def read(self, reader: CompactReader):
         name = reader.read_string("name")
         age = reader.read_int32("age")
         return Person(name, age)
 
-    def write(self, writer: CompactWriter, obj: Person) -> None:
+    def write(self, writer: CompactWriter, obj: Person):
         writer.write_string("name", obj.name)
         writer.write_int32("age", obj.age)
 
-    def get_type_name(self) -> str:
+    def get_type_name(self):
         return "Person"
 
-    def get_class(self) -> CompactSerializableClass:
+    def get_class(self):
         return Person
 
 

--- a/examples/sql/sql_compact_example.py
+++ b/examples/sql/sql_compact_example.py
@@ -1,7 +1,12 @@
 import dataclasses
 
 from hazelcast import HazelcastClient
-from hazelcast.serialization.api import CompactSerializer, CompactWriter, CompactReader, CompactSerializableClass
+from hazelcast.serialization.api import (
+    CompactSerializer,
+    CompactWriter,
+    CompactReader,
+    CompactSerializableClass,
+)
 
 
 @dataclasses.dataclass
@@ -27,9 +32,7 @@ class PersonSerializer(CompactSerializer[Person]):
         return Person
 
 
-client = HazelcastClient(
-    compact_serializers=[PersonSerializer()]
-)
+client = HazelcastClient(compact_serializers=[PersonSerializer()])
 
 client.sql.execute(
     """

--- a/hazelcast/client.py
+++ b/hazelcast/client.py
@@ -196,7 +196,7 @@ class HazelcastClient:
                     }
                 })
 
-        compact_serializers (dict[typing.Type, hazelcast.serialization.api.CompactSerializer]):
+        compact_serializers (list[hazelcast.serialization.api.CompactSerializer]):
             Dictionary of classes to be serialized with Compact serialization
             to Compact serializers.
 
@@ -209,9 +209,9 @@ class HazelcastClient:
                     pass
 
                 client = HazelcastClient(
-                    compact_serializers={
-                        Foo: FooSerializer(),
-                    },
+                    compact_serializers=[
+                        FooSerializer(),
+                    ],
                 )
 
         class_definitions (`list[hazelcast.serialization.portable.classdef.ClassDefinition]`):

--- a/hazelcast/client.py
+++ b/hazelcast/client.py
@@ -197,8 +197,7 @@ class HazelcastClient:
                 })
 
         compact_serializers (list[hazelcast.serialization.api.CompactSerializer]):
-            Dictionary of classes to be serialized with Compact serialization
-            to Compact serializers.
+            List of Compact serializers.
 
             .. code-block:: python
 

--- a/hazelcast/config.py
+++ b/hazelcast/config.py
@@ -638,7 +638,7 @@ class _Config:
         self._creds_password = None
         self._token_provider = None
         self._use_public_ip = False
-        self._compact_serializers: typing.Dict[typing.Type, CompactSerializer] = {}
+        self._compact_serializers: typing.List[CompactSerializer] = []
 
     @property
     def cluster_members(self):
@@ -1369,19 +1369,15 @@ class _Config:
             raise TypeError("use_public_ip must be a boolean")
 
     @property
-    def compact_serializers(self) -> typing.Dict[typing.Type, CompactSerializer]:
+    def compact_serializers(self) -> typing.List[CompactSerializer]:
         return self._compact_serializers
 
     @compact_serializers.setter
-    def compact_serializers(self, value: typing.Dict[typing.Type, CompactSerializer]) -> None:
-        if isinstance(value, dict):
-            for clazz, serializer in value.items():
-                if not isinstance(clazz, type):
-                    raise TypeError("Keys of compact_serializers must be classes")
-
+    def compact_serializers(self, value: typing.List[CompactSerializer]) -> None:
+        if isinstance(value, list):
+            for serializer in value:
                 if not isinstance(serializer, CompactSerializer):
                     raise TypeError("Values of compact_serializers must be CompactSerializer")
-
             self._compact_serializers = value
         else:
             raise TypeError("compact_serializers must be a dict")

--- a/hazelcast/serialization/api.py
+++ b/hazelcast/serialization/api.py
@@ -3060,6 +3060,14 @@ class CompactSerializer(typing.Generic[CompactSerializableClass], abc.ABC):
         """
 
     @abc.abstractmethod
+    def get_class(self) -> CompactSerializableClass:
+        """Returns the class for this serializer.
+
+        Returns:
+            The class for this serializer.
+        """
+
+    @abc.abstractmethod
     def get_type_name(self) -> str:
         """Returns the unique type name associated with
         :const`CompactSerializableClass`.

--- a/hazelcast/serialization/api.py
+++ b/hazelcast/serialization/api.py
@@ -3060,11 +3060,11 @@ class CompactSerializer(typing.Generic[CompactSerializableClass], abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_class(self) -> CompactSerializableClass:
-        """Returns the class for this serializer.
+    def get_class(self) -> typing.Type[CompactSerializableClass]:
+        """Returns the class that this serializer reads or writes.
 
         Returns:
-            The class for this serializer.
+            The class that this serializer reads or writes.
         """
 
     @abc.abstractmethod

--- a/hazelcast/serialization/compact.py
+++ b/hazelcast/serialization/compact.py
@@ -35,11 +35,9 @@ _BOOLEANS_PER_BYTE = 8
 
 
 class CompactStreamSerializer(BaseSerializer):
-    def __init__(self, compact_serializers: typing.Dict[typing.Type, CompactSerializer]):
-        self._type_to_serializer = compact_serializers
-        self._type_name_to_serializer: typing.Dict[str, CompactSerializer] = {
-            serializer.get_type_name(): serializer for serializer in compact_serializers.values()
-        }
+    def __init__(self, compact_serializers: typing.List[CompactSerializer]):
+        self._type_to_serializer = {s.get_class(): s for s in compact_serializers}
+        self._type_name_to_serializer = {s.get_type_name(): s for s in compact_serializers}
         self._type_to_schema: typing.Dict[typing.Type, Schema] = {}
         self._id_to_schema: typing.Dict[int, Schema] = {}
 

--- a/hazelcast/serialization/service.py
+++ b/hazelcast/serialization/service.py
@@ -344,7 +344,7 @@ class SerializerRegistry:
         self._registration_lock = threading.RLock()
         self._int_type_id = _int_type_to_type_id.get(config.default_int_type, None)
 
-        self._compact_types = set(config.compact_serializers.keys())
+        self._compact_types = [c.get_class() for c in config.compact_serializers]
 
     def serializer_by_type_id(self, type_id):
         """Find and return the serializer for the type-id

--- a/hazelcast/serialization/service.py
+++ b/hazelcast/serialization/service.py
@@ -344,7 +344,7 @@ class SerializerRegistry:
         self._registration_lock = threading.RLock()
         self._int_type_id = _int_type_to_type_id.get(config.default_int_type, None)
 
-        self._compact_types = [c.get_class() for c in config.compact_serializers]
+        self._compact_types = {c.get_class() for c in config.compact_serializers}
 
     def serializer_by_type_id(self, type_id):
         """Find and return the serializer for the type-id

--- a/run_tests.py
+++ b/run_tests.py
@@ -21,29 +21,31 @@ def wait_until_rc_is_ready():
     raise Exception("Remote controller failed to start.")
 
 
-if __name__ == "__main__":
-    with open("rc_stdout.log", "w") as rc_stdout:
-        with open("rc_stderr.log", "w") as rc_stderr:
-            rc_process = start_rc(rc_stdout, rc_stderr)
-            try:
-                wait_until_rc_is_ready()
-                sys.stdout.flush()
+with open("rc_stdout.log", "w") as rc_stdout:
+    with open("rc_stderr.log", "w") as rc_stderr:
+        rc_process = start_rc(rc_stdout, rc_stderr)
+        try:
+            wait_until_rc_is_ready()
+            sys.stdout.flush()
 
-                args = [
-                    "pytest",
-                    "--cov=hazelcast",
-                    "--cov-report=xml",
-                ]
+            args = [
+                "pytest",
+                "--cov=hazelcast",
+                "--cov-report=xml",
+            ]
+            args.extend(sys.argv[1:])
 
-                enterprise_key = os.environ.get("HAZELCAST_ENTERPRISE_KEY", None)
-                if not enterprise_key:
-                    args.extend(["-m", "not enterprise"])
+            enterprise_key = os.environ.get("HAZELCAST_ENTERPRISE_KEY", None)
+            if not enterprise_key:
+                args.extend(["-m", "not enterprise"])
 
-                process = subprocess.run(args)
-                rc_process.kill()
-                rc_process.wait()
-                sys.exit(process.returncode)
-            except:
-                rc_process.kill()
-                rc_process.wait()
-                raise
+            print(f"Args: {' '.join(args)}")
+
+            process = subprocess.run(args)
+            rc_process.kill()
+            rc_process.wait()
+            sys.exit(process.returncode)
+        except:
+            rc_process.kill()
+            rc_process.wait()
+            raise

--- a/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
+++ b/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
@@ -69,6 +69,9 @@ class InnerSerializer(CompactSerializer[InnerCompact]):
     def get_type_name(self) -> str:
         return "com.hazelcast.serialization.compact.InnerCompact"
 
+    def get_class(self):
+        return InnerCompact
+
 
 class OuterSerializer(CompactSerializer[OuterCompact]):
     def read(self, reader: CompactReader) -> OuterCompact:
@@ -83,6 +86,9 @@ class OuterSerializer(CompactSerializer[OuterCompact]):
 
     def get_type_name(self) -> str:
         return "com.hazelcast.serialization.compact.OuterCompact"
+
+    def get_class(self):
+        return OuterCompact
 
 
 class CompactIncrementFunction:
@@ -99,6 +105,9 @@ class CompactIncrementFunctionSerializer(CompactSerializer[CompactIncrementFunct
     def get_type_name(self) -> str:
         return "com.hazelcast.serialization.compact.CompactIncrementFunction"
 
+    def get_class(self):
+        return CompactIncrementFunction
+
 
 class CompactReturningFunction:
     pass
@@ -113,6 +122,9 @@ class CompactReturningFunctionSerializer(CompactSerializer[CompactReturningFunct
 
     def get_type_name(self) -> str:
         return "com.hazelcast.serialization.compact.CompactReturningFunction"
+
+    def get_class(self):
+        return CompactReturningFunction
 
 
 class CompactReturningCallable:
@@ -129,6 +141,9 @@ class CompactReturningCallableSerializer(CompactSerializer[CompactReturningCalla
     def get_type_name(self) -> str:
         return "com.hazelcast.serialization.compact.CompactReturningCallable"
 
+    def get_class(self):
+        return CompactReturningCallable
+
 
 class CompactPredicate(Predicate):
     pass
@@ -144,6 +159,9 @@ class CompactPredicateSerializer(CompactSerializer[CompactPredicate]):
     def get_type_name(self) -> str:
         return "com.hazelcast.serialization.compact.CompactPredicate"
 
+    def get_class(self):
+        return CompactPredicate
+
 
 class CompactReturningMapInterceptor:
     pass
@@ -158,6 +176,9 @@ class CompactReturningMapInterceptorSerializer(CompactSerializer[CompactReturnin
 
     def get_type_name(self) -> str:
         return "com.hazelcast.serialization.compact.CompactReturningMapInterceptor"
+
+    def get_class(self):
+        return CompactReturningMapInterceptor
 
 
 try:
@@ -182,6 +203,9 @@ class CompactReturningAggregatorSerializer(CompactSerializer[CompactReturningAgg
     def get_type_name(self) -> str:
         return "com.hazelcast.serialization.compact.CompactReturningAggregator"
 
+    def get_class(self):
+        return CompactReturningAggregator
+
 
 class CompactReturningEntryProcessor:
     pass
@@ -196,6 +220,9 @@ class CompactReturningEntryProcessorSerializer(CompactSerializer[CompactReturnin
 
     def get_type_name(self) -> str:
         return "com.hazelcast.serialization.compact.CompactReturningEntryProcessor"
+
+    def get_class(self):
+        return CompactReturningEntryProcessor
 
 
 class CompactReturningProjection:
@@ -212,6 +239,9 @@ class CompactReturningProjectionSerializer(CompactSerializer[CompactReturningPro
     def get_type_name(self) -> str:
         return "com.hazelcast.serialization.compact.CompactReturningProjection"
 
+    def get_class(self):
+        return CompactReturningProjection
+
 
 class CompactFilter:
     pass
@@ -226,6 +256,9 @@ class CompactFilterSerializer(CompactSerializer[CompactFilter]):
 
     def get_type_name(self) -> str:
         return "com.hazelcast.serialization.compact.CompactFilter"
+
+    def get_class(self):
+        return CompactFilter
 
 
 INNER_COMPACT_INSTANCE = InnerCompact("42")
@@ -263,19 +296,19 @@ class CompactCompatibilityBase(HazelcastTestCase):
         cls.cluster.start_member()
         cls.client_config = {
             "cluster_name": cls.cluster.id,
-            "compact_serializers": {
-                InnerCompact: InnerSerializer(),
-                OuterCompact: OuterSerializer(),
-                CompactIncrementFunction: CompactIncrementFunctionSerializer(),
-                CompactReturningFunction: CompactReturningFunctionSerializer(),
-                CompactReturningCallable: CompactReturningCallableSerializer(),
-                CompactPredicate: CompactPredicateSerializer(),
-                CompactReturningMapInterceptor: CompactReturningMapInterceptorSerializer(),
-                CompactReturningAggregator: CompactReturningAggregatorSerializer(),
-                CompactReturningEntryProcessor: CompactReturningEntryProcessorSerializer(),
-                CompactReturningProjection: CompactReturningProjectionSerializer(),
-                CompactFilter: CompactFilterSerializer(),
-            },
+            "compact_serializers": [
+                InnerSerializer(),
+                OuterSerializer(),
+                CompactIncrementFunctionSerializer(),
+                CompactReturningFunctionSerializer(),
+                CompactReturningCallableSerializer(),
+                CompactPredicateSerializer(),
+                CompactReturningMapInterceptorSerializer(),
+                CompactReturningAggregatorSerializer(),
+                CompactReturningEntryProcessorSerializer(),
+                CompactReturningProjectionSerializer(),
+                CompactFilterSerializer(),
+            ],
         }
 
     @classmethod

--- a/tests/integration/backward_compatible/serialization/compact_test.py
+++ b/tests/integration/backward_compatible/serialization/compact_test.py
@@ -212,6 +212,9 @@ class CompactTest(CompactTestBase):
             def get_type_name(self) -> str:
                 return SomeFields.__name__
 
+            def get_class(self):
+                return SomeFields
+
         self._write_then_read0(all_fields, Serializer(list(all_fields.keys())))
 
     @parameterized.expand(
@@ -273,8 +276,8 @@ class CompactTest(CompactTestBase):
         client = self.create_client(
             {
                 "cluster_name": self.cluster.id,
-                "compact_serializers": {
-                    SomeFieldsSerializer: SomeFieldsSerializer(
+                "compact_serializers": [
+                    SomeFieldsSerializer(
                         [
                             FieldDefinition(
                                 name=field_name,
@@ -283,8 +286,8 @@ class CompactTest(CompactTestBase):
                             )
                         ]
                     ),
-                    Nested: NestedSerializer(),
-                },
+                    NestedSerializer(),
+                ],
             }
         )
 
@@ -310,10 +313,10 @@ class CompactTest(CompactTestBase):
         client = self.create_client(
             {
                 "cluster_name": self.cluster.id,
-                "compact_serializers": {
-                    SomeFieldsSerializer: SomeFieldsSerializer([FieldDefinition(name=field_name)]),
-                    Nested: NestedSerializer(),
-                },
+                "compact_serializers": [
+                    SomeFieldsSerializer([FieldDefinition(name=field_name)]),
+                    NestedSerializer(),
+                ],
             }
         )
 
@@ -343,8 +346,8 @@ class CompactTest(CompactTestBase):
         client = self.create_client(
             {
                 "cluster_name": self.cluster.id,
-                "compact_serializers": {
-                    SomeFieldsSerializer: SomeFieldsSerializer(
+                "compact_serializers": [
+                    SomeFieldsSerializer(
                         [
                             FieldDefinition(
                                 name=field_name,
@@ -352,7 +355,7 @@ class CompactTest(CompactTestBase):
                             )
                         ]
                     ),
-                },
+                ],
             }
         )
 
@@ -383,9 +386,9 @@ class CompactTest(CompactTestBase):
         client = self.create_client(
             {
                 "cluster_name": self.cluster.id,
-                "compact_serializers": {
-                    SomeFields: SomeFieldsSerializer([FieldDefinition(name=field_name)]),
-                },
+                "compact_serializers": [
+                    SomeFieldsSerializer([FieldDefinition(name=field_name)]),
+                ],
             }
         )
 
@@ -415,9 +418,9 @@ class CompactTest(CompactTestBase):
         client = self.create_client(
             {
                 "cluster_name": self.cluster.id,
-                "compact_serializers": {
-                    SomeFields: SomeFieldsSerializer([FieldDefinition(name=field_name)]),
-                },
+                "compact_serializers": [
+                    SomeFieldsSerializer([FieldDefinition(name=field_name)]),
+                ],
             }
         )
 
@@ -447,9 +450,9 @@ class CompactTest(CompactTestBase):
         client = self.create_client(
             {
                 "cluster_name": self.cluster.id,
-                "compact_serializers": {
-                    SomeFields: SomeFieldsSerializer([FieldDefinition(name=field_name)]),
-                },
+                "compact_serializers": [
+                    SomeFieldsSerializer([FieldDefinition(name=field_name)]),
+                ],
             }
         )
 
@@ -532,10 +535,10 @@ class CompactTest(CompactTestBase):
         client = self.create_client(
             {
                 "cluster_name": self.cluster.id,
-                "compact_serializers": {
-                    SomeFields: SomeFieldsSerializer([field_definition]),
-                    Nested: NestedSerializer(),
-                },
+                "compact_serializers": [
+                    SomeFieldsSerializer([field_definition]),
+                    NestedSerializer(),
+                ],
             }
         )
 
@@ -558,10 +561,7 @@ class CompactTest(CompactTestBase):
         client = self.create_client(
             {
                 "cluster_name": self.cluster.id,
-                "compact_serializers": {
-                    SomeFields: serializer,
-                    Nested: NestedSerializer(),
-                },
+                "compact_serializers": [serializer, NestedSerializer()],
             }
         )
 
@@ -611,9 +611,7 @@ class CompactSchemaEvolutionTest(CompactTestBase):
         return self.create_client(
             {
                 "cluster_name": self.cluster.id,
-                "compact_serializers": {
-                    SomeFields: serializer,
-                },
+                "compact_serializers": [serializer],
             }
         )
 
@@ -734,9 +732,7 @@ class CompactOnClusterRestartTest(CompactTestBase):
         client = self.create_client(
             {
                 "cluster_name": self.cluster.id,
-                "compact_serializers": {
-                    SomeFields: SomeFieldsSerializer([FieldDefinition(name="int32")])
-                },
+                "compact_serializers": [SomeFieldsSerializer([FieldDefinition(name="int32")])],
             }
         )
 
@@ -758,9 +754,7 @@ class CompactWithListenerTest(CompactTestBase):
     def test_map_listener(self):
         config = {
             "cluster_name": self.cluster.id,
-            "compact_serializers": {
-                SomeFields: SomeFieldsSerializer([FieldDefinition(name="int32")])
-            },
+            "compact_serializers": [SomeFieldsSerializer([FieldDefinition(name="int32")])],
         }
         client = self.create_client(config)
 
@@ -819,6 +813,9 @@ class NestedSerializer(CompactSerializer[Nested]):
     def get_type_name(self) -> str:
         return Nested.__name__
 
+    def get_class(self) -> Nested:
+        return Nested
+
 
 class FieldDefinition:
     def __init__(
@@ -863,6 +860,9 @@ class SomeFieldsSerializer(CompactSerializer[SomeFields]):
 
     def get_type_name(self) -> str:
         return SomeFields.__name__
+
+    def get_class(self) -> SomeFields:
+        return SomeFields
 
     @staticmethod
     def from_kinds(kinds: typing.List[FieldKind]) -> "SomeFieldsSerializer":


### PR DESCRIPTION
This PR:
* Changes `compact_serializers` configuration to be a list of `CompactSerializer`.
* Adds `get_class` method to the base `CompactSerializer`.
* Updates related docs and tests.
* Trivially updates `run_tests.py` to pass given comand line arguments to `pytest`.