### PR TITLE
Add put_all() to MultiMap [API-1235]

### DIFF
--- a/hazelcast/protocol/builtin.py
+++ b/hazelcast/protocol/builtin.py
@@ -446,6 +446,16 @@ class ListMultiFrameCodec:
             return ListMultiFrameCodec.decode(msg, decoder)
 
 
+class ListDataCodec:
+    @staticmethod
+    def encode(buf, arr):
+        ListMultiFrameCodec.encode(buf, arr, DataCodec.encode)
+
+    @staticmethod
+    def decode(msg):
+        return ListMultiFrameCodec.decode(msg, DataCodec.decode)
+
+
 class ListUUIDCodec:
     @staticmethod
     def encode(buf, arr, is_final=False):

--- a/hazelcast/protocol/codec/multi_map_put_all_codec.py
+++ b/hazelcast/protocol/codec/multi_map_put_all_codec.py
@@ -1,0 +1,19 @@
+from hazelcast.protocol.client_message import OutboundMessage, REQUEST_HEADER_SIZE, create_initial_buffer
+from hazelcast.protocol.builtin import StringCodec
+from hazelcast.protocol.builtin import EntryListCodec
+from hazelcast.protocol.builtin import DataCodec
+from hazelcast.protocol.builtin import ListDataCodec
+
+# hex: 0x021700
+_REQUEST_MESSAGE_TYPE = 136960
+# hex: 0x021701
+_RESPONSE_MESSAGE_TYPE = 136961
+
+_REQUEST_INITIAL_FRAME_SIZE = REQUEST_HEADER_SIZE
+
+
+def encode_request(name, entries):
+    buf = create_initial_buffer(_REQUEST_INITIAL_FRAME_SIZE, _REQUEST_MESSAGE_TYPE)
+    StringCodec.encode(buf, name)
+    EntryListCodec.encode(buf, entries, DataCodec.encode, ListDataCodec.encode, True)
+    return OutboundMessage(buf, False)

--- a/hazelcast/proxy/multi_map.py
+++ b/hazelcast/proxy/multi_map.py
@@ -472,6 +472,7 @@ class MultiMap(Proxy["BlockingMultiMap"], typing.Generic[KeyType, ValueType]):
 
         for key, values in multimap.items():
             try:
+                check_not_none(key, "key can't be None")
                 check_not_none(values, "values can't be None")
                 serialized_key = self._to_data(key)
                 serialized_values = []
@@ -488,7 +489,7 @@ class MultiMap(Proxy["BlockingMultiMap"], typing.Generic[KeyType, ValueType]):
             request = multi_map_put_all_codec.encode_request(self.name, entry_list)
             future = self._invoke_on_partition(request, partition_id)
             futures.append(future)
-        return combine_futures(futures).continue_with(lambda *args: None)
+        return combine_futures(futures).continue_with(lambda _: None)
 
     def remove_entry_listener(self, registration_id: str) -> Future[bool]:
         """Removes the specified entry listener.

--- a/hazelcast/proxy/multi_map.py
+++ b/hazelcast/proxy/multi_map.py
@@ -1,6 +1,8 @@
 import typing
 
-from hazelcast.future import Future
+from collections import defaultdict
+
+from hazelcast.future import combine_futures, Future, ImmediateFuture
 from hazelcast.protocol.codec import (
     multi_map_add_entry_listener_codec,
     multi_map_add_entry_listener_to_key_codec,
@@ -15,6 +17,7 @@ from hazelcast.protocol.codec import (
     multi_map_key_set_codec,
     multi_map_lock_codec,
     multi_map_put_codec,
+    multi_map_put_all_codec,
     multi_map_remove_codec,
     multi_map_remove_entry_codec,
     multi_map_remove_entry_listener_codec,
@@ -26,6 +29,7 @@ from hazelcast.protocol.codec import (
 )
 from hazelcast.proxy.base import Proxy, EntryEvent, EntryEventType
 from hazelcast.types import ValueType, KeyType
+from hazelcast.serialization.data import Data
 from hazelcast.serialization.compact import SchemaNotReplicatedError
 from hazelcast.util import check_not_none, thread_id, to_millis, ImmutableLazyDataList
 
@@ -445,6 +449,47 @@ class MultiMap(Proxy["BlockingMultiMap"], typing.Generic[KeyType, ValueType]):
         request = multi_map_put_codec.encode_request(self.name, key_data, value_data, thread_id())
         return self._invoke_on_key(request, key_data, multi_map_put_codec.decode_response)
 
+    def put_all(self, multimap: typing.Dict[KeyType, typing.Sequence[ValueType]]) -> Future[None]:
+        """Stores the given Map in the MultiMap.
+
+        The results of concurrently mutating the given map are undefined.
+        No atomicity guarantees are given. It could be that in case of failure some of the key/value-pairs get written, while others are not.
+
+        Warning:
+            This method uses ``__hash__`` and ``__eq__`` methods of binary form
+            of the key, not the actual implementations of ``__hash__`` and
+            ``__eq__`` defined in key's class.
+
+        Args:
+            multimap: the map corresponds to multimap entries.
+        """
+        check_not_none(multimap, "multimap can't be None")
+        if not multimap:
+            return ImmediateFuture(None)
+
+        partition_service = self._context.partition_service
+        partition_map: typing.DefaultDict[int, typing.List[typing.Tuple[Data, typing.List[Data]]]] = defaultdict(list)
+
+        for key, values in multimap.items():
+            try:
+                check_not_none(values, "values can't be None")
+                serialized_key = self._to_data(key)
+                serialized_values = []
+                for value in values:
+                    check_not_none(value, "value can't be None")
+                    serialized_values.append(self._to_data(value))
+                partition_id = partition_service.get_partition_id(serialized_key)
+                partition_map[partition_id].append((serialized_key, serialized_values))
+            except SchemaNotReplicatedError as e:
+                return self._send_schema_and_retry(e, self.put_all, multimap)
+
+        futures = []
+        for partition_id, entry_list in partition_map.items():
+            request = multi_map_put_all_codec.encode_request(self.name, entry_list)
+            future = self._invoke_on_partition(request, partition_id)
+            futures.append(future)
+        return combine_futures(futures).continue_with(lambda *args: None)
+
     def remove_entry_listener(self, registration_id: str) -> Future[bool]:
         """Removes the specified entry listener.
 
@@ -676,6 +721,11 @@ class BlockingMultiMap(MultiMap[KeyType, ValueType]):
         value: ValueType,
     ) -> bool:
         return self._wrapped.put(key, value).result()
+
+    def put_all(  # type: ignore[override]
+        self, multimap: typing.Dict[KeyType, typing.Sequence[ValueType]]
+    ) -> None:
+        self._wrapped.put_all(multimap).result()
 
     def remove_entry_listener(  # type: ignore[override]
         self,

--- a/hazelcast/proxy/multi_map.py
+++ b/hazelcast/proxy/multi_map.py
@@ -468,7 +468,9 @@ class MultiMap(Proxy["BlockingMultiMap"], typing.Generic[KeyType, ValueType]):
             return ImmediateFuture(None)
 
         partition_service = self._context.partition_service
-        partition_map: typing.DefaultDict[int, typing.List[typing.Tuple[Data, typing.List[Data]]]] = defaultdict(list)
+        partition_map: typing.DefaultDict[
+            int, typing.List[typing.Tuple[Data, typing.List[Data]]]
+        ] = defaultdict(list)
 
         for key, values in multimap.items():
             try:

--- a/tests/integration/backward_compatible/proxy/multi_map_test.py
+++ b/tests/integration/backward_compatible/proxy/multi_map_test.py
@@ -5,7 +5,8 @@ import itertools
 from hazelcast.errors import HazelcastError
 from hazelcast.proxy.map import EntryEventType
 from tests.base import SingleMemberTestCase
-from tests.util import random_string, event_collector, skip_if_client_version_older_than
+from tests.util import random_string, event_collector
+from tests.util import skip_if_client_version_older_than, skip_if_server_version_older_than
 
 
 class MultiMapTest(SingleMemberTestCase):
@@ -150,7 +151,8 @@ class MultiMapTest(SingleMemberTestCase):
 
         self.assertCountEqual(self.multi_map.get("key"), ["value1", "value2"])
 
-    def test_put_all_get(self):
+    def test_put_all(self):
+        skip_if_server_version_older_than(self, self.client, "4.1")
         skip_if_client_version_older_than(self, "5.2")
         self.multi_map.put_all(
             {"key1": ["value1", "value2", "value3"], "key2": ["value4", "value5", "value6"]}

--- a/tests/integration/backward_compatible/proxy/multi_map_test.py
+++ b/tests/integration/backward_compatible/proxy/multi_map_test.py
@@ -5,7 +5,7 @@ import itertools
 from hazelcast.errors import HazelcastError
 from hazelcast.proxy.map import EntryEventType
 from tests.base import SingleMemberTestCase
-from tests.util import random_string, event_collector
+from tests.util import random_string, event_collector, skip_if_client_version_older_than
 
 
 class MultiMapTest(SingleMemberTestCase):
@@ -149,6 +149,14 @@ class MultiMapTest(SingleMemberTestCase):
         self.assertFalse(self.multi_map.put("key", "value2"))
 
         self.assertCountEqual(self.multi_map.get("key"), ["value1", "value2"])
+
+    def test_put_all_get(self):
+        skip_if_client_version_older_than(self, "5.2")
+        self.multi_map.put_all(
+            {"key1": ["value1", "value2", "value3"], "key2": ["value4", "value5", "value6"]}
+        )
+        self.assertCountEqual(self.multi_map.get("key1"), ["value1", "value2", "value3"])
+        self.assertCountEqual(self.multi_map.get("key2"), ["value4", "value5", "value6"])
 
     def test_remove(self):
         self.multi_map.put("key", "value")

--- a/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
+++ b/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
@@ -996,6 +996,13 @@ class MultiMapCompactCompatibilityTest(CompactCompatibilityBase):
         self.assertTrue(self.multi_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
         self.assertEqual([OUTER_COMPACT_INSTANCE], self.multi_map.get(INNER_COMPACT_INSTANCE))
 
+    # def test_put_all_get(self):
+    #     self.multi_map.put_all(
+    #         {"key1": ["value1", "value2", "value3"], "key2": ["value4", "value5", "value6"]}
+    #     )
+    #     self.assertCountEqual(self.multi_map.get("key1"), ["value1", "value2", "value3"])
+    #     self.assertCountEqual(self.multi_map.get("key2"), ["value4", "value5", "value6"])
+
     def test_value_count(self):
         self.assertEqual(0, self.multi_map.value_count(OUTER_COMPACT_INSTANCE))
         self.multi_map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)

--- a/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
+++ b/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
@@ -11,6 +11,7 @@ from tests.util import (
     compare_client_version,
     compare_server_version_with_rc,
     skip_if_client_version_older_than,
+    skip_if_server_version_older_than,
 )
 
 try:
@@ -996,12 +997,11 @@ class MultiMapCompactCompatibilityTest(CompactCompatibilityBase):
         self.assertTrue(self.multi_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
         self.assertEqual([OUTER_COMPACT_INSTANCE], self.multi_map.get(INNER_COMPACT_INSTANCE))
 
-    # def test_put_all_get(self):
-    #     self.multi_map.put_all(
-    #         {"key1": ["value1", "value2", "value3"], "key2": ["value4", "value5", "value6"]}
-    #     )
-    #     self.assertCountEqual(self.multi_map.get("key1"), ["value1", "value2", "value3"])
-    #     self.assertCountEqual(self.multi_map.get("key2"), ["value4", "value5", "value6"])
+    def test_put_all(self):
+        skip_if_server_version_older_than(self, self.client, "4.1")
+        skip_if_client_version_older_than(self, "5.2")
+        self.multi_map.put_all({INNER_COMPACT_INSTANCE: [OUTER_COMPACT_INSTANCE]})
+        self.assertCountEqual(self.multi_map.get(INNER_COMPACT_INSTANCE), [OUTER_COMPACT_INSTANCE])
 
     def test_value_count(self):
         self.assertEqual(0, self.multi_map.value_count(OUTER_COMPACT_INSTANCE))


### PR DESCRIPTION
- Existing PR has an issue with workflows and [Contributor License Agreement](https://cla.hazelcast.org/hazelcast/hazelcast-python-client?pullRequest=573). Therefore, I opened a new one.
- If I add test (which was commented out in compact compatibility test), it throws an exception in that space but passed fine in mutlimap test.
- I tried to resolve remaining reviews. 
```
compact_compatibility_test.py::MultiMapCompactCompatibilityTest::test_put_all_get ERROR [100%]
test setup failed
cls = <class 'tests.integration.backward_compatible.serialization.compact_compatibility.compact_compatibility_test.MultiMapCompactCompatibilityTest'>

    @classmethod
    def setUpClass(cls) -> None:
        cls.rc = cls.create_rc()
>       if compare_server_version_with_rc(cls.rc, "5.1") < 0:

compact_compatibility_test.py:284: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../../../util.py:114: in compare_server_version_with_rc
    result = rc.executeOnController(None, script, Lang.JAVASCRIPT)
../../../../hzrc/client.py:71: in executeOnController
    return self.remote_controller.executeOnController(cluster_id, script, lang)
../../../../hzrc/RemoteController.py:604: in executeOnController
    return self.recv_executeOnController()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <tests.hzrc.RemoteController.Client object at 0x105e62860>

    def recv_executeOnController(self):
        iprot = self._iprot
        (fname, mtype, rseqid) = iprot.readMessageBegin()
        if mtype == TMessageType.EXCEPTION:
            x = TApplicationException()
            x.read(iprot)
            iprot.readMessageEnd()
>           raise x
E           thrift.Thrift.TApplicationException: Internal error processing executeOnController

../../../../hzrc/RemoteController.py:623: TApplicationException
```
@mdumandag 