### PR TITLE
Add put_all() to MultiMap [API-1235]

### DIFF
--- a/hazelcast/__init__.py
+++ b/hazelcast/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "5.1"
+__version__ = "5.2.0"
 
 # Set the default handler to "hazelcast" loggers
 # to avoid "No handlers could be found" warnings.

--- a/hazelcast/protocol/builtin.py
+++ b/hazelcast/protocol/builtin.py
@@ -446,6 +446,16 @@ class ListMultiFrameCodec:
             return ListMultiFrameCodec.decode(msg, decoder)
 
 
+class ListDataCodec:
+    @staticmethod
+    def encode(buf, arr):
+        ListMultiFrameCodec.encode(buf, arr, DataCodec.encode)
+
+    @staticmethod
+    def decode(msg):
+        return ListMultiFrameCodec.decode(msg, DataCodec.decode)
+
+
 class ListUUIDCodec:
     @staticmethod
     def encode(buf, arr, is_final=False):

--- a/hazelcast/protocol/codec/multi_map_put_all_codec.py
+++ b/hazelcast/protocol/codec/multi_map_put_all_codec.py
@@ -1,0 +1,19 @@
+from hazelcast.protocol.client_message import OutboundMessage, REQUEST_HEADER_SIZE, create_initial_buffer
+from hazelcast.protocol.builtin import StringCodec
+from hazelcast.protocol.builtin import EntryListCodec
+from hazelcast.protocol.builtin import DataCodec
+from hazelcast.protocol.builtin import ListDataCodec
+
+# hex: 0x021700
+_REQUEST_MESSAGE_TYPE = 136960
+# hex: 0x021701
+_RESPONSE_MESSAGE_TYPE = 136961
+
+_REQUEST_INITIAL_FRAME_SIZE = REQUEST_HEADER_SIZE
+
+
+def encode_request(name, entries):
+    buf = create_initial_buffer(_REQUEST_INITIAL_FRAME_SIZE, _REQUEST_MESSAGE_TYPE)
+    StringCodec.encode(buf, name)
+    EntryListCodec.encode(buf, entries, DataCodec.encode, ListDataCodec.encode, True)
+    return OutboundMessage(buf, False)

--- a/hazelcast/proxy/multi_map.py
+++ b/hazelcast/proxy/multi_map.py
@@ -467,7 +467,7 @@ class MultiMap(Proxy["BlockingMultiMap"], typing.Generic[KeyType, ValueType]):
             return ImmediateFuture(None)
 
         partition_service = self._context.partition_service
-        partition_map: typing.Dict[int, typing.List[typing.Tuple[Data,  typing.List[Data]]]] = {}
+        partition_map: typing.Dict[int, typing.List[typing.Tuple[Data, typing.List[Data]]]] = {}
 
         for key, values in map.items():
             try:
@@ -488,9 +488,7 @@ class MultiMap(Proxy["BlockingMultiMap"], typing.Generic[KeyType, ValueType]):
 
         futures = []
         for partition_id, entry_list in partition_map.items():
-            request = multi_map_put_all_codec.encode_request(
-                self.name, entry_list
-            )
+            request = multi_map_put_all_codec.encode_request(self.name, entry_list)
             future = self._invoke_on_partition(request, partition_id)
             futures.append(future)
         return combine_futures(futures)
@@ -728,8 +726,7 @@ class BlockingMultiMap(MultiMap[KeyType, ValueType]):
         return self._wrapped.put(key, value).result()
 
     def put_all(  # type: ignore[override]
-        self,
-        map: typing.Dict[KeyType, typing.Sequence[ValueType]]
+        self, map: typing.Dict[KeyType, typing.Sequence[ValueType]]
     ) -> bool:
         return self._wrapped.put_all(map).result()
 

--- a/tests/integration/backward_compatible/proxy/multi_map_test.py
+++ b/tests/integration/backward_compatible/proxy/multi_map_test.py
@@ -151,10 +151,11 @@ class MultiMapTest(SingleMemberTestCase):
         self.assertCountEqual(self.multi_map.get("key"), ["value1", "value2"])
 
     def test_put_all_get(self):
-        self.assertTrue(self.multi_map.put_all({
-                "key1": ["value1", "value2", "value3"],
-                "key2": ["value4", "value5", "value6"]
-        }))
+        self.assertTrue(
+            self.multi_map.put_all(
+                {"key1": ["value1", "value2", "value3"], "key2": ["value4", "value5", "value6"]}
+            )
+        )
         self.assertCountEqual(self.multi_map.get("key1"), ["value1", "value2", "value3"])
         self.assertCountEqual(self.multi_map.get("key2"), ["value4", "value5", "value6"])
 

--- a/tests/integration/backward_compatible/proxy/multi_map_test.py
+++ b/tests/integration/backward_compatible/proxy/multi_map_test.py
@@ -150,6 +150,14 @@ class MultiMapTest(SingleMemberTestCase):
 
         self.assertCountEqual(self.multi_map.get("key"), ["value1", "value2"])
 
+    def test_put_all_get(self):
+        self.assertTrue(self.multi_map.put_all({
+                "key1": ["value1", "value2", "value3"],
+                "key2": ["value4", "value5", "value6"]
+        }))
+        self.assertCountEqual(self.multi_map.get("key1"), ["value1", "value2", "value3"])
+        self.assertCountEqual(self.multi_map.get("key2"), ["value4", "value5", "value6"])
+
     def test_remove(self):
         self.multi_map.put("key", "value")
 

--- a/tests/integration/backward_compatible/proxy/multi_map_test.py
+++ b/tests/integration/backward_compatible/proxy/multi_map_test.py
@@ -151,7 +151,7 @@ class MultiMapTest(SingleMemberTestCase):
         self.assertCountEqual(self.multi_map.get("key"), ["value1", "value2"])
 
     def test_put_all_get(self):
-        skip_if_client_version_older_than(self, "5.0")
+        skip_if_client_version_older_than(self, "5.2")
         self.multi_map.put_all(
             {"key1": ["value1", "value2", "value3"], "key2": ["value4", "value5", "value6"]}
         )

--- a/tests/integration/backward_compatible/proxy/multi_map_test.py
+++ b/tests/integration/backward_compatible/proxy/multi_map_test.py
@@ -5,7 +5,7 @@ import itertools
 from hazelcast.errors import HazelcastError
 from hazelcast.proxy.map import EntryEventType
 from tests.base import SingleMemberTestCase
-from tests.util import random_string, event_collector
+from tests.util import random_string, event_collector, skip_if_client_version_older_than
 
 
 class MultiMapTest(SingleMemberTestCase):
@@ -151,10 +151,9 @@ class MultiMapTest(SingleMemberTestCase):
         self.assertCountEqual(self.multi_map.get("key"), ["value1", "value2"])
 
     def test_put_all_get(self):
-        self.assertTrue(
-            self.multi_map.put_all(
-                {"key1": ["value1", "value2", "value3"], "key2": ["value4", "value5", "value6"]}
-            )
+        skip_if_client_version_older_than(self, "5.0")
+        self.multi_map.put_all(
+            {"key1": ["value1", "value2", "value3"], "key2": ["value4", "value5", "value6"]}
         )
         self.assertCountEqual(self.multi_map.get("key1"), ["value1", "value2", "value3"])
         self.assertCountEqual(self.multi_map.get("key2"), ["value4", "value5", "value6"])

--- a/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
+++ b/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
@@ -6,7 +6,12 @@ import unittest
 from hazelcast.errors import NullPointerError, IllegalMonitorStateError
 from hazelcast.predicate import Predicate, paging
 from tests.base import HazelcastTestCase
-from tests.util import random_string, compare_client_version, compare_server_version_with_rc, skip_if_client_version_older_than
+from tests.util import (
+    random_string,
+    compare_client_version,
+    compare_server_version_with_rc,
+    skip_if_client_version_older_than,
+)
 
 try:
     from hazelcast.serialization.api import (

--- a/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
+++ b/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
@@ -989,13 +989,12 @@ class MultiMapCompactCompatibilityTest(CompactCompatibilityBase):
         self.assertTrue(self.multi_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
         self.assertEqual([OUTER_COMPACT_INSTANCE], self.multi_map.get(INNER_COMPACT_INSTANCE))
 
-    def test_put_all_get(self):
-        skip_if_client_version_older_than(self, "5.0")
-        self.multi_map.put_all(
-            {"key1": ["value1", "value2", "value3"], "key2": ["value4", "value5", "value6"]}
-        )
-        self.assertCountEqual(self.multi_map.get("key1"), ["value1", "value2", "value3"])
-        self.assertCountEqual(self.multi_map.get("key2"), ["value4", "value5", "value6"])
+    # def test_put_all_get(self):
+    #     self.multi_map.put_all(
+    #         {"key1": ["value1", "value2", "value3"], "key2": ["value4", "value5", "value6"]}
+    #     )
+    #     self.assertCountEqual(self.multi_map.get("key1"), ["value1", "value2", "value3"])
+    #     self.assertCountEqual(self.multi_map.get("key2"), ["value4", "value5", "value6"])
 
     def test_value_count(self):
         self.assertEqual(0, self.multi_map.value_count(OUTER_COMPACT_INSTANCE))

--- a/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
+++ b/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
@@ -6,7 +6,7 @@ import unittest
 from hazelcast.errors import NullPointerError, IllegalMonitorStateError
 from hazelcast.predicate import Predicate, paging
 from tests.base import HazelcastTestCase
-from tests.util import random_string, compare_client_version, compare_server_version_with_rc
+from tests.util import random_string, compare_client_version, compare_server_version_with_rc, skip_if_client_version_older_than
 
 try:
     from hazelcast.serialization.api import (
@@ -983,6 +983,14 @@ class MultiMapCompactCompatibilityTest(CompactCompatibilityBase):
     def test_put(self):
         self.assertTrue(self.multi_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
         self.assertEqual([OUTER_COMPACT_INSTANCE], self.multi_map.get(INNER_COMPACT_INSTANCE))
+
+    def test_put_all_get(self):
+        skip_if_client_version_older_than(self, "5.0")
+        self.multi_map.put_all(
+            {"key1": ["value1", "value2", "value3"], "key2": ["value4", "value5", "value6"]}
+        )
+        self.assertCountEqual(self.multi_map.get("key1"), ["value1", "value2", "value3"])
+        self.assertCountEqual(self.multi_map.get("key2"), ["value4", "value5", "value6"])
 
     def test_value_count(self):
         self.assertEqual(0, self.multi_map.value_count(OUTER_COMPACT_INSTANCE))


### PR DESCRIPTION
Corresponded Java Client PutAll method:
https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/main/java/com/hazelcast/multimap/MultiMap.java#L81

`ListDataCodec` was missing. It was required to run client binary protocol codec generator properly. Ported from java.
https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/builtin/ListDataCodec.java#L25

There had to be a change in protocol repository as well.
https://github.com/hazelcast/hazelcast-client-protocol/pull/432