### PR TITLE
Update documentation support links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -161,9 +161,6 @@ development/usage issues:
    repository <https://github.com/hazelcast/hazelcast-python-client/issues/new>`__
 -  `Documentation <https://hazelcast.readthedocs.io>`__
 -  `Slack <https://slack.hazelcast.com>`__
--  `Google Groups <https://groups.google.com/g/hazelcast>`__
--  `Stack
-   Overflow <https://stackoverflow.com/questions/tagged/hazelcast>`__
 
 Contributing
 ------------

--- a/docs/getting_help.rst
+++ b/docs/getting_help.rst
@@ -6,5 +6,3 @@ development/usage issues:
 
 - `Github Repository <https://github.com/hazelcast/hazelcast-python-client/issues/new>`__
 - `Slack <https://slack.hazelcast.com>`__
-- `Google Groups <https://groups.google.com/forum/#!forum/hazelcast>`__
-- `Stack Overflow <https://stackoverflow.com/questions/tagged/hazelcast>`__


### PR DESCRIPTION
Update support channels in documentation:
- Google Group link removed
   - > The Hazelcast Google User Group is read-only. Please post your questions on the Hazelcast Community Slack)