### PR TITLE
Update Let's Encrypt certificate periodically

### DIFF
--- a/.github/workflows/update_lets_encrypt_certificate.yml
+++ b/.github/workflows/update_lets_encrypt_certificate.yml
@@ -1,0 +1,39 @@
+name: Update Let's Encrypt certificate
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
+jobs:
+  update_certificate:
+    runs-on: ubuntu-latest
+    name: Update Let's Encrypt certificate
+    steps:
+      - name: Checkout to certificates
+        uses: actions/checkout@v3
+        with:
+          repository: hazelcast/private-test-artifacts
+          path: certs
+          ref: data
+          token: ${{ secrets.GH_TOKEN }}
+      - name: Extract the certificate
+        working-directory: certs
+        run: |
+          unzip certs.jar
+      - name: Checkout to client
+        uses: actions/checkout@v3
+        with:
+          repository: hazelcast/hazelcast-python-client
+          path: client
+          ref: master
+          token: ${{ secrets.GH_TOKEN }}
+      - name: Copy updated certificate
+        run: |
+          cp $GITHUB_WORKSPACE/certs/com/hazelcast/nio/ssl/letsencrypt.jks $GITHUB_WORKSPACE/client/tests/integration/backward_compatible/ssl_tests/keystore.jks
+      - name: Commit changes
+        working-directory: client
+        run: |
+          git config user.email "github-actions@hazelcast.com"
+          git config user.name "GitHub Actions"
+          git add tests/integration/backward_compatible/ssl_tests/keystore.jks
+          git commit -m "Update Let's Encrypt Certificate"
+          git push


### PR DESCRIPTION
This PR adds a workflow to update the Let's Encrypt certificate used in tests periodically.

The workflow updates the certificate used in tests every month, based on the certificate generated in the private test artifacts repo. The certificate is renewed every week there, and each certificate is valid for 3 months, so renewing the certificate in this repo every month should work without a problem.