### PR TITLE
Fixed compatibility tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ check:
 	black --check --config black.toml .
 
 test:
+	pytest -m "not enterprise"
+
+test-enterprise:
 	pytest
 
 test-cover:

--- a/hazelcast/util.py
+++ b/hazelcast/util.py
@@ -55,7 +55,7 @@ def current_time_in_millis():
 
 
 def thread_id():
-    return threading.currentThread().ident
+    return threading.current_thread().ident
 
 
 def to_millis(seconds):

--- a/tests/integration/backward_compatible/proxy/vector_collection_test.py
+++ b/tests/integration/backward_compatible/proxy/vector_collection_test.py
@@ -168,7 +168,7 @@ class VectorCollectionTest(SingleMemberTestCase):
         self.vector_collection.clear()
         self.assertEqual(self.vector_collection.size(), 0)
 
-    def assert_document_equal(self, doc1: Document, doc2: Document) -> None:
+    def assert_document_equal(self, doc1, doc2) -> None:
         self.assertEqual(doc1.value, doc2.value)
         self.assertEqual(len(doc1.vectors), len(doc2.vectors))
         # currently there's a bug on the server-side about vector names.
@@ -179,7 +179,7 @@ class VectorCollectionTest(SingleMemberTestCase):
         for i in range(len(doc1.vectors)):
             self.assert_vector_equal(doc1.vectors[i], doc2.vectors[i], skip_check_name)
 
-    def assert_vector_equal(self, vec1: Vector, vec2: Vector, skip_check_name=False):
+    def assert_vector_equal(self, vec1, vec2, skip_check_name=False):
         if not skip_check_name:
             self.assertEqual(vec1.name, vec2.name)
         self.assertEqual(vec1.type, vec2.type)
@@ -188,9 +188,9 @@ class VectorCollectionTest(SingleMemberTestCase):
             self.assertAlmostEqual(vec1.vector[i], vec2.vector[i])
 
     @classmethod
-    def vec1(cls, elems) -> Vector:
+    def vec1(cls, elems):
         return Vector("vector", Type.DENSE, elems)
 
     @classmethod
-    def doc1(cls, value, vector_elems) -> Document:
+    def doc1(cls, value, vector_elems):
         return Document(value, cls.vec1(vector_elems))

--- a/tests/integration/backward_compatible/threading_test.py
+++ b/tests/integration/backward_compatible/threading_test.py
@@ -43,7 +43,7 @@ class ThreadingTest(SingleMemberTestCase):
                     self.map.unlock(key)
                 except:
                     self.logger.exception("Exception in thread")
-                    exceptions.append((threading.currentThread().getName(), sys.exc_info()))
+                    exceptions.append((threading.current_thread().name, sys.exc_info()))
 
         threads = [self.start_new_thread(put_get_remove) for _ in range(0, num_threads)]
 

--- a/tests/unit/proxy/cp/atomic_long_test.py
+++ b/tests/unit/proxy/cp/atomic_long_test.py
@@ -1,10 +1,12 @@
 import unittest
 
+import pytest
 from mock import MagicMock
 
 from hazelcast.proxy.cp.atomic_long import AtomicLong
 
 
+@pytest.mark.enterprise
 class AtomicLongInvalidInputTest(unittest.TestCase):
     def setUp(self):
         self.atomic_long = AtomicLong(MagicMock(), None, None, None, None)

--- a/tests/unit/proxy/cp/atomic_reference_test.py
+++ b/tests/unit/proxy/cp/atomic_reference_test.py
@@ -1,10 +1,12 @@
 import unittest
 
+import pytest
 from mock import MagicMock
 
 from hazelcast.proxy.cp.atomic_reference import AtomicReference
 
 
+@pytest.mark.enterprise
 class AtomicReferenceInvalidInputTest(unittest.TestCase):
     def setUp(self):
         self.atomic_ref = AtomicReference(MagicMock(), None, None, None, None)


### PR DESCRIPTION
Fixed compatibility tests, use current_thread instead of deprecated currentThread.