### PR TITLE
Update Hazelcast documentation link version

### DIFF
--- a/examples/jupyter-notebooks/Hazelcast Python Client SQL Support with Hazelcast Viridian Notebook.ipynb
+++ b/examples/jupyter-notebooks/Hazelcast Python Client SQL Support with Hazelcast Viridian Notebook.ipynb
@@ -253,7 +253,7 @@
    "cell_type": "markdown",
    "source": [
     "Here is the critical part. We will insert the data from TMDB API to our Hazelcast Cluster. You can do this in two way. Firstly, you can get a map by calling `hazelcast.get_map()` method and use `put()`, `remove()` and other methods of the returned distributed map object. Secondly you can create a mapping for your data schema using SQL syntax and it directly creates both map and mapping. We preferred second way to show SQL functions in this notebook. \n",
-    "</br></br>In the mapping query, you should sepicfy the fields of data schema. It can be both primitive types or complex types. Using this mapping, we will execute SQL queries on our maps. You can select any column you want to map; not all fields are mandatory. For more information about mapping, you can visit https://docs.hazelcast.com/hazelcast/5.3/sql/mapping-to-maps\n",
+    "</br></br>In the mapping query, you should sepicfy the fields of data schema. It can be both primitive types or complex types. Using this mapping, we will execute SQL queries on our maps. You can select any column you want to map; not all fields are mandatory. For more information about mapping, you can visit https://docs.hazelcast.com/hazelcast/latest/sql/mapping-to-maps\n",
     "</br></br>\n",
     "Now, execute following cells to create mappings to execute SQL queries against your data."
    ],


### PR DESCRIPTION
Replace any references to `https://docs.hazelcast.com/hazelcast/5.x` with `https://docs.hazelcast.com/hazelcast/latest`