### PR TITLE
Python 3.12 ssl no longer has the `ssl.wrap_socket` method causes `hazelcast_cloud_discovery_test` failure [API-2195]

### DIFF
--- a/tests/unit/discovery/hazelcast_cloud_discovery_test.py
+++ b/tests/unit/discovery/hazelcast_cloud_discovery_test.py
@@ -74,7 +74,9 @@ class Server:
     def __init__(self):
         self.server = HTTPServer((HOST, 0), CloudHTTPHandler)
         ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-        ssl_context.load_cert_chain("cert.pem", "key.pem")
+        ssl_context.load_cert_chain(
+            get_abs_path(self.cur_dir, "cert.pem"), get_abs_path(self.cur_dir, "key.pem")
+        )
         self.server.socket = ssl_context.wrap_socket(
             self.server.socket,
             server_side=True,

--- a/tests/unit/discovery/hazelcast_cloud_discovery_test.py
+++ b/tests/unit/discovery/hazelcast_cloud_discovery_test.py
@@ -73,10 +73,10 @@ class Server:
 
     def __init__(self):
         self.server = HTTPServer((HOST, 0), CloudHTTPHandler)
-        self.server.socket = ssl.wrap_socket(
+        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        ssl_context.load_cert_chain("cert.pem", "key.pem")
+        self.server.socket = ssl_context.wrap_socket(
             self.server.socket,
-            get_abs_path(self.cur_dir, "key.pem"),
-            get_abs_path(self.cur_dir, "cert.pem"),
             server_side=True,
         )
         self.port = self.server.socket.getsockname()[1]


### PR DESCRIPTION
Python 3.12 ssl no longer has the `ssl.wrap_socket` method but it is replaced with the ssl_context usage. The tests fail at 3.12 build without this fix.