### PR TITLE
Nested compact field's serializer can be None if it is not registered [API-1416]

### DIFF
--- a/hazelcast/serialization/compact.py
+++ b/hazelcast/serialization/compact.py
@@ -46,7 +46,7 @@ class CompactStreamSerializer(BaseSerializer):
         serializer = self._type_to_serializer.get(clazz)
         if serializer is None:
             raise HazelcastSerializationError(
-                "No serializer is registered for class {}.".format(type(obj).__name__)
+                f"No serializer is registered for class/constructor {clazz.__name__}."
             )
         schema = self._type_to_schema.get(clazz)
         if not schema:

--- a/hazelcast/serialization/compact.py
+++ b/hazelcast/serialization/compact.py
@@ -45,9 +45,7 @@ class CompactStreamSerializer(BaseSerializer):
         clazz = type(obj)
         serializer = self._type_to_serializer.get(clazz)
         if serializer is None:
-            raise HazelcastSerializationError(
-                f"No serializer is registered for class {clazz}."
-            )
+            raise HazelcastSerializationError(f"No serializer is registered for class {clazz}.")
         schema = self._type_to_schema.get(clazz)
         if not schema:
             schema = CompactStreamSerializer._build_schema(serializer, obj)

--- a/hazelcast/serialization/compact.py
+++ b/hazelcast/serialization/compact.py
@@ -46,7 +46,7 @@ class CompactStreamSerializer(BaseSerializer):
         serializer = self._type_to_serializer.get(clazz)
         if serializer is None:
             raise HazelcastSerializationError(
-                f"No serializer is registered for class/constructor {clazz}."
+                f"No serializer is registered for class {clazz}."
             )
         schema = self._type_to_schema.get(clazz)
         if not schema:

--- a/hazelcast/serialization/compact.py
+++ b/hazelcast/serialization/compact.py
@@ -43,7 +43,9 @@ class CompactStreamSerializer(BaseSerializer):
 
     def write(self, out: ObjectDataOutput, obj: typing.Any) -> None:
         clazz = type(obj)
-        serializer = self._type_to_serializer[clazz]
+        serializer = self._type_to_serializer.get(clazz)
+        if serializer is None:
+            raise HazelcastSerializationError('No serializer is registered for class {}.'.format(type(obj).__name__))
         schema = self._type_to_schema.get(clazz)
         if not schema:
             schema = CompactStreamSerializer._build_schema(serializer, obj)

--- a/hazelcast/serialization/compact.py
+++ b/hazelcast/serialization/compact.py
@@ -46,7 +46,7 @@ class CompactStreamSerializer(BaseSerializer):
         serializer = self._type_to_serializer.get(clazz)
         if serializer is None:
             raise HazelcastSerializationError(
-                f"No serializer is registered for class/constructor {clazz.__name__}."
+                f"No serializer is registered for class/constructor {clazz}."
             )
         schema = self._type_to_schema.get(clazz)
         if not schema:

--- a/hazelcast/serialization/compact.py
+++ b/hazelcast/serialization/compact.py
@@ -45,7 +45,9 @@ class CompactStreamSerializer(BaseSerializer):
         clazz = type(obj)
         serializer = self._type_to_serializer.get(clazz)
         if serializer is None:
-            raise HazelcastSerializationError('No serializer is registered for class {}.'.format(type(obj).__name__))
+            raise HazelcastSerializationError(
+                "No serializer is registered for class {}.".format(type(obj).__name__)
+            )
         schema = self._type_to_schema.get(clazz)
         if not schema:
             schema = CompactStreamSerializer._build_schema(serializer, obj)

--- a/tests/integration/backward_compatible/serialization/compact_test.py
+++ b/tests/integration/backward_compatible/serialization/compact_test.py
@@ -785,22 +785,20 @@ class CompactWithListenerTest(CompactTestBase):
 
 
 class CompactWithNestedFieldTest(CompactTestBase):
-
     def test_missing_nested_serializer(self):
         serializer = SomeFieldsSerializer.from_kinds(FIELD_KINDS)
         fields = {kind.name.lower(): REFERENCE_OBJECTS[kind] for kind in FIELD_KINDS}
 
-        config = {
-            "cluster_name": self.cluster.id,
-            "compact_serializers": [serializer]
-        }
+        config = {"cluster_name": self.cluster.id, "compact_serializers": [serializer]}
 
         client = self.create_client(config)
 
         map_name = random_string()
         m = client.get_map(map_name).blocking()
 
-        with self.assertRaisesRegex(HazelcastSerializationError, "No serializer is registered for class Nested."):
+        with self.assertRaisesRegex(
+            HazelcastSerializationError, "No serializer is registered for class Nested."
+        ):
             m.put("key", SomeFields(**fields))
 
 

--- a/tests/integration/backward_compatible/serialization/compact_test.py
+++ b/tests/integration/backward_compatible/serialization/compact_test.py
@@ -784,24 +784,6 @@ class CompactWithListenerTest(CompactTestBase):
         self.assertTrueEventually(lambda: self.assertEqual(1, counter.get()))
 
 
-class CompactWithNestedFieldTest(CompactTestBase):
-    def test_missing_nested_serializer(self):
-        serializer = SomeFieldsSerializer.from_kinds(FIELD_KINDS)
-        fields = {kind.name.lower(): REFERENCE_OBJECTS[kind] for kind in FIELD_KINDS}
-
-        config = {"cluster_name": self.cluster.id, "compact_serializers": [serializer]}
-
-        client = self.create_client(config)
-
-        map_name = random_string()
-        m = client.get_map(map_name).blocking()
-
-        with self.assertRaisesRegex(
-            HazelcastSerializationError, "No serializer is registered for class Nested."
-        ):
-            m.put("key", SomeFields(**fields))
-
-
 class SomeFields:
     def __init__(self, **fields):
         self._fields = fields

--- a/tests/unit/serialization/compact_test.py
+++ b/tests/unit/serialization/compact_test.py
@@ -19,12 +19,6 @@ from hazelcast.serialization.compact import (
     FieldKind,
     SchemaNotReplicatedError,
 )
-from tests.integration.backward_compatible.serialization.compact_test import (
-    SomeFieldsSerializer,
-    FIELD_KINDS,
-    REFERENCE_OBJECTS,
-    SomeFields,
-)
 
 
 class RabinFingerprintTest(unittest.TestCase):
@@ -268,7 +262,7 @@ class NestedSerializerTest(unittest.TestCase):
         service = SerializationServiceV1(config)
 
         with self.assertRaisesRegex(
-            HazelcastSerializationError, "No serializer is registered for class/constructor"
+            HazelcastSerializationError, "No serializer is registered for class"
         ):
             obj = Parent(Child("test"))
             self._serialize(service, obj)


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast-python-client/issues/556

Added check for None serializer, on it, throw a HazelcastSerializationError in this case.
Added a new test for missing nested serializer case, it checks if a HazelcastSerializationError has been thrown.