### PR TITLE
Make map#remove_all tests backward compatibility aware

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,9 +72,9 @@ author = "Hazelcast Inc. Developers"
 # built documents.
 #
 # The short X.Y version.
-version = "5.1"
+version = "5.2.0"
 # The full version, including alpha/beta/rc tags.
-release = "5.1"
+release = "5.2.0"
 
 autodoc_member_order = "bysource"
 autoclass_content = "both"

--- a/hazelcast/__init__.py
+++ b/hazelcast/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "5.1"
+__version__ = "5.2.0"
 
 # Set the default handler to "hazelcast" loggers
 # to avoid "No handlers could be found" warnings.

--- a/tests/integration/backward_compatible/proxy/map_nearcache_test.py
+++ b/tests/integration/backward_compatible/proxy/map_nearcache_test.py
@@ -7,7 +7,7 @@ from hazelcast.predicate import true
 from tests.hzrc.ttypes import Lang
 
 from tests.base import SingleMemberTestCase, HazelcastTestCase
-from tests.util import random_string
+from tests.util import random_string, skip_if_client_version_older_than
 from hazelcast import HazelcastClient
 
 
@@ -57,6 +57,8 @@ class MapTest(SingleMemberTestCase):
         self.assertEqual(0, len(self.map._wrapped._near_cache))
 
     def test_remove_all(self):
+        skip_if_client_version_older_than(self, "5.2.0")
+
         self.fill_map_and_near_cache(10)
         self.map.remove_all(predicate=true())
         self.assertEqual(0, len(self.map._wrapped._near_cache))

--- a/tests/integration/backward_compatible/proxy/map_test.py
+++ b/tests/integration/backward_compatible/proxy/map_test.py
@@ -496,10 +496,14 @@ class MapTest(SingleMemberTestCase):
         self.assertFalse(self.map.contains_key("key"))
 
     def test_remove_all_with_none_predicate(self):
+        skip_if_client_version_older_than(self, "5.2.0")
+
         with self.assertRaises(AssertionError):
             self.map.remove_all(None)
 
     def test_remove_all(self):
+        skip_if_client_version_older_than(self, "5.2.0")
+
         self.fill_map()
         self.map.remove_all(predicate=sql("__key > 'key-7'"))
         self.assertEqual(self.map.size(), 8)

--- a/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
+++ b/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
@@ -6,7 +6,12 @@ import unittest
 from hazelcast.errors import NullPointerError, IllegalMonitorStateError
 from hazelcast.predicate import Predicate, paging
 from tests.base import HazelcastTestCase
-from tests.util import random_string, compare_client_version, compare_server_version_with_rc
+from tests.util import (
+    random_string,
+    compare_client_version,
+    compare_server_version_with_rc,
+    skip_if_client_version_older_than,
+)
 
 try:
     from hazelcast.serialization.api import (
@@ -789,6 +794,13 @@ class MapCompatibilityTest(CompactCompatibilityBase):
         self.assertIsNone(self.map.remove(OUTER_COMPACT_INSTANCE))
         self._put_from_another_client(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
         self.assertEqual(INNER_COMPACT_INSTANCE, self.map.remove(OUTER_COMPACT_INSTANCE))
+
+    def test_remove_all(self):
+        skip_if_client_version_older_than(self, "5.2")
+
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self.assertIsNone(self.map.remove_all(CompactPredicate()))
+        self.assertEqual(0, self.map.size())
 
     def test_remove_if_same(self):
         self.assertFalse(self.map.remove_if_same(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))


### PR DESCRIPTION
These tests were added, but there were no checks for them for the older client versions in the backward compatibility tests.

This PR bumps the client version to 5.2.0 and adds the necessary checks.

Also, a test for Compact compatibility is added for this functionality.