### PR TITLE
Migrate GitHub actions from AdoptOpenJDK to Eclipse Temurin [HZ-4195]

### DIFF
--- a/.github/workflows/coverage_runner.yml
+++ b/.github/workflows/coverage_runner.yml
@@ -48,9 +48,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
           
       - name: Install JDK      
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '8'
 
       - name: Checkout code for PR

--- a/.github/workflows/nightly_runner.yml
+++ b/.github/workflows/nightly_runner.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '8'

--- a/.github/workflows/nightly_runner.yml
+++ b/.github/workflows/nightly_runner.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install JDK
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '8'
       - name: Checkout to code
         uses: actions/checkout@v2


### PR DESCRIPTION
The `setup-java` [documentation highlights that AdoptOpenJDK no longer receives security updates](https://github.com/actions/setup-java#:~:text=NOTE%3A%20AdoptOpenJDK%20got%20moved%20to%20Eclipse%20Temurin), and instead the Eclipse Temurin JDK should be used.

Fixes [HZ-4195](https://hazelcast.atlassian.net/browse/HZ-4195)

[HZ-4195]: https://hazelcast.atlassian.net/browse/HZ-4195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ