### PR TITLE
Update Compact related tests for backward compatibility tests

### DIFF
--- a/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
+++ b/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
@@ -280,6 +280,12 @@ class CompactCompatibilityBase(HazelcastTestCase):
             cls.rc.exit()
             raise unittest.SkipTest("Compact serialization requires 5.1 server")
 
+        if compare_server_version_with_rc(cls.rc, "5.2") >= 0 and compare_client_version("5.2") < 0:
+            cls.rc.exit()
+            raise unittest.SkipTest(
+                "Compact serialization 5.2 server is not compatible with clients older than 5.2"
+            )
+
         config = f"""
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/tests/integration/backward_compatible/serialization/compact_test.py
+++ b/tests/integration/backward_compatible/serialization/compact_test.py
@@ -105,6 +105,12 @@ class CompactTestBase(HazelcastTestCase):
             cls.rc.exit()
             raise unittest.SkipTest("Compact serialization requires 5.1 server")
 
+        if compare_server_version_with_rc(cls.rc, "5.2") >= 0 and compare_client_version("5.2") < 0:
+            cls.rc.exit()
+            raise unittest.SkipTest(
+                "Compact serialization 5.2 server is not compatible with clients older than 5.2"
+            )
+
         config = """
         <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"


### PR DESCRIPTION
We need to skip 5.2 server versions if the client version is <5.2.

This PR updates the tests to skip on such scenarious.