### PR TITLE
Add code sample to show how Hazelcast works with Pandas DataFrames.

### DIFF
--- a/examples/packages/pandas_example.py
+++ b/examples/packages/pandas_example.py
@@ -1,0 +1,51 @@
+import np as np
+import pandas as pd
+from matplotlib import pyplot as plt
+import hazelcast
+
+"""Create Hazelcast client connection"""
+client = hazelcast.HazelcastClient()
+
+"""Get a IMap for storing patient's DataFrame"""
+patients = client.get_map("patients").blocking()
+
+"""
+Store the heart rate and blood pressure data of fifty patients as DataFrame objects in Hazelcast cluster.
+"""
+for pid in range(0, 50):
+    """
+    Create a random DataFrame.
+    """
+    df = pd.DataFrame(
+        data={
+            "blood_pressure": np.random.randint(80, 120, size=(75,)),
+            "heart_rate": np.random.randint(60, 100, size=(75,)),
+        },
+        index=pd.date_range("1/1/2023", periods=75, freq="H"),
+    )
+    """
+    There are multiple serialization methods for DataFrame. Hazelcast uses pickle serialization as default
+    for various Python objects. So, you can simply put your data directly using default pickle serialization.
+
+    patients.put("1", df)
+
+    Alternatively, you can convert your DataFrame to JSON, CSV or a dict using to_json(), to_csv() and to_dict() methods.
+    Notice that these methods returns string representation of DataFrame in requested format.
+
+    Convert to CSV: df = df.to_csv()
+    Convert to JSON: df = df.to_json()
+    Convert to dict: df = df.to_dict()
+
+    If you use these representation, you need to re-create DataFrame object as follows since they are stored as 
+    string in Hazelcast cluster. For example, if you are converting DataFrame to CSV, use following while reading: 
+
+    df = pd.from_csv(StringIO(patients.get("patient-1")))
+    """
+    patients.put(f"{pid}", df.to_json())
+
+pid = np.random.randint(0, 50)
+df = pd.read_json(patients.get(f"{pid}"))
+
+df.plot(use_index=True, y=["blood_pressure", "heart_rate"], figsize=(15, 5), kind="line")
+plt.title(f"Blood Pressure and Heart Rate Plot of Patient-{pid}")
+plt.show()

--- a/examples/packages/pandas_example.py
+++ b/examples/packages/pandas_example.py
@@ -1,51 +1,59 @@
+"""
+You can store Pandas DataFrame objects in Hazelcast cluster and retrieve with low-latency.
+There are multiple serialization methods for DataFrame objects.
+Hazelcast uses pickle serialization as default for various Python objects including DataFrame.
+So, you can simply put your data directly using default pickle serialization without any conversions.
+
+patients.put(1, df)
+
+Alternatively, you can convert your DataFrame to JSON, CSV or a dict using to_json(), to_csv() and to_dict() methods.
+Note that JSON or CSV serializations returns string representation of DataFrame in requested format.
+
+Convert to CSV: df = df.to_csv()
+Convert to JSON: df = df.to_json()
+Convert to dict: df = df.to_dict()
+
+If you prefer to use these converted representations, you need to re-create DataFrame object since they are not stored
+as DataFrame object in Hazelcast cluster. For CSV, JSON and dict conversions, use following methods while retrieving:
+
+Create from CSV: df = pd.from_csv(StringIO(patients.get(1)))
+Create from JSON: df = pd.read_json(patients.get(1))
+Create from dict object: df = pd.DataFrame(patients.get(1))
+
+In addition to methods above, you can write your own custom serializer for DatFrame objects. For more information about
+Pyton client serialization methods, see https://hazelcast.readthedocs.io/en/stable/serialization.html#
+"""
+
+import hazelcast
+from hazelcast.core import HazelcastJsonValue
+from matplotlib import pyplot as plt
 import np as np
 import pandas as pd
-from matplotlib import pyplot as plt
-import hazelcast
 
-"""Create Hazelcast client connection"""
+# Create Hazelcast client
 client = hazelcast.HazelcastClient()
 
-"""Get a IMap for storing patient's DataFrame"""
+# Get an IMap for storing patient's DataFrame objects
 patients = client.get_map("patients").blocking()
 
-"""
-Store the heart rate and blood pressure data of fifty patients as DataFrame objects in Hazelcast cluster.
-"""
+# Store the blood pressure and heart rate data of fifty patients in a DataFrame and load it to Hazelcast cluster as JSON
 for pid in range(0, 50):
-    """
-    Create a random DataFrame.
-    """
+    # Create DataFrame with random values
     df = pd.DataFrame(
         data={
             "blood_pressure": np.random.randint(80, 120, size=(75,)),
             "heart_rate": np.random.randint(60, 100, size=(75,)),
         },
-        index=pd.date_range("1/1/2023", periods=75, freq="H"),
+        index=pd.date_range("2023-01-15", periods=75, freq="H"),
     )
-    """
-    There are multiple serialization methods for DataFrame. Hazelcast uses pickle serialization as default
-    for various Python objects. So, you can simply put your data directly using default pickle serialization.
-
-    patients.put("1", df)
-
-    Alternatively, you can convert your DataFrame to JSON, CSV or a dict using to_json(), to_csv() and to_dict() methods.
-    Notice that these methods returns string representation of DataFrame in requested format.
-
-    Convert to CSV: df = df.to_csv()
-    Convert to JSON: df = df.to_json()
-    Convert to dict: df = df.to_dict()
-
-    If you use these representation, you need to re-create DataFrame object as follows since they are stored as 
-    string in Hazelcast cluster. For example, if you are converting DataFrame to CSV, use following while reading: 
-
-    df = pd.from_csv(StringIO(patients.get("patient-1")))
-    """
-    patients.put(f"{pid}", df.to_json())
+    # Load DataFrame to Hazelcast cluster as HazelcastJsonValue
+    patients.put(pid, HazelcastJsonValue(df.to_json()))
 
 pid = np.random.randint(0, 50)
-df = pd.read_json(patients.get(f"{pid}"))
+# Retrieve the data of a random patient
+df = pd.read_json(patients.get(pid).to_string())
 
+# Plot the data
 df.plot(use_index=True, y=["blood_pressure", "heart_rate"], figsize=(15, 5), kind="line")
 plt.title(f"Blood Pressure and Heart Rate Plot of Patient-{pid}")
 plt.show()

--- a/examples/pandas/pandas_example.py
+++ b/examples/pandas/pandas_example.py
@@ -27,7 +27,7 @@ Pyton client serialization methods, see https://hazelcast.readthedocs.io/en/stab
 import hazelcast
 from hazelcast.core import HazelcastJsonValue
 from matplotlib import pyplot as plt
-import np as np
+import numpy as np
 import pandas as pd
 
 # Create Hazelcast client


### PR DESCRIPTION
Hi 👋

Fixes: https://github.com/hazelcast/hazelcast-python-client/issues/601

This PR adds a code sample to document how Pandas DataFrame can be used with Hazelcast Python Client. There are multiple ways to store the DataFrame in Hazelcast, I tried to list them all.

 I am new to open source, so I would really appreciate all comments if you have any suggesstion. 

Thanks in advance.