### PR TITLE
Update dependency:get command to latest syntax

### DIFF
--- a/start_rc.py
+++ b/start_rc.py
@@ -48,7 +48,7 @@ def download_if_necessary(repo, artifact_id, version, is_test_artifact=False):
         "-q",
         "dependency:get",
         "-Dtransitive=false",
-        "-DrepoUrl=" + repo,
+        "-DremoteRepositories=" + repo,
         "-Dartifact=" + artifact,
         "-Ddest=" + dest_file_name,
     ]
@@ -73,7 +73,9 @@ def start_rc(stdout=None, stderr=None):
     enterprise_key = os.environ.get("HAZELCAST_ENTERPRISE_KEY", None)
 
     if enterprise_key:
-        server = download_if_necessary(ENTERPRISE_REPO, "hazelcast-enterprise", SERVER_VERSION)
+        server = download_if_necessary(
+            ENTERPRISE_REPO, "hazelcast-enterprise", SERVER_VERSION
+        )
     else:
         server = download_if_necessary(REPO, "hazelcast", SERVER_VERSION)
 
@@ -92,7 +94,9 @@ def start_rc(stdout=None, stderr=None):
     if enterprise_key:
         args.insert(1, "-Dhazelcast.enterprise.license.key=" + enterprise_key)
 
-    return subprocess.Popen(args=args, stdout=stdout, stderr=stderr, shell=IS_ON_WINDOWS)
+    return subprocess.Popen(
+        args=args, stdout=stdout, stderr=stderr, shell=IS_ON_WINDOWS
+    )
 
 
 if __name__ == "__main__":

--- a/start_rc.py
+++ b/start_rc.py
@@ -46,7 +46,7 @@ def download_if_necessary(repo, artifact_id, version, is_test_artifact=False):
     args = [
         "mvn",
         "-q",
-        "org.apache.maven.plugins:maven-dependency-plugin:2.10.0:get",
+        "org.apache.maven.plugins:maven-dependency-plugin:2.10:get",
         "-Dtransitive=false",
         "-DremoteRepositories=" + repo,
         "-Dartifact=" + artifact,

--- a/start_rc.py
+++ b/start_rc.py
@@ -50,7 +50,6 @@ def download_if_necessary(repo, artifact_id, version, is_test_artifact=False):
         "-Dtransitive=false",
         "-DremoteRepositories=" + repo,
         "-Dartifact=" + artifact,
-        "-Dartifact=" + artifact,
         "-Ddest=" + dest_file_name,
     ]
 

--- a/start_rc.py
+++ b/start_rc.py
@@ -73,11 +73,9 @@ def start_rc(stdout=None, stderr=None):
     enterprise_key = os.environ.get("HAZELCAST_ENTERPRISE_KEY", None)
 
     if enterprise_key:
-        server = download_if_necessary(
-            ENTERPRISE_REPO, "hazelcast-enterprise", SERVER_VERSION
-        )
-    else:
-        server = download_if_necessary(REPO, "hazelcast", SERVER_VERSION)
+            server = download_if_necessary(ENTERPRISE_REPO, "hazelcast-enterprise", SERVER_VERSION)
+        else:
+            server = download_if_necessary(REPO, "hazelcast", SERVER_VERSION)
 
     artifacts.append(server)
 
@@ -92,11 +90,9 @@ def start_rc(stdout=None, stderr=None):
     ]
 
     if enterprise_key:
-        args.insert(1, "-Dhazelcast.enterprise.license.key=" + enterprise_key)
+            args.insert(1, "-Dhazelcast.enterprise.license.key=" + enterprise_key)
 
-    return subprocess.Popen(
-        args=args, stdout=stdout, stderr=stderr, shell=IS_ON_WINDOWS
-    )
+        return subprocess.Popen(args=args, stdout=stdout, stderr=stderr, shell=IS_ON_WINDOWS)
 
 
 if __name__ == "__main__":

--- a/start_rc.py
+++ b/start_rc.py
@@ -46,7 +46,7 @@ def download_if_necessary(repo, artifact_id, version, is_test_artifact=False):
     args = [
         "mvn",
         "-q",
-        "dependency:get",
+        "org.apache.maven.plugins:maven-dependency-plugin:3.6.0:get",
         "-Dtransitive=false",
         "-DremoteRepositories=" + repo,
         "-Dartifact=" + artifact,

--- a/start_rc.py
+++ b/start_rc.py
@@ -46,9 +46,10 @@ def download_if_necessary(repo, artifact_id, version, is_test_artifact=False):
     args = [
         "mvn",
         "-q",
-        "org.apache.maven.plugins:maven-dependency-plugin:3.6.0:get",
+        "org.apache.maven.plugins:maven-dependency-plugin:2.10.0:get",
         "-Dtransitive=false",
         "-DremoteRepositories=" + repo,
+        "-Dartifact=" + artifact,
         "-Dartifact=" + artifact,
         "-Ddest=" + dest_file_name,
     ]

--- a/start_rc.py
+++ b/start_rc.py
@@ -73,9 +73,9 @@ def start_rc(stdout=None, stderr=None):
     enterprise_key = os.environ.get("HAZELCAST_ENTERPRISE_KEY", None)
 
     if enterprise_key:
-            server = download_if_necessary(ENTERPRISE_REPO, "hazelcast-enterprise", SERVER_VERSION)
-        else:
-            server = download_if_necessary(REPO, "hazelcast", SERVER_VERSION)
+        server = download_if_necessary(ENTERPRISE_REPO, "hazelcast-enterprise", SERVER_VERSION)
+    else:
+        server = download_if_necessary(REPO, "hazelcast", SERVER_VERSION)
 
     artifacts.append(server)
 
@@ -90,9 +90,9 @@ def start_rc(stdout=None, stderr=None):
     ]
 
     if enterprise_key:
-            args.insert(1, "-Dhazelcast.enterprise.license.key=" + enterprise_key)
+        args.insert(1, "-Dhazelcast.enterprise.license.key=" + enterprise_key)
 
-        return subprocess.Popen(args=args, stdout=stdout, stderr=stderr, shell=IS_ON_WINDOWS)
+    return subprocess.Popen(args=args, stdout=stdout, stderr=stderr, shell=IS_ON_WINDOWS)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The `python run_tests.py` script cannot be run as it has the same problem as described in https://github.com/hazelcast/hazelcast-cpp-client/pull/1206