### PR TITLE
Use truly unreachable address in ConnectionManagerTranslateTest

### DIFF
--- a/tests/integration/connection_manager_test.py
+++ b/tests/integration/connection_manager_test.py
@@ -10,7 +10,9 @@ from hazelcast.util import AtomicInteger
 from tests.base import HazelcastTestCase, SingleMemberTestCase
 from tests.util import random_string
 
-_UNREACHABLE_ADDRESS = Address("192.168.0.1", 5701)
+# 198.51.100.0/24 is assigned as TEST-NET-2 and should be unreachable
+# See: https://en.wikipedia.org/wiki/Reserved_IP_addresses
+_UNREACHABLE_ADDRESS = Address("198.51.100.1", 5701)
 _MEMBER_VERSION = MemberVersion(5, 0, 0)
 _CLIENT_PUBLIC_ENDPOINT_QUALIFIER = EndpointQualifier(ProtocolType.CLIENT, "public")
 


### PR DESCRIPTION
As reported by Serkan on a similar issue for Node.js, the `192.168.0.1` is reachable from time to time in the Windows runners in Github Actions.

Being able to reach this address causes some tests to fail. (See the recent nightly runs for the failing tests)

As a solution, we are using a truly unreachable address, similar to what we did for Node.js client.