### PR TITLE
Use released Hazelcast `5.4.0` instead of `SNAPSHOT`

### DIFF
--- a/start_rc.py
+++ b/start_rc.py
@@ -3,7 +3,7 @@ import subprocess
 import sys
 from os.path import isfile
 
-SERVER_VERSION = "5.4.0-SNAPSHOT"
+SERVER_VERSION = "5.4.0"
 RC_VERSION = "0.8-SNAPSHOT"
 
 RELEASE_REPO = "https://repo1.maven.apache.org/maven2"


### PR DESCRIPTION
Now `5.4.0` is released, the released version should be used in preferences to a pre-release `SNAPSHOT`.