### PR TITLE
Update vector collection API - search, optimize, clear, size

### DIFF
--- a/.github/workflows/coverage_runner.yml
+++ b/.github/workflows/coverage_runner.yml
@@ -75,7 +75,7 @@ jobs:
           
       - name: Run tests
         env:
-          HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
+          HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}
         run: python run_tests.py
             
       - name: Publish results to Codecov for PR coming from hazelcast organization

--- a/.github/workflows/nightly_runner.yml
+++ b/.github/workflows/nightly_runner.yml
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements-test.txt
       - name: Run tests
         env:
-          HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
+          HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}
         run: python run_tests.py
       - name: Upload remote controller logs on test failure
         uses: actions/upload-artifact@v2

--- a/README.rst
+++ b/README.rst
@@ -143,6 +143,7 @@ Features
 -  Distributed, CRDT based counter, called **PNCounter**
 -  Distributed concurrency primitives from CP Subsystem such as
    **FencedLock**, **Semaphore**, **AtomicLong**
+-  Similarity search using **VectorCollection** (Beta)
 -  Integration with `Hazelcast Cloud <https://cloud.hazelcast.com/>`__
 -  Support for serverless and traditional web service architectures with
    **Unisocket** and **Smart** operation modes

--- a/examples/vector_collection/vector_collection.py
+++ b/examples/vector_collection/vector_collection.py
@@ -53,9 +53,9 @@ def main():
     # Search for a vector
     results = vc.search_near_vector(
         Vector("default-vector", Type.DENSE, [0.2, 0.3]),
+        limit=2,
         include_value=True,
         include_vectors=True,
-        limit=2,
     )
     for i, result in enumerate(results):
         print(
@@ -77,9 +77,9 @@ def main():
     # Search for a vector
     results = vc.search_near_vector(
         Vector("default-vector", Type.DENSE, [0.2, 0.3]),
+        limit=2,
         include_value=True,
         include_vectors=True,
-        limit=2,
     )
     for i, result in enumerate(results):
         print(

--- a/examples/vector_collection/vector_collection.py
+++ b/examples/vector_collection/vector_collection.py
@@ -1,6 +1,5 @@
 import logging
 
-from hazelcast import vector
 from hazelcast.vector import Type, Vector, Metric, IndexConfig
 
 logging.basicConfig(level=logging.DEBUG)
@@ -48,6 +47,9 @@ def main():
     key = "key-2"
     vc.set(key, doc2)
 
+    # Optimize collection
+    vc.optimize()
+
     # Search for a vector
     results = vc.search_near_vector(
         Vector("default-vector", Type.DENSE, [0.2, 0.3]),
@@ -68,6 +70,29 @@ def main():
             result.vectors,
         )
 
+    # Delete all entries
+    vc.clear()
+    print("cleared collection")
+
+    # Search for a vector
+    results = vc.search_near_vector(
+        Vector("default-vector", Type.DENSE, [0.2, 0.3]),
+        include_value=True,
+        include_vectors=True,
+        limit=2,
+    )
+    for i, result in enumerate(results):
+        print(
+            f"{i+1}.",
+            "Key:",
+            result.key,
+            "Value:",
+            result.value,
+            "Score:",
+            result.score,
+            "Vector:",
+            result.vectors,
+        )
 
 if __name__ == "__main__":
     main()

--- a/examples/vector_collection/vector_collection.py
+++ b/examples/vector_collection/vector_collection.py
@@ -70,9 +70,12 @@ def main():
             result.vectors,
         )
 
+    print("size:", vc.size())
+
     # Delete all entries
     vc.clear()
     print("cleared collection")
+    print("size:", vc.size())
 
     # Search for a vector
     results = vc.search_near_vector(

--- a/examples/vector_collection/vector_collection.py
+++ b/examples/vector_collection/vector_collection.py
@@ -94,5 +94,6 @@ def main():
             result.vectors,
         )
 
+
 if __name__ == "__main__":
     main()

--- a/hazelcast/protocol/codec/custom/vector_search_options_codec.py
+++ b/hazelcast/protocol/codec/custom/vector_search_options_codec.py
@@ -2,8 +2,6 @@ from hazelcast.protocol.builtin import FixSizedTypesCodec, CodecUtil
 from hazelcast.serialization.bits import *
 from hazelcast.protocol.client_message import END_FRAME_BUF, END_FINAL_FRAME_BUF, SIZE_OF_FRAME_LENGTH_AND_FLAGS, create_initial_buffer_custom
 from hazelcast.vector import VectorSearchOptions
-from hazelcast.protocol.builtin import ListMultiFrameCodec
-from hazelcast.protocol.codec.custom.vector_pair_codec import VectorPairCodec
 from hazelcast.protocol.builtin import MapCodec
 from hazelcast.protocol.builtin import StringCodec
 
@@ -24,7 +22,6 @@ class VectorSearchOptionsCodec:
         FixSizedTypesCodec.encode_boolean(initial_frame_buf, _INCLUDE_VECTORS_ENCODE_OFFSET, vector_search_options.include_vectors)
         FixSizedTypesCodec.encode_int(initial_frame_buf, _LIMIT_ENCODE_OFFSET, vector_search_options.limit)
         buf.extend(initial_frame_buf)
-        ListMultiFrameCodec.encode(buf, vector_search_options.vectors, VectorPairCodec.encode)
         MapCodec.encode_nullable(buf, vector_search_options.hints, StringCodec.encode, StringCodec.encode)
         if is_final:
             buf.extend(END_FINAL_FRAME_BUF)
@@ -38,7 +35,6 @@ class VectorSearchOptionsCodec:
         include_value = FixSizedTypesCodec.decode_boolean(initial_frame.buf, _INCLUDE_VALUE_DECODE_OFFSET)
         include_vectors = FixSizedTypesCodec.decode_boolean(initial_frame.buf, _INCLUDE_VECTORS_DECODE_OFFSET)
         limit = FixSizedTypesCodec.decode_int(initial_frame.buf, _LIMIT_DECODE_OFFSET)
-        vectors = ListMultiFrameCodec.decode(msg, VectorPairCodec.decode)
         hints = MapCodec.decode_nullable(msg, StringCodec.decode, StringCodec.decode)
         CodecUtil.fast_forward_to_end_frame(msg)
-        return VectorSearchOptions(include_value, include_vectors, limit, vectors, hints)
+        return VectorSearchOptions(include_value, include_vectors, limit, hints)

--- a/hazelcast/protocol/codec/custom/vector_search_result_codec.py
+++ b/hazelcast/protocol/codec/custom/vector_search_result_codec.py
@@ -18,7 +18,7 @@ class VectorSearchResultCodec:
         FixSizedTypesCodec.encode_float(initial_frame_buf, _SCORE_ENCODE_OFFSET, vector_search_result.score)
         buf.extend(initial_frame_buf)
         DataCodec.encode(buf, vector_search_result.key)
-        CodecUtil.encode_nullable(buf, vector_search_result.document, DataCodec.encode)
+        CodecUtil.encode_nullable(buf, vector_search_result.value, DataCodec.encode)
         ListMultiFrameCodec.encode_nullable(buf, vector_search_result.vectors, VectorPairCodec.encode)
         if is_final:
             buf.extend(END_FINAL_FRAME_BUF)
@@ -31,7 +31,7 @@ class VectorSearchResultCodec:
         initial_frame = msg.next_frame()
         score = FixSizedTypesCodec.decode_float(initial_frame.buf, _SCORE_DECODE_OFFSET)
         key = DataCodec.decode(msg)
-        document = CodecUtil.decode_nullable(msg, DataCodec.decode)
+        value = CodecUtil.decode_nullable(msg, DataCodec.decode)
         vectors = ListMultiFrameCodec.decode_nullable(msg, VectorPairCodec.decode)
         CodecUtil.fast_forward_to_end_frame(msg)
-        return VectorSearchResult(key, document, score, vectors)
+        return VectorSearchResult(key, value, score, vectors)

--- a/hazelcast/protocol/codec/vector_collection_clear_codec.py
+++ b/hazelcast/protocol/codec/vector_collection_clear_codec.py
@@ -1,0 +1,15 @@
+from hazelcast.protocol.client_message import OutboundMessage, REQUEST_HEADER_SIZE, create_initial_buffer
+from hazelcast.protocol.builtin import StringCodec
+
+# hex: 0x240A00
+_REQUEST_MESSAGE_TYPE = 2361856
+# hex: 0x240A01
+_RESPONSE_MESSAGE_TYPE = 2361857
+
+_REQUEST_INITIAL_FRAME_SIZE = REQUEST_HEADER_SIZE
+
+
+def encode_request(name):
+    buf = create_initial_buffer(_REQUEST_INITIAL_FRAME_SIZE, _REQUEST_MESSAGE_TYPE)
+    StringCodec.encode(buf, name, True)
+    return OutboundMessage(buf, False)

--- a/hazelcast/protocol/codec/vector_collection_optimize_codec.py
+++ b/hazelcast/protocol/codec/vector_collection_optimize_codec.py
@@ -1,0 +1,17 @@
+from hazelcast.protocol.client_message import OutboundMessage, REQUEST_HEADER_SIZE, create_initial_buffer
+from hazelcast.protocol.builtin import StringCodec
+from hazelcast.protocol.builtin import CodecUtil
+
+# hex: 0x240900
+_REQUEST_MESSAGE_TYPE = 2361600
+# hex: 0x240901
+_RESPONSE_MESSAGE_TYPE = 2361601
+
+_REQUEST_INITIAL_FRAME_SIZE = REQUEST_HEADER_SIZE
+
+
+def encode_request(name, index_name):
+    buf = create_initial_buffer(_REQUEST_INITIAL_FRAME_SIZE, _REQUEST_MESSAGE_TYPE)
+    StringCodec.encode(buf, name)
+    CodecUtil.encode_nullable(buf, index_name, StringCodec.encode, True)
+    return OutboundMessage(buf, True)

--- a/hazelcast/protocol/codec/vector_collection_put_all_codec.py
+++ b/hazelcast/protocol/codec/vector_collection_put_all_codec.py
@@ -1,5 +1,7 @@
 from hazelcast.protocol.client_message import OutboundMessage, REQUEST_HEADER_SIZE, create_initial_buffer
-from hazelcast.protocol.builtin import StringCodec, EntryListCodec, DataCodec
+from hazelcast.protocol.builtin import StringCodec
+from hazelcast.protocol.builtin import EntryListCodec
+from hazelcast.protocol.builtin import DataCodec
 from hazelcast.protocol.codec.custom.vector_document_codec import VectorDocumentCodec
 
 # hex: 0x240300

--- a/hazelcast/protocol/codec/vector_collection_search_near_vector_codec.py
+++ b/hazelcast/protocol/codec/vector_collection_search_near_vector_codec.py
@@ -1,7 +1,8 @@
 from hazelcast.protocol.client_message import OutboundMessage, REQUEST_HEADER_SIZE, create_initial_buffer
 from hazelcast.protocol.builtin import StringCodec
-from hazelcast.protocol.codec.custom.vector_search_options_codec import VectorSearchOptionsCodec
 from hazelcast.protocol.builtin import ListMultiFrameCodec
+from hazelcast.protocol.codec.custom.vector_pair_codec import VectorPairCodec
+from hazelcast.protocol.codec.custom.vector_search_options_codec import VectorSearchOptionsCodec
 from hazelcast.protocol.codec.custom.vector_search_result_codec import VectorSearchResultCodec
 
 # hex: 0x240800
@@ -12,9 +13,10 @@ _RESPONSE_MESSAGE_TYPE = 2361345
 _REQUEST_INITIAL_FRAME_SIZE = REQUEST_HEADER_SIZE
 
 
-def encode_request(name, options):
+def encode_request(name, vectors, options):
     buf = create_initial_buffer(_REQUEST_INITIAL_FRAME_SIZE, _REQUEST_MESSAGE_TYPE)
     StringCodec.encode(buf, name)
+    ListMultiFrameCodec.encode(buf, vectors, VectorPairCodec.encode)
     VectorSearchOptionsCodec.encode(buf, options, True)
     return OutboundMessage(buf, True)
 

--- a/hazelcast/protocol/codec/vector_collection_size_codec.py
+++ b/hazelcast/protocol/codec/vector_collection_size_codec.py
@@ -1,0 +1,22 @@
+from hazelcast.protocol.builtin import FixSizedTypesCodec
+from hazelcast.protocol.client_message import OutboundMessage, REQUEST_HEADER_SIZE, create_initial_buffer, RESPONSE_HEADER_SIZE
+from hazelcast.protocol.builtin import StringCodec
+
+# hex: 0x240B00
+_REQUEST_MESSAGE_TYPE = 2362112
+# hex: 0x240B01
+_RESPONSE_MESSAGE_TYPE = 2362113
+
+_REQUEST_INITIAL_FRAME_SIZE = REQUEST_HEADER_SIZE
+_RESPONSE_RESPONSE_OFFSET = RESPONSE_HEADER_SIZE
+
+
+def encode_request(name):
+    buf = create_initial_buffer(_REQUEST_INITIAL_FRAME_SIZE, _REQUEST_MESSAGE_TYPE)
+    StringCodec.encode(buf, name, True)
+    return OutboundMessage(buf, True)
+
+
+def decode_response(msg):
+    initial_frame = msg.next_frame()
+    return FixSizedTypesCodec.decode_long(initial_frame.buf, _RESPONSE_RESPONSE_OFFSET)

--- a/hazelcast/proxy/vector_collection.py
+++ b/hazelcast/proxy/vector_collection.py
@@ -90,7 +90,7 @@ class VectorCollection(Proxy["BlockingVectorCollection"]):
         *,
         include_value: bool = False,
         include_vectors: bool = False,
-        limit: int = -1
+        limit: int
     ) -> Future[List[SearchResult]]:
         check_not_none(vector, "vector can't be None")
         return self._search_near_vector_internal(
@@ -152,7 +152,7 @@ class VectorCollection(Proxy["BlockingVectorCollection"]):
         *,
         include_value: bool = False,
         include_vectors: bool = False,
-        limit: int = -1
+        limit: int
     ) -> Future[List[SearchResult]]:
         def handler(message):
             results: List[
@@ -259,7 +259,7 @@ class BlockingVectorCollection:
         *,
         include_value: bool = False,
         include_vectors: bool = False,
-        limit: Optional[int] = None
+        limit: int
     ) -> List[SearchResult]:
         future = self._wrapped.search_near_vector(
             vector,

--- a/hazelcast/proxy/vector_collection.py
+++ b/hazelcast/proxy/vector_collection.py
@@ -13,6 +13,7 @@ from hazelcast.protocol.codec import (
     vector_collection_put_all_codec,
     vector_collection_clear_codec,
     vector_collection_optimize_codec,
+    vector_collection_size_codec,
 )
 from hazelcast.proxy import Proxy
 from hazelcast.serialization.compact import SchemaNotReplicatedError
@@ -115,6 +116,10 @@ class VectorCollection(Proxy["BlockingVectorCollection"]):
     def clear(self) -> Future[None]:
         request = vector_collection_clear_codec.encode_request(self.name)
         return self._invoke(request)
+
+    def size(self) -> Future[int]:
+        request = vector_collection_size_codec.encode_request(self.name)
+        return self._invoke(request, vector_collection_size_codec.decode_response)
 
     def _set_internal(self, key: Any, document: Document) -> Future[None]:
         try:
@@ -289,6 +294,9 @@ class BlockingVectorCollection:
 
     def optimize(self, index_name: str = None) -> None:
         return self._wrapped.optimize(index_name).result()
+
+    def size(self) -> int:
+        return self._wrapped.size().result()
 
     def destroy(self) -> bool:
         return self._wrapped.destroy()

--- a/hazelcast/proxy/vector_collection.py
+++ b/hazelcast/proxy/vector_collection.py
@@ -91,7 +91,8 @@ class VectorCollection(Proxy["BlockingVectorCollection"]):
         *,
         include_value: bool = False,
         include_vectors: bool = False,
-        limit: int
+        limit: int,
+        hints: Dict[str, str] = None
     ) -> Future[List[SearchResult]]:
         check_not_none(vector, "vector can't be None")
         return self._search_near_vector_internal(
@@ -99,6 +100,7 @@ class VectorCollection(Proxy["BlockingVectorCollection"]):
             include_value=include_value,
             include_vectors=include_vectors,
             limit=limit,
+            hints=hints,
         )
 
     def remove(self, key: Any) -> Future[Optional[Document]]:
@@ -157,7 +159,8 @@ class VectorCollection(Proxy["BlockingVectorCollection"]):
         *,
         include_value: bool = False,
         include_vectors: bool = False,
-        limit: int
+        limit: int,
+        hints: Dict[str, str] = None
     ) -> Future[List[SearchResult]]:
         def handler(message):
             results: List[
@@ -177,6 +180,7 @@ class VectorCollection(Proxy["BlockingVectorCollection"]):
             include_value=include_value,
             include_vectors=include_vectors,
             limit=limit,
+            hints=hints or {},
         )
         request = vector_collection_search_near_vector_codec.encode_request(
             self.name,
@@ -264,13 +268,15 @@ class BlockingVectorCollection:
         *,
         include_value: bool = False,
         include_vectors: bool = False,
-        limit: int
+        limit: int,
+        hints: Dict[str, str] = None
     ) -> List[SearchResult]:
         future = self._wrapped.search_near_vector(
             vector,
             include_value=include_value,
             include_vectors=include_vectors,
             limit=limit,
+            hints=hints,
         )
         return future.result()
 

--- a/hazelcast/proxy/vector_collection.py
+++ b/hazelcast/proxy/vector_collection.py
@@ -287,8 +287,8 @@ class BlockingVectorCollection:
     def clear(self) -> None:
         return self._wrapped.clear().result()
 
-    def optimize(self) -> None:
-        return self._wrapped.optimize().result()
+    def optimize(self, index_name: str = None) -> None:
+        return self._wrapped.optimize(index_name).result()
 
     def destroy(self) -> bool:
         return self._wrapped.destroy()

--- a/hazelcast/proxy/vector_collection.py
+++ b/hazelcast/proxy/vector_collection.py
@@ -112,14 +112,31 @@ class VectorCollection(Proxy["BlockingVectorCollection"]):
         return self._delete_internal(key)
 
     def optimize(self, index_name: str = None) -> Future[None]:
+        """Optimize index by fully removing nodes marked for deletion, trimming neighbor sets
+        to the advertised degree, and updating the entry node as necessary.
+
+        Warning:
+            This operation can take long time to execute and consume a lot of server resources.
+
+        Args:
+            index_name: Name of the index to optimize. If not specified, the only index defined
+                for the collection will be used. Must be specified if the collection has more than
+                one index.
+        """
         request = vector_collection_optimize_codec.encode_request(self.name, index_name)
         return self._invoke(request)
 
     def clear(self) -> Future[None]:
+        """Clears the VectorCollection."""
         request = vector_collection_clear_codec.encode_request(self.name)
         return self._invoke(request)
 
     def size(self) -> Future[int]:
+        """Returns the number of Documents in this VectorCollection.
+
+        Returns:
+            Number of Documents in this VectorCollection.
+        """
         request = vector_collection_size_codec.encode_request(self.name)
         return self._invoke(request, vector_collection_size_codec.decode_response)
 

--- a/hazelcast/vector.py
+++ b/hazelcast/vector.py
@@ -40,8 +40,8 @@ class Document:
     def __copy__(self):
         return Document(self.value, self.vectors)
 
-    def __str__(self):
-        return self.value + " " + str(self.vectors)
+    def __repr__(self):
+        return f"Vector<value={self.value}, vectors=self.vectors}>"
 
 
 VectorDocument = Document

--- a/hazelcast/vector.py
+++ b/hazelcast/vector.py
@@ -41,7 +41,7 @@ class Document:
         return Document(self.value, self.vectors)
 
     def __repr__(self):
-        return f"Vector<value={self.value}, vectors=self.vectors}>"
+        return f"Document<value={self.value}, vectors={self.vectors}>"
 
 
 VectorDocument = Document

--- a/hazelcast/vector.py
+++ b/hazelcast/vector.py
@@ -80,7 +80,6 @@ VectorIndexConfig = IndexConfig
 @dataclasses.dataclass
 class VectorSearchOptions:
 
-    vectors: List[Vector]
     include_value: bool
     include_vectors: bool
     limit: int

--- a/hazelcast/vector.py
+++ b/hazelcast/vector.py
@@ -40,6 +40,9 @@ class Document:
     def __copy__(self):
         return Document(self.value, self.vectors)
 
+    def __str__(self):
+        return self.value + " " + str(self.vectors)
+
 
 VectorDocument = Document
 

--- a/start_rc.py
+++ b/start_rc.py
@@ -77,14 +77,6 @@ def start_rc(stdout=None, stderr=None):
         server = download_if_necessary(
             ENTERPRISE_REPO, HAZELCAST_GROUP, "hazelcast-enterprise", SERVER_VERSION
         )
-        vector = download_if_necessary(
-            ENTERPRISE_REPO, HAZELCAST_GROUP, "hazelcast-enterprise-vector", SERVER_VERSION
-        )
-        artifacts.append(vector)
-        jvector = download_if_necessary(RELEASE_REPO, "io.github.jbellis", "jvector", "2.0.5")
-        artifacts.append(jvector)
-        math3 = download_if_necessary(RELEASE_REPO, "org.apache.commons", "commons-math3", "3.6.1")
-        artifacts.append(math3)
     else:
         server = download_if_necessary(REPO, HAZELCAST_GROUP, "hazelcast", SERVER_VERSION)
 

--- a/tests/integration/backward_compatible/proxy/vector_collection_test.py
+++ b/tests/integration/backward_compatible/proxy/vector_collection_test.py
@@ -144,6 +144,14 @@ class VectorCollectionTest(SingleMemberTestCase):
         self.assertIsNone(result1.value)
         self.assertIsNone(result1.vectors)
 
+    def test_size(self):
+        self.assertEqual(self.vector_collection.size(), 0)
+        doc = Document("v1", Vector("vector", Type.DENSE, [0.1, 0.2, 0.3]))
+        self.vector_collection.put("k1", doc)
+        self.assertEqual(self.vector_collection.size(), 1)
+        self.vector_collection.clear()
+        self.assertEqual(self.vector_collection.size(), 0)
+
     def assert_document_equal(self, doc1: Document, doc2: Document) -> None:
         self.assertEqual(doc1.value, doc2.value)
         self.assertEqual(len(doc1.vectors), len(doc2.vectors))

--- a/tests/integration/backward_compatible/proxy/vector_collection_test.py
+++ b/tests/integration/backward_compatible/proxy/vector_collection_test.py
@@ -89,6 +89,27 @@ class VectorCollectionTest(SingleMemberTestCase):
         k2 = self.vector_collection.get("k2")
         self.assert_document_equal(k2, doc2)
 
+    def test_clear(self):
+        doc = self.vector_collection.get("k1")
+        self.assertIsNone(doc)
+        doc = Document("v1", self.vec1([0.1, 0.2, 0.3]))
+        self.vector_collection.set("k1", doc)
+        self.vector_collection.clear()
+        doc = self.vector_collection.get("k1")
+        self.assertIsNone(doc)
+
+    def test_optimize(self):
+        doc = Document("v1", self.vec1([0.1, 0.2, 0.3]))
+        self.vector_collection.set("k1", doc)
+        # it is hard to observe results of optimize, so just test that the invocation works
+        self.vector_collection.optimize()
+
+    def test_optimize_with_name(self):
+        doc = Document("v1", self.vec1([0.1, 0.2, 0.3]))
+        self.vector_collection.set("k1", doc)
+        # it is hard to observe results of optimize, so just test that the invocation works
+        self.vector_collection.optimize("vector")
+
     def test_search_near_vector_include_all(self):
         target_doc = self.doc1("v1", [0.3, 0.4, 0.5])
         self.vector_collection.put_all(


### PR DESCRIPTION
Implement client side changes related to recent client protocol changes and some cleanup:
- move vector to top-level search parameter
- add search hints (minimal API with `Dict[str, str]`, can be improved later to be more python-like)
- add `optimize` and `clear`
- add `size`
- fix automatically generated codecs (https://github.com/hazelcast/hazelcast-client-protocol/pull/528)
- additional vector JARs are no longer needed
- add `Document.__repr__` for easier printing
- removed default search limit, `-1` was invalid value
- use V7 license key for tests