### PR TITLE
Introduce minor fixes before 5.2.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ images <https://hub.docker.com/r/hazelcast/hazelcast/>`__.
 
 .. code:: bash
 
-   docker run -p 5701:5701 hazelcast/hazelcast:5.1
+   docker run -p 5701:5701 hazelcast/hazelcast:5.2
 
 You can also use our ZIP or TAR
 `distributions <https://hazelcast.com/open-source-projects/downloads/>`__.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -48,7 +48,7 @@ There are following options to start a Hazelcast cluster easily:
 
   .. code:: bash
 
-      docker run -p 5701:5701 hazelcast/hazelcast:5.1
+      docker run -p 5701:5701 hazelcast/hazelcast:5.2
 
 - You can use `Hazelcast CLI
   <https://docs.hazelcast.com/hazelcast/latest/getting-started/install-hazelcast#using-a-package-manager>`__.

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,7 +14,7 @@ How to try these examples
 * If not, you can use our official Docker images to start a member.
 
     ```bash
-    docker run -p 5701:5701 hazelcast/hazelcast:5.1
+    docker run -p 5701:5701 hazelcast/hazelcast:5.2
     ```
   To see the other ways to start Hazelcast members, see 
   [Working with Hazelcast Clusters](https://hazelcast.readthedocs.io/en/stable/getting_started.html#working-with-hazelcast-clusters)

--- a/examples/jupyter-notebooks/Hazelcast Python Client SQL Support with Hazelcast Viridian Notebook.ipynb
+++ b/examples/jupyter-notebooks/Hazelcast Python Client SQL Support with Hazelcast Viridian Notebook.ipynb
@@ -254,7 +254,7 @@
    "cell_type": "markdown",
    "source": [
     "Here is the critical part. We will insert the data from TMDB API to our Hazelcast Cluster. You can do this in two way. Firstly, you can get a map by calling `hazelcast.get_map()` method and use `put()`, `remove()` and other methods of the returned distributed map object. Secondly you can create a mapping for your data schema using SQL syntax and it directly creates both map and mapping. We preferred second way to show SQL functions in this notebook. \n",
-    "</br></br>In the mapping query, you should sepicfy the fields of data schema. It can be both primitive types or complex types. Using this mapping, we will execute SQL queries on our maps. You can select any column you want to map; not all fields are mandatory. For more information about mapping, you can visit https://docs.hazelcast.com/hazelcast/5.1/sql/mapping-to-maps\n",
+    "</br></br>In the mapping query, you should sepicfy the fields of data schema. It can be both primitive types or complex types. Using this mapping, we will execute SQL queries on our maps. You can select any column you want to map; not all fields are mandatory. For more information about mapping, you can visit https://docs.hazelcast.com/hazelcast/5.2/sql/mapping-to-maps\n",
     "</br></br>\n",
     "Now, execute following cells to create mappings to execute SQL queries against your data."
    ],

--- a/examples/paging-predicate/member-with-comparator/pom.xml
+++ b/examples/paging-predicate/member-with-comparator/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>5.1.3</version>
+            <version>5.2.3</version>
         </dependency>
     </dependencies>
 

--- a/hazelcast/serialization/api.py
+++ b/hazelcast/serialization/api.py
@@ -2594,22 +2594,22 @@ class CompactWriter(abc.ABC):
         """
 
 
-CompactSerializableClass = typing.TypeVar("CompactSerializableClass")
+CompactSerializableType = typing.TypeVar("CompactSerializableType")
 """Type of the Compact serializable classes."""
 
 
-class CompactSerializer(typing.Generic[CompactSerializableClass], abc.ABC):
+class CompactSerializer(typing.Generic[CompactSerializableType], abc.ABC):
     """Defines the contract of the serializers used for Compact serialization.
 
     After defining a serializer for the objects of the class
-    :const:`CompactSerializableClass`, the serializer can be registered to the
+    :const:`CompactSerializableType`, the serializer can be registered to the
     :attr:`hazelcast.config.Config.compact_serializers`.
 
     :func:`write` and :func:`read` methods must be consistent with each other.
     """
 
     @abc.abstractmethod
-    def read(self, reader: CompactReader) -> CompactSerializableClass:
+    def read(self, reader: CompactReader) -> CompactSerializableType:
         """Deserializes the object from the reader.
 
         Args:
@@ -2624,7 +2624,7 @@ class CompactSerializer(typing.Generic[CompactSerializableClass], abc.ABC):
         """
 
     @abc.abstractmethod
-    def write(self, writer: CompactWriter, obj: CompactSerializableClass) -> None:
+    def write(self, writer: CompactWriter, obj: CompactSerializableType) -> None:
         """Serializes the object to writer.
 
         Args:
@@ -2637,7 +2637,7 @@ class CompactSerializer(typing.Generic[CompactSerializableClass], abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_class(self) -> typing.Type[CompactSerializableClass]:
+    def get_class(self) -> typing.Type[CompactSerializableType]:
         """Returns the class that this serializer reads or writes.
 
         Returns:
@@ -2647,7 +2647,7 @@ class CompactSerializer(typing.Generic[CompactSerializableClass], abc.ABC):
     @abc.abstractmethod
     def get_type_name(self) -> str:
         """Returns the unique type name associated with
-        :const`CompactSerializableClass`.
+        :const`CompactSerializableType`.
 
         If the class is ever evolved by adding or removing fields,
         the type name for the evolved serializers must be the same


### PR DESCRIPTION
- Updated the Hazelcast version used in README and examples to 5.2
- Renamed CompactSerializableClass to CompactSerializableType to be more consistent with the other type-var definitions.