### PR TITLE
Eagerly deserialize SQL columns of type OBJECT [API-1964]

### DIFF
--- a/docs/serialization.rst
+++ b/docs/serialization.rst
@@ -267,18 +267,6 @@ depending on the object in that method might result in an undefined behavior.
 Additionally, evolved serializers must have the same type name with the
 initial version of the serializer.
 
-Limitations
-~~~~~~~~~~~
-
-Currently, the following APIs are not fully supported with the Compact
-serialization format. They may or may not work, depending on whether the
-schema is available on the client or not.
-
-All of these APIs will work with the Compact serialization format, once it is
-promoted to the stable status.
-
-- Reading OBJECT columns of the SQL results
-
 IdentifiedDataSerializable Serialization
 ----------------------------------------
 

--- a/hazelcast/protocol/codec/sql_execute_codec.py
+++ b/hazelcast/protocol/codec/sql_execute_codec.py
@@ -36,11 +36,11 @@ def encode_request(sql, parameters, timeout_millis, cursor_buffer_size, schema, 
     return OutboundMessage(buf, False)
 
 
-def decode_response(msg):
+def decode_response(msg, to_object_fn):
     initial_frame = msg.next_frame()
     response = dict()
     response["update_count"] = FixSizedTypesCodec.decode_long(initial_frame.buf, _RESPONSE_UPDATE_COUNT_OFFSET)
     response["row_metadata"] = ListMultiFrameCodec.decode_nullable(msg, SqlColumnMetadataCodec.decode)
-    response["row_page"] = CodecUtil.decode_nullable(msg, SqlPageCodec.decode)
+    response["row_page"] = CodecUtil.decode_nullable(msg, lambda m: SqlPageCodec.decode(m, to_object_fn))
     response["error"] = CodecUtil.decode_nullable(msg, SqlErrorCodec.decode)
     return response

--- a/hazelcast/protocol/codec/sql_fetch_codec.py
+++ b/hazelcast/protocol/codec/sql_fetch_codec.py
@@ -22,9 +22,9 @@ def encode_request(query_id, cursor_buffer_size):
     return OutboundMessage(buf, False)
 
 
-def decode_response(msg):
+def decode_response(msg, to_object_fn):
     msg.next_frame()
     response = dict()
-    response["row_page"] = CodecUtil.decode_nullable(msg, SqlPageCodec.decode)
+    response["row_page"] = CodecUtil.decode_nullable(msg, lambda m: SqlPageCodec.decode(m, to_object_fn))
     response["error"] = CodecUtil.decode_nullable(msg, SqlErrorCodec.decode)
     return response

--- a/hazelcast/serialization/portable/serializer.py
+++ b/hazelcast/serialization/portable/serializer.py
@@ -54,13 +54,13 @@ class PortableSerializer(StreamSerializer):
 
     def create_new_portable_instance(self, factory_id, class_id):
         portable_factory = self._portable_factories.get(factory_id)
-        if not portable_factory:
+        if portable_factory is None:
             raise HazelcastSerializationError(
                 "Could not find portable_factory for factory-id: %s" % factory_id
             )
 
         portable = portable_factory.get(class_id)
-        if not portable:
+        if portable is None:
             raise HazelcastSerializationError(
                 "Could not create Portable for class-id: %s" % class_id
             )

--- a/hazelcast/serialization/portable/serializer.py
+++ b/hazelcast/serialization/portable/serializer.py
@@ -53,18 +53,18 @@ class PortableSerializer(StreamSerializer):
         return current_version
 
     def create_new_portable_instance(self, factory_id, class_id):
-        try:
-            portable_factory = self._portable_factories[factory_id]
-        except KeyError:
+        portable_factory = self._portable_factories.get(factory_id)
+        if not portable_factory:
             raise HazelcastSerializationError(
                 "Could not find portable_factory for factory-id: %s" % factory_id
             )
 
-        portable = portable_factory[class_id]
-        if portable is None:
+        portable = portable_factory.get(class_id)
+        if not portable:
             raise HazelcastSerializationError(
                 "Could not create Portable for class-id: %s" % class_id
             )
+
         return portable()
 
     def create_reader(self, inp, factory_id, class_id, version, portable_version):

--- a/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
+++ b/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
@@ -1847,14 +1847,14 @@ class SqlCompactCompatibilityTest(CompactCompatibilityBase):
         super().tearDown()
 
     def test_sql(self):
-        self._put_from_another_client(1, INNER_COMPACT_INSTANCE)
+        self._put_from_another_client(1, OUTER_COMPACT_INSTANCE)
         result = self.client.sql.execute(
             f'SELECT this FROM "{self.map_name}" WHERE ? IS NOT NULL',
-            OUTER_COMPACT_INSTANCE,
+            INNER_COMPACT_INSTANCE,
         ).result()
 
         rows = [row["this"] for row in result]
-        self.assertEqual([INNER_COMPACT_INSTANCE], rows)
+        self.assertEqual([OUTER_COMPACT_INSTANCE], rows)
 
     def _put_from_another_client(self, key, value):
         other_client = self.create_client(self.client_config)


### PR DESCRIPTION
Due to lazy deserialization, Compact serialized objects were
not working nicely with SQL. It was possible to get deserialization
errors that cannot be easily understood by the user.

Similar to what we did for other APIs, we have removed lazy
deserialization from this API as well.

To do that efficiently, I have modified the protocol code generator
so that we can pass to_object function to the SqlPageCodec where
we can do deserialization while filling rows and columns, so that
we will not iterate over the result set once more.

protocol pr: https://github.com/hazelcast/hazelcast-client-protocol/pull/461