### PR TITLE
Eagerly deserialize responses consisting of list of data [API-1964]

### DIFF
--- a/docs/serialization.rst
+++ b/docs/serialization.rst
@@ -278,33 +278,6 @@ All of these APIs will work with the Compact serialization format, once it is
 promoted to the stable status.
 
 - Reading OBJECT columns of the SQL results
-- Listening for :class:`hazelcast.proxy.reliable_topic.ReliableTopic` messages
-- :func:`hazelcast.proxy.list.List.iterator`
-- :func:`hazelcast.proxy.list.List.list_iterator`
-- :func:`hazelcast.proxy.list.List.get_all`
-- :func:`hazelcast.proxy.list.List.sub_list`
-- :func:`hazelcast.proxy.map.Map.values`
-- :func:`hazelcast.proxy.map.Map.entry_set`
-- :func:`hazelcast.proxy.map.Map.execute_on_keys`
-- :func:`hazelcast.proxy.map.Map.key_set`
-- :func:`hazelcast.proxy.map.Map.project`
-- :func:`hazelcast.proxy.map.Map.execute_on_entries`
-- :func:`hazelcast.proxy.map.Map.get_all`
-- :func:`hazelcast.proxy.multi_map.MultiMap.remove_all`
-- :func:`hazelcast.proxy.multi_map.MultiMap.key_set`
-- :func:`hazelcast.proxy.multi_map.MultiMap.values`
-- :func:`hazelcast.proxy.multi_map.MultiMap.entry_set`
-- :func:`hazelcast.proxy.multi_map.MultiMap.get`
-- :func:`hazelcast.proxy.queue.Queue.iterator`
-- :func:`hazelcast.proxy.replicated_map.ReplicatedMap.values`
-- :func:`hazelcast.proxy.replicated_map.ReplicatedMap.entry_set`
-- :func:`hazelcast.proxy.replicated_map.ReplicatedMap.key_set`
-- :func:`hazelcast.proxy.set.Set.get_all`
-- :func:`hazelcast.proxy.ringbuffer.Ringbuffer.read_many`
-- :func:`hazelcast.proxy.transactional_map.TransactionalMap.values`
-- :func:`hazelcast.proxy.transactional_map.TransactionalMap.key_set`
-- :func:`hazelcast.proxy.transactional_multi_map.TransactionalMultiMap.get`
-- :func:`hazelcast.proxy.transactional_multi_map.TransactionalMultiMap.remove_all`
 
 IdentifiedDataSerializable Serialization
 ----------------------------------------

--- a/hazelcast/proxy/list.py
+++ b/hazelcast/proxy/list.py
@@ -29,7 +29,7 @@ from hazelcast.protocol.codec import (
 from hazelcast.proxy.base import PartitionSpecificProxy, ItemEvent, ItemEventType
 from hazelcast.types import ItemType
 from hazelcast.serialization.compact import SchemaNotReplicatedError
-from hazelcast.util import check_not_none, ImmutableLazyDataList
+from hazelcast.util import check_not_none, deserialize_list_in_place
 
 
 class List(PartitionSpecificProxy["BlockingList"], typing.Generic[ItemType]):
@@ -247,9 +247,8 @@ class List(PartitionSpecificProxy["BlockingList"], typing.Generic[ItemType]):
         """
 
         def handler(message):
-            return ImmutableLazyDataList(
-                list_get_all_codec.decode_response(message), self._to_object
-            )
+            data_list = list_get_all_codec.decode_response(message)
+            return deserialize_list_in_place(data_list, self._to_object)
 
         request = list_get_all_codec.encode_request(self.name)
         return self._invoke(request, handler)
@@ -263,9 +262,8 @@ class List(PartitionSpecificProxy["BlockingList"], typing.Generic[ItemType]):
         """
 
         def handler(message):
-            return ImmutableLazyDataList(
-                list_iterator_codec.decode_response(message), self._to_object
-            )
+            data_list = list_iterator_codec.decode_response(message)
+            return deserialize_list_in_place(data_list, self._to_object)
 
         request = list_iterator_codec.encode_request(self.name)
         return self._invoke(request, handler)
@@ -337,9 +335,8 @@ class List(PartitionSpecificProxy["BlockingList"], typing.Generic[ItemType]):
         """
 
         def handler(message):
-            return ImmutableLazyDataList(
-                list_list_iterator_codec.decode_response(message), self._to_object
-            )
+            data_list = list_list_iterator_codec.decode_response(message)
+            return deserialize_list_in_place(data_list, self._to_object)
 
         request = list_list_iterator_codec.encode_request(self.name, index)
         return self._invoke(request, handler)
@@ -494,7 +491,8 @@ class List(PartitionSpecificProxy["BlockingList"], typing.Generic[ItemType]):
         """
 
         def handler(message):
-            return ImmutableLazyDataList(list_sub_codec.decode_response(message), self._to_object)
+            data_list = list_sub_codec.decode_response(message)
+            return deserialize_list_in_place(data_list, self._to_object)
 
         request = list_sub_codec.encode_request(self.name, from_index, to_index)
         return self._invoke(request, handler)

--- a/hazelcast/proxy/map.py
+++ b/hazelcast/proxy/map.py
@@ -87,8 +87,9 @@ from hazelcast.util import (
     check_not_none,
     thread_id,
     to_millis,
-    ImmutableLazyDataList,
     IterationType,
+    deserialize_entry_list_in_place,
+    deserialize_list_in_place,
 )
 
 
@@ -563,7 +564,8 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
                     predicate.anchor_list = response["anchor_data_list"].as_anchor_list(
                         self._to_object
                     )
-                    return ImmutableLazyDataList(response["response"], self._to_object)
+                    entry_data_list = response["response"]
+                    return deserialize_entry_list_in_place(entry_data_list, self._to_object)
 
                 request = map_entries_with_paging_predicate_codec.encode_request(self.name, holder)
             else:
@@ -573,17 +575,15 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
                     return self._send_schema_and_retry(e, self.entry_set, predicate)
 
                 def handler(message):
-                    return ImmutableLazyDataList(
-                        map_entries_with_predicate_codec.decode_response(message), self._to_object
-                    )
+                    entry_data_list = map_entries_with_predicate_codec.decode_response(message)
+                    return deserialize_entry_list_in_place(entry_data_list, self._to_object)
 
                 request = map_entries_with_predicate_codec.encode_request(self.name, predicate_data)
         else:
 
             def handler(message):
-                return ImmutableLazyDataList(
-                    map_entry_set_codec.decode_response(message), self._to_object
-                )
+                entry_data_list = map_entry_set_codec.decode_response(message)
+                return deserialize_entry_list_in_place(entry_data_list, self._to_object)
 
             request = map_entry_set_codec.encode_request(self.name)
 
@@ -648,9 +648,8 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
                 )
 
             def handler(message):
-                return ImmutableLazyDataList(
-                    map_execute_with_predicate_codec.decode_response(message), self._to_object
-                )
+                entry_data_list = map_execute_with_predicate_codec.decode_response(message)
+                return deserialize_entry_list_in_place(entry_data_list, self._to_object)
 
             request = map_execute_with_predicate_codec.encode_request(
                 self.name, entry_processor_data, predicate_data
@@ -664,9 +663,8 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
                 )
 
             def handler(message):
-                return ImmutableLazyDataList(
-                    map_execute_on_all_keys_codec.decode_response(message), self._to_object
-                )
+                entry_data_list = map_execute_on_all_keys_codec.decode_response(message)
+                return deserialize_entry_list_in_place(entry_data_list, self._to_object)
 
             request = map_execute_on_all_keys_codec.encode_request(self.name, entry_processor_data)
 
@@ -730,9 +728,8 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
             return self._send_schema_and_retry(e, self.execute_on_keys, keys, entry_processor)
 
         def handler(message):
-            return ImmutableLazyDataList(
-                map_execute_on_keys_codec.decode_response(message), self._to_object
-            )
+            entry_data_list = map_execute_on_keys_codec.decode_response(message)
+            return deserialize_entry_list_in_place(entry_data_list, self._to_object)
 
         request = map_execute_on_keys_codec.encode_request(
             self.name, entry_processor_data, key_list
@@ -943,7 +940,8 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
                     predicate.anchor_list = response["anchor_data_list"].as_anchor_list(
                         self._to_object
                     )
-                    return ImmutableLazyDataList(response["response"], self._to_object)
+                    data_list = response["response"]
+                    return deserialize_list_in_place(data_list, self._to_object)
 
                 request = map_key_set_with_paging_predicate_codec.encode_request(self.name, holder)
             else:
@@ -953,17 +951,15 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
                     return self._send_schema_and_retry(e, self.key_set, predicate)
 
                 def handler(message):
-                    return ImmutableLazyDataList(
-                        map_key_set_with_predicate_codec.decode_response(message), self._to_object
-                    )
+                    data_list = map_key_set_with_predicate_codec.decode_response(message)
+                    return deserialize_list_in_place(data_list, self._to_object)
 
                 request = map_key_set_with_predicate_codec.encode_request(self.name, predicate_data)
         else:
 
             def handler(message):
-                return ImmutableLazyDataList(
-                    map_key_set_codec.decode_response(message), self._to_object
-                )
+                data_list = map_key_set_codec.decode_response(message)
+                return deserialize_list_in_place(data_list, self._to_object)
 
             request = map_key_set_codec.encode_request(self.name)
 
@@ -1067,9 +1063,8 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
                 return self._send_schema_and_retry(e, self.project, projection, predicate)
 
             def handler(message):
-                return ImmutableLazyDataList(
-                    map_project_with_predicate_codec.decode_response(message), self._to_object
-                )
+                data_list = map_project_with_predicate_codec.decode_response(message)
+                return deserialize_list_in_place(data_list, self._to_object)
 
             request = map_project_with_predicate_codec.encode_request(
                 self.name, projection_data, predicate_data
@@ -1081,9 +1076,8 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
                 return self._send_schema_and_retry(e, self.project, projection, predicate)
 
             def handler(message):
-                return ImmutableLazyDataList(
-                    map_project_codec.decode_response(message), self._to_object
-                )
+                data_list = map_project_codec.decode_response(message)
+                return deserialize_list_in_place(data_list, self._to_object)
 
             request = map_project_codec.encode_request(self.name, projection_data)
 
@@ -1652,7 +1646,8 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
                     predicate.anchor_list = response["anchor_data_list"].as_anchor_list(
                         self._to_object
                     )
-                    return ImmutableLazyDataList(response["response"], self._to_object)
+                    data_list = response["response"]
+                    return deserialize_list_in_place(data_list, self._to_object)
 
                 request = map_values_with_paging_predicate_codec.encode_request(self.name, holder)
             else:
@@ -1662,17 +1657,15 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
                     return self._send_schema_and_retry(e, self.values, predicate)
 
                 def handler(message):
-                    return ImmutableLazyDataList(
-                        map_values_with_predicate_codec.decode_response(message), self._to_object
-                    )
+                    data_list = map_values_with_predicate_codec.decode_response(message)
+                    return deserialize_list_in_place(data_list, self._to_object)
 
                 request = map_values_with_predicate_codec.encode_request(self.name, predicate_data)
         else:
 
             def handler(message):
-                return ImmutableLazyDataList(
-                    map_values_codec.decode_response(message), self._to_object
-                )
+                data_list = map_values_codec.decode_response(message)
+                return deserialize_list_in_place(data_list, self._to_object)
 
             request = map_values_codec.encode_request(self.name)
 
@@ -1698,9 +1691,8 @@ class Map(Proxy["BlockingMap"], typing.Generic[KeyType, ValueType]):
             futures = []
 
         def handler(message):
-            return ImmutableLazyDataList(
-                map_get_all_codec.decode_response(message), self._to_object
-            )
+            entry_data_list = map_get_all_codec.decode_response(message)
+            return deserialize_entry_list_in_place(entry_data_list, self._to_object)
 
         for partition_id, key_dict in partition_to_keys.items():
             request = map_get_all_codec.encode_request(self.name, key_dict.values())

--- a/hazelcast/proxy/queue.py
+++ b/hazelcast/proxy/queue.py
@@ -26,7 +26,7 @@ from hazelcast.protocol.codec import (
 from hazelcast.proxy.base import PartitionSpecificProxy, ItemEvent, ItemEventType
 from hazelcast.types import ItemType
 from hazelcast.serialization.compact import SchemaNotReplicatedError
-from hazelcast.util import check_not_none, to_millis, ImmutableLazyDataList
+from hazelcast.util import check_not_none, to_millis, deserialize_list_in_place
 
 
 class Queue(PartitionSpecificProxy["BlockingQueue"], typing.Generic[ItemType]):
@@ -202,9 +202,8 @@ class Queue(PartitionSpecificProxy["BlockingQueue"], typing.Generic[ItemType]):
         """
 
         def handler(message):
-            return ImmutableLazyDataList(
-                queue_iterator_codec.decode_response(message), self._to_object
-            )
+            data_list = queue_iterator_codec.decode_response(message)
+            return deserialize_list_in_place(data_list, self._to_object)
 
         request = queue_iterator_codec.encode_request(self.name)
         return self._invoke(request, handler)

--- a/hazelcast/proxy/reliable_topic.py
+++ b/hazelcast/proxy/reliable_topic.py
@@ -226,7 +226,7 @@ class _MessageRunner:
             result = future.result()
 
             # Check if there are any messages lost since the last read
-            # and whether or not the listener can tolerate that.
+            # and whether the listener can tolerate that.
             lost_count = (result.next_sequence_to_read_from - result.read_count) - self._sequence
             if lost_count != 0 and not self._is_loss_tolerable(lost_count):
                 self.cancel()
@@ -254,7 +254,7 @@ class _MessageRunner:
 
                     topic_message = TopicMessage(
                         self._topic_name,
-                        self._to_object(message.payload),
+                        message.payload,
                         message.publish_time,
                         member,
                     )

--- a/hazelcast/proxy/ringbuffer.py
+++ b/hazelcast/proxy/ringbuffer.py
@@ -131,13 +131,13 @@ class ReadResult(Sequence):
         """
         return self._item_seqs[index]
 
-    def __getitem__(self, index: int):
+    def __getitem__(self, index: typing.Union[int, slice]) -> typing.Any:
         return self._items[index]
 
     def __len__(self) -> int:
         return len(self._items)
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         # This implementation is copied from the
         # now removed super class. It is implemented
         # to maintain backward compatibility.

--- a/hazelcast/proxy/ringbuffer.py
+++ b/hazelcast/proxy/ringbuffer.py
@@ -1,4 +1,5 @@
 import typing
+from collections.abc import Sequence, Iterable
 
 from hazelcast.future import ImmediateFuture, Future
 from hazelcast.protocol.codec import (
@@ -20,7 +21,7 @@ from hazelcast.util import (
     check_not_none,
     check_not_empty,
     check_true,
-    ImmutableLazyDataList,
+    deserialize_list_in_place,
 )
 
 OVERFLOW_POLICY_OVERWRITE = 0
@@ -52,7 +53,7 @@ The maximum number of items to be added to RingBuffer or read from RingBuffer at
 """
 
 
-class ReadResult(ImmutableLazyDataList):
+class ReadResult(Sequence):
     """Defines the result of a :func:`Ringbuffer.read_many` operation."""
 
     SEQUENCE_UNAVAILABLE = -1
@@ -61,11 +62,12 @@ class ReadResult(ImmutableLazyDataList):
     members not returning the sequence).
     """
 
-    def __init__(self, read_count, next_seq, items, item_seqs, to_object):
-        super(ReadResult, self).__init__(items, to_object)
+    def __init__(self, read_count, next_seq, item_seqs, items):
+        super(ReadResult, self).__init__()
         self._read_count = read_count
         self._next_seq = next_seq
         self._item_seqs = item_seqs
+        self._items = items
 
     @property
     def read_count(self) -> int:
@@ -90,7 +92,7 @@ class ReadResult(ImmutableLazyDataList):
         See Also:
             :attr:`read_count`
         """
-        return len(self._list_data)
+        return len(self._items)
 
     @property
     def next_sequence_to_read_from(self) -> int:
@@ -128,6 +130,21 @@ class ReadResult(ImmutableLazyDataList):
             The sequence number for the ringbuffer item.
         """
         return self._item_seqs[index]
+
+    def __getitem__(self, index: int):
+        return self._items[index]
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def __eq__(self, other):
+        # This implementation is copied from the
+        # now removed super class. It is implemented
+        # to maintain backward compatibility.
+        if not isinstance(other, Iterable):
+            return False
+
+        return self._items == other
 
 
 class Ringbuffer(PartitionSpecificProxy["BlockingRingbuffer"], typing.Generic[ItemType]):
@@ -379,12 +396,12 @@ class Ringbuffer(PartitionSpecificProxy["BlockingRingbuffer"], typing.Generic[It
 
         def handler(message):
             response = ringbuffer_read_many_codec.decode_response(message)
+            items = deserialize_list_in_place(response["items"], self._to_object)
             read_count = response["read_count"]
             next_seq = response["next_seq"]
-            items = response["items"]
             item_seqs = response["item_seqs"]
 
-            return ReadResult(read_count, next_seq, items, item_seqs, self._to_object)
+            return ReadResult(read_count, next_seq, item_seqs, items)
 
         def continuation(future):
             # Since the first call to capacity

--- a/hazelcast/proxy/set.py
+++ b/hazelcast/proxy/set.py
@@ -20,7 +20,7 @@ from hazelcast.protocol.codec import (
 from hazelcast.proxy.base import PartitionSpecificProxy, ItemEvent, ItemEventType
 from hazelcast.types import ItemType
 from hazelcast.serialization.compact import SchemaNotReplicatedError
-from hazelcast.util import check_not_none, ImmutableLazyDataList
+from hazelcast.util import check_not_none, deserialize_list_in_place
 
 
 class Set(PartitionSpecificProxy, typing.Generic[ItemType]):
@@ -164,9 +164,8 @@ class Set(PartitionSpecificProxy, typing.Generic[ItemType]):
         """
 
         def handler(message):
-            return ImmutableLazyDataList(
-                set_get_all_codec.decode_response(message), self._to_object
-            )
+            data_list = set_get_all_codec.decode_response(message)
+            return deserialize_list_in_place(data_list, self._to_object)
 
         request = set_get_all_codec.encode_request(self.name)
         return self._invoke(request, handler)

--- a/hazelcast/proxy/transactional_map.py
+++ b/hazelcast/proxy/transactional_map.py
@@ -23,7 +23,7 @@ from hazelcast.protocol.codec import (
 from hazelcast.proxy.base import TransactionalProxy
 from hazelcast.types import ValueType, KeyType
 from hazelcast.serialization.compact import SchemaNotReplicatedError
-from hazelcast.util import check_not_none, to_millis, thread_id, ImmutableLazyDataList
+from hazelcast.util import check_not_none, to_millis, thread_id, deserialize_list_in_place
 
 
 class TransactionalMap(TransactionalProxy, typing.Generic[KeyType, ValueType]):
@@ -383,10 +383,8 @@ class TransactionalMap(TransactionalProxy, typing.Generic[KeyType, ValueType]):
                 return self.key_set(predicate)
 
             def handler(message):
-                return ImmutableLazyDataList(
-                    transactional_map_key_set_with_predicate_codec.decode_response(message),
-                    self._to_object,
-                )
+                data_list = transactional_map_key_set_with_predicate_codec.decode_response(message)
+                return deserialize_list_in_place(data_list, self._to_object)
 
             request = transactional_map_key_set_with_predicate_codec.encode_request(
                 self.name, self.transaction.id, thread_id(), predicate_data
@@ -394,9 +392,8 @@ class TransactionalMap(TransactionalProxy, typing.Generic[KeyType, ValueType]):
         else:
 
             def handler(message):
-                return ImmutableLazyDataList(
-                    transactional_map_key_set_codec.decode_response(message), self._to_object
-                )
+                data_list = transactional_map_key_set_codec.decode_response(message)
+                return deserialize_list_in_place(data_list, self._to_object)
 
             request = transactional_map_key_set_codec.encode_request(
                 self.name, self.transaction.id, thread_id()
@@ -422,10 +419,8 @@ class TransactionalMap(TransactionalProxy, typing.Generic[KeyType, ValueType]):
                 return self.values(predicate)
 
             def handler(message):
-                return ImmutableLazyDataList(
-                    transactional_map_values_with_predicate_codec.decode_response(message),
-                    self._to_object,
-                )
+                data_list = transactional_map_values_with_predicate_codec.decode_response(message)
+                return deserialize_list_in_place(data_list, self._to_object)
 
             request = transactional_map_values_with_predicate_codec.encode_request(
                 self.name, self.transaction.id, thread_id(), predicate_data
@@ -433,9 +428,8 @@ class TransactionalMap(TransactionalProxy, typing.Generic[KeyType, ValueType]):
         else:
 
             def handler(message):
-                return ImmutableLazyDataList(
-                    transactional_map_values_codec.decode_response(message), self._to_object
-                )
+                data_list = transactional_map_values_codec.decode_response(message)
+                return deserialize_list_in_place(data_list, self._to_object)
 
             request = transactional_map_values_codec.encode_request(
                 self.name, self.transaction.id, thread_id()

--- a/hazelcast/proxy/transactional_multi_map.py
+++ b/hazelcast/proxy/transactional_multi_map.py
@@ -11,7 +11,7 @@ from hazelcast.protocol.codec import (
 from hazelcast.proxy.base import TransactionalProxy
 from hazelcast.types import KeyType, ValueType
 from hazelcast.serialization.compact import SchemaNotReplicatedError
-from hazelcast.util import check_not_none, thread_id, ImmutableLazyDataList
+from hazelcast.util import check_not_none, thread_id, deserialize_list_in_place
 
 
 class TransactionalMultiMap(TransactionalProxy, typing.Generic[KeyType, ValueType]):
@@ -64,9 +64,8 @@ class TransactionalMultiMap(TransactionalProxy, typing.Generic[KeyType, ValueTyp
             return self.get(key)
 
         def handler(message):
-            return ImmutableLazyDataList(
-                transactional_multi_map_get_codec.decode_response(message), self._to_object
-            )
+            data_list = transactional_multi_map_get_codec.decode_response(message)
+            return deserialize_list_in_place(data_list, self._to_object)
 
         request = transactional_multi_map_get_codec.encode_request(
             self.name, self.transaction.id, thread_id(), key_data
@@ -116,9 +115,8 @@ class TransactionalMultiMap(TransactionalProxy, typing.Generic[KeyType, ValueTyp
             return self.remove_all(key)
 
         def handler(message):
-            return ImmutableLazyDataList(
-                transactional_multi_map_remove_codec.decode_response(message), self._to_object
-            )
+            data_list = transactional_multi_map_remove_codec.decode_response(message)
+            return deserialize_list_in_place(data_list, self._to_object)
 
         request = transactional_multi_map_remove_codec.encode_request(
             self.name, self.transaction.id, thread_id(), key_data

--- a/hazelcast/serialization/service.py
+++ b/hazelcast/serialization/service.py
@@ -220,11 +220,12 @@ class SerializationServiceV1:
     def compact_stream_serializer(self) -> CompactStreamSerializer:
         return self._compact_stream_serializer
 
-    @staticmethod
-    def _get_builtin_identified_factories():
+    def _get_builtin_identified_factories(self):
         return {
             ReliableTopicMessage.FACTORY_ID: {
-                ReliableTopicMessage.CLASS_ID: ReliableTopicMessage,
+                ReliableTopicMessage.CLASS_ID: lambda: ReliableTopicMessage(
+                    serialization_service=self
+                ),
             },
             CanonicalizingHashSet.FACTORY_ID: {
                 CanonicalizingHashSet.CLASS_ID: CanonicalizingHashSet,

--- a/hazelcast/util.py
+++ b/hazelcast/util.py
@@ -1,12 +1,13 @@
 import random
 import threading
 import time
+import typing
 import uuid
-
-from collections.abc import Sequence, Iterable
 
 from hazelcast.serialization import UUID_MSB_SHIFT, UUID_LSB_MASK, UUID_MSB_MASK
 
+if typing.TYPE_CHECKING:
+    from hazelcast.serialization.data import Data
 
 DEFAULT_ADDRESS = "127.0.0.1"
 DEFAULT_PORT = 5701
@@ -135,14 +136,19 @@ def get_portable_version(portable, default_version):
     return version
 
 
-def deserialize_list_in_place(data_list, to_object_fn):
+def deserialize_list_in_place(
+    data_list: typing.List["Data"], to_object_fn: typing.Callable[["Data"], typing.Any]
+) -> typing.List:
     for i in range(len(data_list)):
         data_list[i] = to_object_fn(data_list[i])
 
     return data_list
 
 
-def deserialize_entry_list_in_place(entry_data_list, to_object_fn):
+def deserialize_entry_list_in_place(
+    entry_data_list: typing.List[typing.Tuple["Data", "Data"]],
+    to_object_fn: typing.Callable[["Data"], typing.Any],
+) -> typing.List[typing.Tuple[typing.Any, typing.Any]]:
     for i in range(len(entry_data_list)):
         item = entry_data_list[i]
         entry_data_list[i] = (to_object_fn(item[0]), to_object_fn(item[1]))

--- a/hazelcast/util.py
+++ b/hazelcast/util.py
@@ -124,46 +124,6 @@ class AtomicInteger:
             self._counter += count
 
 
-class ImmutableLazyDataList(Sequence):
-    def __init__(self, list_data, to_object):
-        super(ImmutableLazyDataList, self).__init__()
-        self._list_data = list_data
-        self._list_obj = [None] * len(self._list_data)
-        self.to_object = to_object
-
-    def __contains__(self, value):
-        return super(ImmutableLazyDataList, self).__contains__(value)
-
-    def __len__(self):
-        return self._list_data.__len__()
-
-    def __getitem__(self, index):
-        val = self._list_obj[index]
-        if not val:
-            data = self._list_data[index]
-            if isinstance(data, tuple):
-                (key, value) = data
-                self._list_obj[index] = (self.to_object(key), self.to_object(value))
-            else:
-                self._list_obj[index] = self.to_object(data)
-        return self._list_obj[index]
-
-    def __eq__(self, other):
-        if not isinstance(other, Iterable):
-            return False
-        self._populate()
-        return self._list_obj == other
-
-    def _populate(self):
-        for index, data in enumerate(self._list_data):
-            if not self._list_obj[index]:
-                self.__getitem__(index)
-
-    def __repr__(self):
-        self._populate()
-        return str(self._list_obj)
-
-
 # Serialization Utilities
 
 
@@ -173,6 +133,21 @@ def get_portable_version(portable, default_version):
     except AttributeError:
         version = default_version
     return version
+
+
+def deserialize_list_in_place(data_list, to_object_fn):
+    for i in range(len(data_list)):
+        data_list[i] = to_object_fn(data_list[i])
+
+    return data_list
+
+
+def deserialize_entry_list_in_place(entry_data_list, to_object_fn):
+    for i in range(len(entry_data_list)):
+        item = entry_data_list[i]
+        entry_data_list[i] = (to_object_fn(item[0]), to_object_fn(item[1]))
+
+    return entry_data_list
 
 
 # Version utilities

--- a/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
+++ b/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
@@ -509,15 +509,31 @@ class ListCompactCompatibilityTest(CompactCompatibilityBase):
         self._add_from_another_client(OUTER_COMPACT_INSTANCE)
         self.assertEqual(OUTER_COMPACT_INSTANCE, self.list.get(0))
 
+    def test_get_all(self):
+        self._add_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self.assertEqual([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE], self.list.get_all())
+
     def test_index_of(self):
         self.assertEqual(-1, self.list.index_of(OUTER_COMPACT_INSTANCE))
         self.list.add(OUTER_COMPACT_INSTANCE)
         self.assertEqual(0, self.list.index_of(OUTER_COMPACT_INSTANCE))
 
+    def test_iterator(self):
+        self._add_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self.assertEqual([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE], self.list.iterator())
+
     def test_last_index_of(self):
         self.assertEqual(-1, self.list.last_index_of(OUTER_COMPACT_INSTANCE))
         self.list.add(OUTER_COMPACT_INSTANCE)
         self.assertEqual(0, self.list.last_index_of(OUTER_COMPACT_INSTANCE))
+
+    def test_list_iterator(self):
+        self._add_from_another_client(
+            INNER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE
+        )
+        self.assertEqual(
+            [INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE], self.list.list_iterator(1)
+        )
 
     def test_remove(self):
         self.assertFalse(self.list.remove(OUTER_COMPACT_INSTANCE))
@@ -545,10 +561,19 @@ class ListCompactCompatibilityTest(CompactCompatibilityBase):
         self.assertEqual(42, self.list.set_at(0, OUTER_COMPACT_INSTANCE))
         self.assertEqual(OUTER_COMPACT_INSTANCE, self.list.set_at(0, INNER_COMPACT_INSTANCE))
 
-    def _add_from_another_client(self, value):
+    def test_sublist(self):
+        self._add_from_another_client(
+            INNER_COMPACT_INSTANCE,
+            INNER_COMPACT_INSTANCE,
+            OUTER_COMPACT_INSTANCE,
+            OUTER_COMPACT_INSTANCE,
+        )
+        self.assertEqual([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE], self.list.sub_list(1, 3))
+
+    def _add_from_another_client(self, *values):
         other_client = self.create_client(self.client_config)
         other_client_list = other_client.get_list(self.list.name).blocking()
-        other_client_list.add(value)
+        other_client_list.add_all(values)
 
 
 class MapCompatibilityTest(CompactCompatibilityBase):
@@ -635,21 +660,21 @@ class MapCompatibilityTest(CompactCompatibilityBase):
         self.map.delete(OUTER_COMPACT_INSTANCE)
         self.assertIsNone(self.map.get(OUTER_COMPACT_INSTANCE))
 
+    def test_entry_set(self):
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self.assertEqual([(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)], self.map.entry_set())
+
     def test_entry_set_with_predicate(self):
-        # Put an entry from the same client to register these schemas
-        # to its local registry, so that the lazy-deserialization works.
-        self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         self.assertEqual(
-            [(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)],
+            [(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)],
             self.map.entry_set(CompactPredicate()),
         )
 
     def test_entry_set_with_paging_predicate(self):
-        # Put an entry from the same client to register these schemas
-        # to its local registry, so that the lazy-deserialization works.
-        self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         self.assertEqual(
-            [(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)],
+            [(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)],
             self.map.entry_set(paging(CompactPredicate(), 1)),
         )
 
@@ -659,16 +684,16 @@ class MapCompatibilityTest(CompactCompatibilityBase):
         self.assertTrue(self.map.evict(OUTER_COMPACT_INSTANCE))
 
     def test_execute_on_entries(self):
-        self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         self.assertEqual(
-            [(OUTER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)],
+            [(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)],
             self.map.execute_on_entries(CompactReturningEntryProcessor()),
         )
 
     def test_execute_on_entries_predicate(self):
-        self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         self.assertEqual(
-            [(OUTER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)],
+            [(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)],
             self.map.execute_on_entries(CompactReturningEntryProcessor(), CompactPredicate()),
         )
 
@@ -680,10 +705,10 @@ class MapCompatibilityTest(CompactCompatibilityBase):
         )
 
     def test_execute_on_keys(self):
-        self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         self.assertEqual(
-            [(OUTER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)],
-            self.map.execute_on_keys([OUTER_COMPACT_INSTANCE], CompactReturningEntryProcessor()),
+            [(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)],
+            self.map.execute_on_keys([INNER_COMPACT_INSTANCE], CompactReturningEntryProcessor()),
         )
 
     def test_force_unlock(self):
@@ -697,12 +722,10 @@ class MapCompatibilityTest(CompactCompatibilityBase):
         self.assertEqual(INNER_COMPACT_INSTANCE, self.map.get(OUTER_COMPACT_INSTANCE))
 
     def test_get_all(self):
-        # Put an entry from the same client to register these schemas
-        # to its local registry, so that the lazy-deserialization works.
-        self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         self.assertEqual(
-            {OUTER_COMPACT_INSTANCE: INNER_COMPACT_INSTANCE},
-            self.map.get_all([OUTER_COMPACT_INSTANCE]),
+            {INNER_COMPACT_INSTANCE: OUTER_COMPACT_INSTANCE},
+            self.map.get_all([INNER_COMPACT_INSTANCE]),
         )
 
     def test_get_entry_view(self):
@@ -716,19 +739,19 @@ class MapCompatibilityTest(CompactCompatibilityBase):
         self.map.lock(OUTER_COMPACT_INSTANCE)
         self.assertTrue(self.map.is_locked(OUTER_COMPACT_INSTANCE))
 
+    def test_key_set(self):
+        self._put_from_another_client(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self.assertEqual([OUTER_COMPACT_INSTANCE], self.map.key_set())
+
     def test_key_set_with_predicate(self):
-        # Put an entry from the same client to register these schemas
-        # to its local registry, so that the lazy-deserialization works.
-        self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self._put_from_another_client(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
         self.assertEqual(
             [OUTER_COMPACT_INSTANCE],
             self.map.key_set(CompactPredicate()),
         )
 
     def test_key_set_with_paging_predicate(self):
-        # Put an entry from the same client to register these schemas
-        # to its local registry, so that the lazy-deserialization works.
-        self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self._put_from_another_client(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
         self.assertEqual(
             [OUTER_COMPACT_INSTANCE],
             self.map.key_set(paging(CompactPredicate(), 1)),
@@ -752,18 +775,14 @@ class MapCompatibilityTest(CompactCompatibilityBase):
         self.assertTrue(self.map.is_locked(OUTER_COMPACT_INSTANCE))
 
     def test_project(self):
-        # Put an entry from the same client to register these schemas
-        # to its local registry, so that the lazy-deserialization works.
-        self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         self.assertEqual(
             [OUTER_COMPACT_INSTANCE],
             self.map.project(CompactReturningProjection()),
         )
 
     def test_project_with_predicate(self):
-        # Put an entry from the same client to register these schemas
-        # to its local registry, so that the lazy-deserialization works.
-        self.map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         self.assertEqual(
             [OUTER_COMPACT_INSTANCE],
             self.map.project(CompactReturningProjection(), CompactPredicate()),
@@ -854,16 +873,16 @@ class MapCompatibilityTest(CompactCompatibilityBase):
             # of key to the server.
             pass
 
+    def test_values(self):
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self.assertEqual([OUTER_COMPACT_INSTANCE], self.map.values())
+
     def test_values_with_predicate(self):
-        # Put an entry from the same client to register these schemas
-        # to its local registry, so that the lazy-deserialization works.
-        self.map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         self.assertEqual([OUTER_COMPACT_INSTANCE], self.map.values(CompactPredicate()))
 
     def test_values_with_paging_predicate(self):
-        # Put an entry from the same client to register these schemas
-        # to its local registry, so that the lazy-deserialization works.
-        self.map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         self.assertEqual([OUTER_COMPACT_INSTANCE], self.map.values(paging(CompactPredicate(), 1)))
 
     def _put_from_another_client(self, key, value):
@@ -958,10 +977,15 @@ class MultiMapCompactCompatibilityTest(CompactCompatibilityBase):
             self.multi_map.contains_entry(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         )
 
+    def test_entry_set(self):
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self.assertEqual(
+            [(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)], self.multi_map.entry_set()
+        )
+
     def test_get(self):
-        self.assertEqual([], self.multi_map.get(OUTER_COMPACT_INSTANCE))
-        self.multi_map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
-        self.assertEqual([INNER_COMPACT_INSTANCE], self.multi_map.get(OUTER_COMPACT_INSTANCE))
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self.assertEqual([OUTER_COMPACT_INSTANCE], self.multi_map.get(INNER_COMPACT_INSTANCE))
 
     def test_is_locked(self):
         self.assertFalse(self.multi_map.is_locked(OUTER_COMPACT_INSTANCE))
@@ -978,16 +1002,19 @@ class MultiMapCompactCompatibilityTest(CompactCompatibilityBase):
         self.multi_map.lock(OUTER_COMPACT_INSTANCE)
         self.assertTrue(self.multi_map.is_locked(OUTER_COMPACT_INSTANCE))
 
+    def test_key_set(self):
+        self._put_from_another_client(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self.assertEqual([OUTER_COMPACT_INSTANCE], self.multi_map.key_set())
+
     def test_remove(self):
         self.assertFalse(self.multi_map.remove(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
         self.multi_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         self.assertTrue(self.multi_map.remove(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
 
     def test_remove_all(self):
-        self.assertEqual([], self.multi_map.remove_all(OUTER_COMPACT_INSTANCE))
-        self.multi_map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         self.assertEqual(
-            [INNER_COMPACT_INSTANCE], self.multi_map.remove_all(OUTER_COMPACT_INSTANCE)
+            [OUTER_COMPACT_INSTANCE], self.multi_map.remove_all(INNER_COMPACT_INSTANCE)
         )
 
     def test_put(self):
@@ -1017,6 +1044,10 @@ class MultiMapCompactCompatibilityTest(CompactCompatibilityBase):
             # that we can send the serialized form
             # of key to the server.
             pass
+
+    def test_values(self):
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self.assertEqual([OUTER_COMPACT_INSTANCE], self.multi_map.values())
 
     def _assert_entry_event(self, events):
         self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
@@ -1085,10 +1116,13 @@ class QueueCompactCompatibilityTest(CompactCompatibilityBase):
 
     def test_drain_to(self):
         target = []
-        self._add_from_another_client(INNER_COMPACT_INSTANCE)
-        self._add_from_another_client(OUTER_COMPACT_INSTANCE)
+        self._add_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         self.assertEqual(2, self.queue.drain_to(target))
         self.assertEqual([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE], target)
+
+    def test_iterator(self):
+        self._add_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self.assertEqual([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE], self.queue.iterator())
 
     def test_offer(self):
         self.assertTrue(self.queue.offer(OUTER_COMPACT_INSTANCE))
@@ -1126,10 +1160,10 @@ class QueueCompactCompatibilityTest(CompactCompatibilityBase):
         self._add_from_another_client(OUTER_COMPACT_INSTANCE)
         self.assertEqual(OUTER_COMPACT_INSTANCE, self.queue.take())
 
-    def _add_from_another_client(self, item):
+    def _add_from_another_client(self, *items):
         other_client = self.create_client(self.client_config)
         other_client_queue = other_client.get_queue(self.queue.name).blocking()
-        other_client_queue.add(item)
+        other_client_queue.add_all(items)
 
 
 class ReliableTopicCompactCompatibilityTest(CompactCompatibilityBase):
@@ -1140,6 +1174,23 @@ class ReliableTopicCompactCompatibilityTest(CompactCompatibilityBase):
     def tearDown(self) -> None:
         self.reliable_topic.destroy()
         super().tearDown()
+
+    def test_add_listener(self):
+        messages = []
+
+        def listener(message):
+            messages.append(message)
+
+        self.reliable_topic.add_listener(listener)
+
+        self._publish_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+
+        def assertion():
+            self.assertEqual(2, len(messages))
+            self.assertEqual(INNER_COMPACT_INSTANCE, messages[0].message)
+            self.assertEqual(OUTER_COMPACT_INSTANCE, messages[1].message)
+
+        self.assertTrueEventually(assertion)
 
     def test_publish(self):
         messages = []
@@ -1174,6 +1225,13 @@ class ReliableTopicCompactCompatibilityTest(CompactCompatibilityBase):
             self.assertEqual(OUTER_COMPACT_INSTANCE, messages[1].message)
 
         self.assertTrueEventually(assertion)
+
+    def _publish_from_another_client(self, *messages):
+        other_client = self.create_client(self.client_config)
+        other_client_reliable_topic = other_client.get_reliable_topic(
+            self.reliable_topic.name
+        ).blocking()
+        other_client_reliable_topic.publish_all(messages)
 
 
 class ReplicatedMapCompactCompatibilityTest(CompactCompatibilityBase):
@@ -1234,10 +1292,20 @@ class ReplicatedMapCompactCompatibilityTest(CompactCompatibilityBase):
         self.replicated_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         self.assertTrue(self.replicated_map.contains_value(OUTER_COMPACT_INSTANCE))
 
+    def test_entry_set(self):
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self.assertEqual(
+            [(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)], self.replicated_map.entry_set()
+        )
+
     def test_get(self):
         self.assertIsNone(self.replicated_map.get(OUTER_COMPACT_INSTANCE))
         self.replicated_map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
         self.assertEqual(INNER_COMPACT_INSTANCE, self.replicated_map.get(OUTER_COMPACT_INSTANCE))
+
+    def test_key_set(self):
+        self._put_from_another_client(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self.assertEqual([OUTER_COMPACT_INSTANCE], self.replicated_map.key_set())
 
     def test_put(self):
         self.assertIsNone(self.replicated_map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE))
@@ -1261,6 +1329,10 @@ class ReplicatedMapCompactCompatibilityTest(CompactCompatibilityBase):
         self.assertIsNone(self.replicated_map.remove(OUTER_COMPACT_INSTANCE))
         self.replicated_map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
         self.assertEqual(INNER_COMPACT_INSTANCE, self.replicated_map.remove(OUTER_COMPACT_INSTANCE))
+
+    def test_values(self):
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self.assertEqual([OUTER_COMPACT_INSTANCE], self.replicated_map.values())
 
     def _assert_entry_event(self, events):
         self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
@@ -1307,19 +1379,24 @@ class RingbufferCompactCompatibilityTest(CompactCompatibilityBase):
         self._add_from_another_client(OUTER_COMPACT_INSTANCE)
         self.assertEqual(OUTER_COMPACT_INSTANCE, self.ringbuffer.read_one(0))
 
-    def test_read_many_with_filter(self):
-        # Add an item from the same client to register these schemas
-        # to its local registry, so that the lazy-deserialization works.
-        self.ringbuffer.add(OUTER_COMPACT_INSTANCE)
+    def test_read_many(self):
+        self._add_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         self.assertEqual(
-            [OUTER_COMPACT_INSTANCE],
-            self.ringbuffer.read_many(0, 0, 1, filter=CompactFilter()),
+            [INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE],
+            self.ringbuffer.read_many(0, 0, 2),
         )
 
-    def _add_from_another_client(self, item):
+    def test_read_many_with_filter(self):
+        self._add_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self.assertEqual(
+            [INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE],
+            self.ringbuffer.read_many(0, 0, 2, filter=CompactFilter()),
+        )
+
+    def _add_from_another_client(self, *items):
         other_client = self.create_client(self.client_config)
         other_client_ringbuffer = other_client.get_ringbuffer(self.ringbuffer.name).blocking()
-        other_client_ringbuffer.add(item)
+        other_client_ringbuffer.add_all(items)
 
 
 class SetCompactCompatibilityTest(CompactCompatibilityBase):
@@ -1367,6 +1444,10 @@ class SetCompactCompatibilityTest(CompactCompatibilityBase):
         self.set.add_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE])
         self.assertTrue(self.set.contains_all([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE]))
 
+    def test_get_all(self):
+        self._add_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self.assertCountEqual([INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE], self.set.get_all())
+
     def test_remove(self):
         self.assertFalse(self.set.remove(OUTER_COMPACT_INSTANCE))
         self.set.add(OUTER_COMPACT_INSTANCE)
@@ -1383,10 +1464,10 @@ class SetCompactCompatibilityTest(CompactCompatibilityBase):
         self.set.add_all(items + ["x"])
         self.assertTrue(self.set.retain_all(items))
 
-    def _add_from_another_client(self, item):
+    def _add_from_another_client(self, *items):
         other_client = self.create_client(self.client_config)
         other_client_set = other_client.get_set(self.set.name).blocking()
-        other_client_set.add(item)
+        other_client_set.add_all(items)
 
 
 class TopicCompactCompatibilityTest(CompactCompatibilityBase):
@@ -1574,16 +1655,28 @@ class TransactionalMapCompactCompatibilityTest(CompactCompatibilityBase):
 
         self.assertTrue(self.map.is_empty())
 
+    def test_key_set(self):
+        self._put_from_another_client(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        with self.transaction:
+            transactional_map = self._get_transactional_map()
+            self.assertEqual([OUTER_COMPACT_INSTANCE], transactional_map.key_set())
+
     def test_key_set_with_predicate(self):
-        self.map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self._put_from_another_client(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
         with self.transaction:
             transactional_map = self._get_transactional_map()
             self.assertEqual(
-                [INNER_COMPACT_INSTANCE], transactional_map.key_set(CompactPredicate())
+                [OUTER_COMPACT_INSTANCE], transactional_map.key_set(CompactPredicate())
             )
 
+    def test_values(self):
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        with self.transaction:
+            transactional_map = self._get_transactional_map()
+            self.assertEqual([OUTER_COMPACT_INSTANCE], transactional_map.values())
+
     def test_values_with_predicate(self):
-        self.map.put(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         with self.transaction:
             transactional_map = self._get_transactional_map()
             self.assertEqual([OUTER_COMPACT_INSTANCE], transactional_map.values(CompactPredicate()))
@@ -1616,13 +1709,11 @@ class TransactionalMultiMapCompactCompatibilityTest(CompactCompatibilityBase):
             )
 
     def test_get(self):
-        # Put an entry from the same client to register these schemas
-        # to its local registry, so that the lazy-deserialization works.
-        self.multi_map.put(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         with self.transaction:
             transactional_multi_map = self._get_transactional_multi_map()
             self.assertEqual(
-                [INNER_COMPACT_INSTANCE], transactional_multi_map.get(OUTER_COMPACT_INSTANCE)
+                [OUTER_COMPACT_INSTANCE], transactional_multi_map.get(INNER_COMPACT_INSTANCE)
             )
 
     def test_remove(self):
@@ -1634,11 +1725,11 @@ class TransactionalMultiMapCompactCompatibilityTest(CompactCompatibilityBase):
             )
 
     def test_remove_all(self):
-        self._put_from_another_client(OUTER_COMPACT_INSTANCE, INNER_COMPACT_INSTANCE)
+        self._put_from_another_client(INNER_COMPACT_INSTANCE, OUTER_COMPACT_INSTANCE)
         with self.transaction:
             transactional_multi_map = self._get_transactional_multi_map()
             self.assertEqual(
-                [INNER_COMPACT_INSTANCE], transactional_multi_map.remove_all(OUTER_COMPACT_INSTANCE)
+                [OUTER_COMPACT_INSTANCE], transactional_multi_map.remove_all(INNER_COMPACT_INSTANCE)
             )
 
     def test_value_count(self):


### PR DESCRIPTION
We were performing lazy deserialization on APIs that return a list of data, such as map#values(). This was not going to work with Compact, as after returning the list to the user, there might be Compact serialized data on the list which we don't have the schema on the client yet. If it was a normal response, the client would have fetched the schema, but it is not possible with these lazy APIs. We perform the deserialization while getting the list items and this is a sync API. We can't perform a blocking call there, because there is a chance that this will be executed in the reactor thread, which would result in a deadlock.

So, the only possible way of making these APIs work with Compact is to convert them to eager deserialization.

This PR removes lazy deserialization in everything apart from SQL, which will be handled in another PR.