### PR TITLE
trigger type 'opened' is removed

### DIFF
--- a/.github/workflows/coverage_runner.yml
+++ b/.github/workflows/coverage_runner.yml
@@ -14,8 +14,6 @@ on:
     branches:
       - master
       - '[45].*.z'
-    types:
-      [opened]
       
 jobs:
   check_for_membership:


### PR DESCRIPTION
Tests are only running when a PR is opened, but it wasn't set in the old workflow. If needed tests should be triggered when PR is reopened and new commits come. When types are not set it uses default ones `opened` `reopened` `synchronize`  