### PR TITLE
Use the Viridian name for cloud discovery documentations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,7 +143,7 @@ Features
 -  Distributed, CRDT based counter, called **PNCounter**
 -  Distributed concurrency primitives from CP Subsystem such as
    **FencedLock**, **Semaphore**, **AtomicLong**
--  Integration with `Hazelcast Cloud <https://cloud.hazelcast.com/>`__
+-  Integration with `Hazelcast Viridian <https://viridian.hazelcast.com/>`__
 -  Support for serverless and traditional web service architectures with
    **Unisocket** and **Smart** operation modes
 -  Ability to listen to client lifecycle, cluster state, and distributed

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -40,11 +40,10 @@ features:
 - Client Near Cache Stats
 - Client Runtime Stats
 - Client Operating Systems Stats
-- Hazelcast Cloud Discovery
+- Hazelcast Viridian Discovery
 - Smart Client
 - Unisocket Client
 - Lifecycle Service
-- Hazelcast Cloud Discovery
 - IdentifiedDataSerializable Serialization
 - Portable Serialization
 - Custom Serialization

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -105,7 +105,7 @@ Features
 -  Distributed, CRDT based counter, called **PNCounter**
 -  Distributed concurrency primitives from CP Subsystem such as
    **FencedLock**, **Semaphore**, **AtomicLong**
--  Integration with `Hazelcast Cloud <https://cloud.hazelcast.com/>`__
+-  Integration with `Hazelcast Viridian <https://viridian.hazelcast.com/>`__
 -  Support for serverless and traditional web service architectures with
    **Unisocket** and **Smart** operation modes
 -  Ability to listen to client lifecycle, cluster state, and distributed

--- a/docs/setting_up_client_network.rst
+++ b/docs/setting_up_client_network.rst
@@ -108,12 +108,12 @@ their certificate authorities so that the members can know which
 clients they can trust. See the
 :ref:`securing_client_connection:mutual authentication` section.
 
-Enabling Hazelcast Cloud Discovery
-----------------------------------
+Enabling Hazelcast Viridian Discovery
+-------------------------------------
 
 Hazelcast Python client can discover and connect to Hazelcast clusters
-running on `Hazelcast Cloud <https://cloud.hazelcast.com/>`__. For this,
-provide authentication information as ``cluster_name`` and enable cloud
+running on `Hazelcast Viridian <https://viridian.hazelcast.com/>`__. For this,
+provide authentication information as ``cluster_name`` and enable Viridian
 discovery by setting your ``cloud_discovery_token`` as shown below.
 
 .. code:: python

--- a/examples/jupyter-notebooks/Hazelcast Python Client SQL Support with Hazelcast Viridian Notebook.ipynb
+++ b/examples/jupyter-notebooks/Hazelcast Python Client SQL Support with Hazelcast Viridian Notebook.ipynb
@@ -201,7 +201,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "We are ready to connect our cluster from Python program. Hazelcast uses config settings to find your cluster. We are providing our Viridian tokens for configuration to connect Hazelcast Cloud. After seeing the `Connection successful.` message, we can create mappings for our data. \n",
+    "We are ready to connect our cluster from Python program. Hazelcast uses config settings to find your cluster. We are providing a token to the configuration to connect Hazelcast Viridian. After seeing the `Connection successful.` message, we can create mappings for our data. \n",
     "\n",
     "Reminder: If you want to connect to a local cluster in Jupyter Notebook, you should download the notebook file and remove the Viridian configuration options inside `hazelcast.HazelcastClient()` functional call."
    ],
@@ -217,7 +217,6 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "hazelcast.discovery.HazelcastCloudDiscovery._CLOUD_URL_BASE = \"api.viridian.hazelcast.com\"\n",
     "client = hazelcast.HazelcastClient(\n",
     "    cluster_name=CLUSTER_NAME,\n",
     "    cloud_discovery_token=DISCOVERY_TOKEN,\n",

--- a/hazelcast/client.py
+++ b/hazelcast/client.py
@@ -530,7 +530,7 @@ class HazelcastClient:
         if address_list_provided and cloud_enabled:
             raise IllegalStateError(
                 "Only one discovery method can be enabled at a time. "
-                "Cluster members given explicitly: %s, Hazelcast Cloud enabled: %s"
+                "Cluster members given explicitly: %s, Hazelcast Viridian enabled: %s"
                 % (address_list_provided, cloud_enabled)
             )
 

--- a/hazelcast/discovery.py
+++ b/hazelcast/discovery.py
@@ -11,7 +11,7 @@ _logger = logging.getLogger(__name__)
 
 class HazelcastCloudAddressProvider:
     """Provides initial addresses for client to find and connect to a node
-    and resolves private IP addresses of Hazelcast Cloud service.
+    and resolves private IP addresses of Hazelcast Viridian service.
     """
 
     def __init__(self, token, connection_timeout):
@@ -19,7 +19,7 @@ class HazelcastCloudAddressProvider:
         self._private_to_public = dict()
 
     def load_addresses(self):
-        """Loads member addresses from Hazelcast Cloud endpoint.
+        """Loads member addresses from Hazelcast Viridian endpoint.
 
         Returns:
             tuple[list[hazelcast.core.Address], list[hazelcast.core.Address]]: The possible member addresses
@@ -30,7 +30,7 @@ class HazelcastCloudAddressProvider:
             # Every private address is primary
             return list(nodes.keys()), []
         except Exception as e:
-            _logger.warning("Failed to load addresses from Hazelcast Cloud: %s", e)
+            _logger.warning("Failed to load addresses from Hazelcast Viridian: %s", e)
         return [], []
 
     def translate(self, address):
@@ -58,11 +58,11 @@ class HazelcastCloudAddressProvider:
         try:
             self._private_to_public = self.cloud_discovery.discover_nodes()
         except Exception as e:
-            _logger.warning("Failed to load addresses from Hazelcast.cloud: %s", e)
+            _logger.warning("Failed to load addresses from Hazelcast Viridian: %s", e)
 
 
 class HazelcastCloudDiscovery:
-    """Discovery service that discover nodes via Hazelcast.cloud
+    """Service that discovers nodes via Hazelcast Viridian.
     https://api.viridian.hazelcast.com/cluster/discovery?token=<TOKEN>
     """
 
@@ -78,7 +78,7 @@ class HazelcastCloudDiscovery:
         self._ctx = ssl.create_default_context()
 
     def discover_nodes(self):
-        """Discovers nodes from Hazelcast.cloud.
+        """Discovers nodes from Hazelcast Viridian.
 
         Returns:
             dict[hazelcast.core.Address, hazelcast.core.Address]: Dictionary that maps private


### PR DESCRIPTION
We are now defaulting to the Viridian, instead of Cloud, so that our documentation should also reflect that.

Therefore, I have replaced usages of Hazelcast Cloud with Hazelcast Viridian in this PR.