### PR TITLE
Use LFU eviction policy in NearCacheTestCase#test_put_get

### DIFF
--- a/tests/unit/near_cache_test.py
+++ b/tests/unit/near_cache_test.py
@@ -35,7 +35,7 @@ class NearCacheTestCase(unittest.TestCase):
 
     def test_put_get(self):
         near_cache = self.create_near_cache(
-            self.service, InMemoryFormat.OBJECT, 100, 100, EvictionPolicy.LRU, 100
+            self.service, InMemoryFormat.OBJECT, 100, 100, EvictionPolicy.LFU, 100
         )
         for i in range(0, 120):
             key = "key-{}".format(i)


### PR DESCRIPTION
This test was failing frequently on nightly builds on Windows.

After some inspection, from the logs, I saw that the `key-0` is expired, despite it being accessed in every iteration of the loop.

The problem is, time resolution in Windows is pretty bad. It has milliseconds precision, and the test is prone to failure with that. It is entirely possible that the test runs fairly quickly, fill the near cache with entries within a millisecond, and when we are about to evict some entries to open up space for new keys, `key-0` might be in the eviction pool, due to us not being able to differentiate the last access times with such a low precision.

The actual solution to this problem would be to use high-precision timers added in the later versions of the Python, but I leave this one to later, we need to re-write the near cache anyways no need to patch it here and there.