### PR TITLE
Introduce various updates for the Compact serialization [API-1564]

### DIFF
--- a/hazelcast/serialization/compact.py
+++ b/hazelcast/serialization/compact.py
@@ -1559,11 +1559,10 @@ class DefaultCompactReader(CompactReader):
 class SchemaWriter(CompactWriter):
     def __init__(self, type_name: str):
         self._type_name = type_name
-        self._fields: typing.List[FieldDescriptor] = []
-        self._field_names: typing.Set[str] = set()
+        self._fields: typing.Dict[str, FieldDescriptor] = {}
 
     def build(self) -> "Schema":
-        return Schema(self._type_name, self._fields)
+        return Schema(self._type_name, list(self._fields.values()))
 
     def write_boolean(self, field_name: str, value: bool) -> None:
         self._add_field(field_name, FieldKind.BOOLEAN)
@@ -1740,11 +1739,10 @@ class SchemaWriter(CompactWriter):
         self._add_field(field_name, FieldKind.ARRAY_OF_COMPACT)
 
     def _add_field(self, name: str, kind: "FieldKind"):
-        if name in self._field_names:
+        if name in self._fields:
             raise HazelcastSerializationError(f"Field with the name '{name}' already exists")
 
-        self._field_names.add(name)
-        self._fields.append(FieldDescriptor(name, kind))
+        self._fields[name] = FieldDescriptor(name, kind)
 
 
 class Schema:

--- a/hazelcast/serialization/service.py
+++ b/hazelcast/serialization/service.py
@@ -111,6 +111,11 @@ class SerializationServiceV1:
         for _type, custom_serializer in config.custom_serializers.items():
             self._registry.safe_register_serializer(custom_serializer(), _type)
 
+        # Called here so that we can make sure that we are not overriding
+        # any of the default serializers registered above with the Compact
+        # serialization.
+        self._registry.validate()
+
     def to_data(self, obj, partitioning_strategy=None):
         """Serialize the input object into byte array representation
 
@@ -241,12 +246,12 @@ class SerializationServiceV1:
         self._registry.register_constant_serializer(BooleanSerializer(), bool)
         self._registry.register_constant_serializer(CharSerializer())
         self._registry.register_constant_serializer(ShortSerializer())
-        self._registry.register_constant_serializer(IntegerSerializer())
+        self._registry.register_constant_serializer(IntegerSerializer(), int)
         self._registry.register_constant_serializer(LongSerializer())
         self._registry.register_constant_serializer(FloatSerializer())
         self._registry.register_constant_serializer(DoubleSerializer(), float)
         self._registry.register_constant_serializer(UuidSerializer(), uuid.UUID)
-        self._registry.register_constant_serializer(StringSerializer())
+        self._registry.register_constant_serializer(StringSerializer(), str)
         # Arrays of primitives and String
         self._registry.register_constant_serializer(ByteArraySerializer(), bytearray)
         self._registry.register_constant_serializer(BooleanArraySerializer())
@@ -495,6 +500,22 @@ class SerializerRegistry:
         if serializer is not None:
             self.safe_register_serializer(serializer, obj_type)
         return serializer
+
+    def validate(self):
+        """
+        Makes sure that the classes registered as Compact serializable are not
+        overriding the default serializers.
+
+        Must be called in the constructor of the serialization service after it
+        completes registering default serializers.
+        """
+        for compact_type in self._compact_types:
+            if compact_type in self._constant_type_dict:
+                raise HazelcastSerializationError(
+                    f"Compact serializer for the class {compact_type}' can not be "
+                    f"registered as it overrides the default serializer for that "
+                    f"class provided by Hazelcast."
+                )
 
     def destroy(self):
         for serializer in list(self._type_dict.values()):

--- a/hazelcast/serialization/service.py
+++ b/hazelcast/serialization/service.py
@@ -7,7 +7,7 @@ import uuid
 import typing
 
 from hazelcast.config import IntType, Config
-from hazelcast.errors import HazelcastInstanceNotActiveError
+from hazelcast.errors import HazelcastInstanceNotActiveError, IllegalArgumentError
 from hazelcast.serialization.api import IdentifiedDataSerializable, Portable
 from hazelcast.serialization.compact import (
     SchemaNotFoundError,
@@ -511,7 +511,7 @@ class SerializerRegistry:
         """
         for compact_type in self._compact_types:
             if compact_type in self._constant_type_dict:
-                raise HazelcastSerializationError(
+                raise IllegalArgumentError(
                     f"Compact serializer for the class {compact_type}' can not be "
                     f"registered as it overrides the default serializer for that "
                     f"class provided by Hazelcast."

--- a/tests/unit/serialization/compact_test.py
+++ b/tests/unit/serialization/compact_test.py
@@ -198,6 +198,12 @@ class SchemaWriterTest(unittest.TestCase):
         for name, kind in fields:
             self.assertEqual(kind, schema.fields.get(name).kind)
 
+    def test_schema_writer_with_duplicate_field_names(self):
+        writer = SchemaWriter("foo")
+        writer.write_int32("bar", 42)
+        with self.assertRaisesRegex(HazelcastSerializationError, "already exists"):
+            writer.write_string("bar", "42")
+
 
 class Child:
     def __init__(self, name: str):
@@ -214,7 +220,7 @@ class ChildSerializer(CompactSerializer[Child]):
         name = reader.read_string("name")
         return Child(name)
 
-    def write(self, writer: CompactWriter, obj: Parent):
+    def write(self, writer: CompactWriter, obj: Child):
         writer.write_string("name", obj.name)
 
     def get_type_name(self):
@@ -259,3 +265,51 @@ class NestedSerializerTest(unittest.TestCase):
         ):
             obj = Parent(Child("test"))
             self._serialize(service, obj)
+
+
+class CompactSerializationTest(unittest.TestCase):
+    def test_overriding_default_serializers(self):
+        config = Config()
+        config.compact_serializers = [StringCompactSerializer()]
+
+        with self.assertRaisesRegex(
+            HazelcastSerializationError, "can not be registered as it overrides"
+        ):
+            SerializationServiceV1(config)
+
+    def test_serializer_with_duplicate_field_names(self):
+        config = Config()
+        config.compact_serializers = [SerializerWithDuplicateFieldsNames()]
+
+        service = SerializationServiceV1(config)
+        with self.assertRaisesRegex(HazelcastSerializationError, "already exists"):
+            service.to_data(Child("foo"))
+
+
+class StringCompactSerializer(CompactSerializer[str]):
+    def read(self, reader: CompactReader) -> str:
+        pass
+
+    def write(self, writer: CompactWriter, obj: str) -> None:
+        pass
+
+    def get_class(self) -> typing.Type[str]:
+        return str
+
+    def get_type_name(self) -> str:
+        return "str"
+
+
+class SerializerWithDuplicateFieldsNames(CompactSerializer[Child]):
+    def read(self, reader: CompactReader) -> Child:
+        pass
+
+    def write(self, writer: CompactWriter, obj: Child) -> None:
+        writer.write_string("name", obj.name)
+        writer.write_string("name", obj.name)
+
+    def get_class(self) -> typing.Type[Child]:
+        return Child
+
+    def get_type_name(self) -> str:
+        return "child"

--- a/tests/unit/serialization/compact_test.py
+++ b/tests/unit/serialization/compact_test.py
@@ -6,7 +6,7 @@ import uuid
 from parameterized import parameterized
 
 from hazelcast.config import Config
-from hazelcast.errors import HazelcastSerializationError
+from hazelcast.errors import HazelcastSerializationError, IllegalArgumentError
 from hazelcast.serialization import SerializationServiceV1
 from hazelcast.serialization.api import CompactSerializer, CompactReader, CompactWriter, FieldKind
 from hazelcast.serialization.compact import (
@@ -272,9 +272,7 @@ class CompactSerializationTest(unittest.TestCase):
         config = Config()
         config.compact_serializers = [StringCompactSerializer()]
 
-        with self.assertRaisesRegex(
-            HazelcastSerializationError, "can not be registered as it overrides"
-        ):
+        with self.assertRaisesRegex(IllegalArgumentError, "can not be registered as it overrides"):
             SerializationServiceV1(config)
 
     def test_serializer_with_duplicate_field_names(self):


### PR DESCRIPTION
This PR introduces couple of updates to the implementation

- Schema now holds a regular dict, instead of OrderedDict for faster lookups and simpler implementation
- Prevent duplicate field names by adding a check to the schema writer
- Disallowing compact serializers to override builtin serializer


closes https://github.com/hazelcast/hazelcast-python-client/issues/559
closes https://github.com/hazelcast/hazelcast-python-client/issues/579