### PR TITLE
Remove proxy from CPProxyManager._lock_proxies upon lock destruction

### DIFF
--- a/hazelcast/cp.py
+++ b/hazelcast/cp.py
@@ -226,8 +226,14 @@ class CPProxyManager:
                     return proxy
 
             proxy = FencedLock(self._context, group_id, LOCK_SERVICE, proxy_name, object_name)
+            proxy._proxy_removal = lambda: self._remove_lock_proxy(proxy_name)
             self._lock_proxies[proxy_name] = proxy
             return proxy
+
+    def _remove_lock_proxy(self, proxy_name):
+        with self._mux:
+            if proxy_name in self._lock_proxies:
+                self._lock_proxies.pop(proxy_name)
 
     def _create_semaphore(self, group_id, proxy_name, object_name):
         codec = semaphore_get_semaphore_type_codec

--- a/hazelcast/proxy/cp/fenced_lock.py
+++ b/hazelcast/proxy/cp/fenced_lock.py
@@ -65,6 +65,7 @@ class FencedLock(SessionAwareCPProxy["BlockingFencedLock"]):
     def __init__(self, context, group_id, service_name, proxy_name, object_name):
         super(FencedLock, self).__init__(context, group_id, service_name, proxy_name, object_name)
         self._lock_session_ids = dict()  # thread-id to session id that has acquired the lock
+        self._proxy_removal = None
 
     def lock(self) -> Future[int]:
         """Acquires the lock and returns the fencing token assigned to the
@@ -308,6 +309,8 @@ class FencedLock(SessionAwareCPProxy["BlockingFencedLock"]):
 
     def destroy(self) -> Future[None]:
         self._lock_session_ids.clear()
+        if self._proxy_removal is not None:
+            self._proxy_removal()
         return super(FencedLock, self).destroy()
 
     def blocking(self) -> "BlockingFencedLock":


### PR DESCRIPTION
Removes the lock proxy from `CPProxyManager._lock_proxies` when the lock is destroyed. I don't think this is a big issue here: it's just a bit better internal bookkeeping. What I understand/have seen these clients are short lived and locks are rarely destroyed (?) due to its implications.

With this patch:

```python
lock = client.cp_subsystem.get_lock("my-distributed-lock").blocking()
fence = lock.lock()
try:
    # do something here
    pass
finally:
    lock.unlock()

lock.destroy() # <-- the lock proxy is removed from CPProxyManager._lock_proxies
```

Fixes: #643 