### PR TITLE
Send client state to cluster in reconnections [API-1564]

### DIFF
--- a/tests/integration/backward_compatible/serialization/compact_test.py
+++ b/tests/integration/backward_compatible/serialization/compact_test.py
@@ -202,7 +202,7 @@ class CompactTest(CompactTestBase):
             def get_type_name(self) -> str:
                 return SomeFields.__name__
 
-            def get_class(self):
+            def get_class(self) -> typing.Type[SomeFields]:
                 return SomeFields
 
         self._write_then_read0(all_fields, Serializer(list(all_fields.keys())))
@@ -803,7 +803,7 @@ class NestedSerializer(CompactSerializer[Nested]):
     def get_type_name(self) -> str:
         return Nested.__name__
 
-    def get_class(self) -> Nested:
+    def get_class(self) -> typing.Type[Nested]:
         return Nested
 
 
@@ -851,7 +851,7 @@ class SomeFieldsSerializer(CompactSerializer[SomeFields]):
     def get_type_name(self) -> str:
         return SomeFields.__name__
 
-    def get_class(self) -> SomeFields:
+    def get_class(self) -> typing.Type[SomeFields]:
         return SomeFields
 
     @staticmethod

--- a/tests/integration/connection_manager_test.py
+++ b/tests/integration/connection_manager_test.py
@@ -1,3 +1,4 @@
+import threading
 import uuid
 
 from mock import patch
@@ -6,6 +7,7 @@ from hazelcast import HazelcastClient
 from hazelcast.core import Address, MemberInfo, MemberVersion, EndpointQualifier, ProtocolType
 from hazelcast.errors import IllegalStateError, TargetDisconnectedError
 from hazelcast.future import ImmediateFuture, ImmediateExceptionFuture
+from hazelcast.lifecycle import LifecycleState
 from hazelcast.util import AtomicInteger
 from tests.base import HazelcastTestCase, SingleMemberTestCase
 from tests.util import random_string
@@ -180,10 +182,46 @@ class ConnectionManagerOnClusterRestartTest(SingleMemberTestCase):
 
         self.assertEqual(5, counter.get())
 
+    def test_client_state_is_sent_on_reconnection_when_the_cluster_id_is_same(self):
+        disconnected = threading.Event()
+        reconnected = threading.Event()
+
+        def listener(state):
+            if state == LifecycleState.DISCONNECTED:
+                disconnected.set()
+            elif disconnected.is_set() and state == LifecycleState.CONNECTED:
+                reconnected.set()
+
+        self.client.lifecycle_service.add_listener(listener)
+
+        conn_manager = self.client._connection_manager
+        counter = AtomicInteger()
+
+        def send_state_to_cluster_fn():
+            counter.add(1)
+            return ImmediateFuture(None)
+
+        conn_manager._send_state_to_cluster_fn = send_state_to_cluster_fn
+
+        # Keep the cluster alive, but close the connection
+        # to simulate re-connection to a cluster with
+        # the same cluster id.
+        connection = conn_manager.get_random_connection()
+        connection.close_connection("expected", None)
+
+        disconnected.wait()
+        reconnected.wait()
+
+        self._wait_until_state_is_sent()
+
+        self.assertEqual(1, counter.get())
+
     def _restart_cluster(self):
         self.rc.terminateMember(self.cluster.id, self.member.uuid)
         ConnectionManagerOnClusterRestartTest.member = self.cluster.start_member()
+        self._wait_until_state_is_sent()
 
+    def _wait_until_state_is_sent(self):
         # Perform an invocation to wait until the client state is sent
         m = self.client.get_map(random_string()).blocking()
         m.set(1, 1)


### PR DESCRIPTION
In split-brain scenarios, the cluster id stays the same for different halves of the split.

When the client disconnects from the first half it was connected to and reconnects to the other half, from the point of view of the client, it connects to the same cluster.

However, it might very well be the case that, the client has sent some state to the first half of the cluster, and that state must be replicated to the other half when the client reconnects to it.

This is especially needed for Compact schemas.

In this PR, we are sending the client state to the cluster after reconnections, regardless it is connected back to possibly the same cluster with the same id or not.

We couldn't add proper split brain tests, as the remote controller does not have that ability yet. However, I have added a simple test that verifies the current behavior.

closes https://github.com/hazelcast/hazelcast-python-client/issues/575