### PR TITLE
Use the private snapshot repo

### DIFF
--- a/.github/workflows/coverage_runner.yml
+++ b/.github/workflows/coverage_runner.yml
@@ -75,9 +75,9 @@ jobs:
           
       - name: Run tests
         env:
-          HAZELCAST_ENTERPRISE_KEY: "${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}"
-          HZ_SNAPSHOT_INTERNAL_USERNAME: "${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}"
-          HZ_SNAPSHOT_INTERNAL_PASSWORD: "${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}"
+          HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}
+          HZ_SNAPSHOT_INTERNAL_USERNAME: ${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
+          HZ_SNAPSHOT_INTERNAL_PASSWORD: ${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
         run: python run_tests.py
             
       - name: Publish results to Codecov for PR coming from hazelcast organization

--- a/.github/workflows/coverage_runner.yml
+++ b/.github/workflows/coverage_runner.yml
@@ -75,7 +75,9 @@ jobs:
           
       - name: Run tests
         env:
-          HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}
+          HAZELCAST_ENTERPRISE_KEY: "${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}"
+          HZ_SNAPSHOT_INTERNAL_USERNAME: "${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}"
+          HZ_SNAPSHOT_INTERNAL_PASSWORD: "${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}"
         run: python run_tests.py
             
       - name: Publish results to Codecov for PR coming from hazelcast organization

--- a/README.rst
+++ b/README.rst
@@ -216,11 +216,18 @@ following:
 -  `Supported Java virtual machine <https://docs.hazelcast.com/hazelcast/latest/deploy/versioning-compatibility#supported-java-virtual-machines>`
 -  `Apache Maven <https://maven.apache.org/>`
 
-Following commands starts the tests:
+Set the environment variables for credentials:
 
 .. code:: bash
 
-    python run_tests.py
+    export MAVEN_USERNAME=YOUR_MAVEN_USERNAME
+    export MAVEN_PASSWORD=YOUR_MAVEN_PASSWORD
+
+Following command starts the tests:
+
+.. code:: bash
+
+    python3 run_tests.py
 
 Test script automatically downloads ``hazelcast-remote-controller`` and
 Hazelcast. The script uses Maven to download those.
@@ -233,7 +240,7 @@ License
 Copyright
 ---------
 
-Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
 
 Visit `hazelcast.com <https://hazelcast.com>`__ for more
 information.

--- a/README.rst
+++ b/README.rst
@@ -220,8 +220,8 @@ Set the environment variables for credentials:
 
 .. code:: bash
 
-    export MAVEN_USERNAME=YOUR_MAVEN_USERNAME
-    export MAVEN_PASSWORD=YOUR_MAVEN_PASSWORD
+    export HZ_SNAPSHOT_INTERNAL_USERNAME=YOUR_MAVEN_USERNAME
+    export HZ_SNAPSHOT_INTERNAL_PASSWORD=YOUR_MAVEN_PASSWORD
 
 Following command starts the tests:
 

--- a/hazelcast/proxy/cp/count_down_latch.py
+++ b/hazelcast/proxy/cp/count_down_latch.py
@@ -1,5 +1,7 @@
 import uuid
 
+import pytest
+
 from hazelcast.errors import OperationTimeoutError
 from hazelcast.future import Future
 from hazelcast.protocol.codec import (
@@ -13,6 +15,7 @@ from hazelcast.proxy.cp import BaseCPProxy
 from hazelcast.util import to_millis, check_true, check_is_number, check_is_int
 
 
+@pytest.mark.enterprise
 class CountDownLatch(BaseCPProxy["BlockingCountDownLatch"]):
     """A distributed, concurrent countdown latch data structure.
 

--- a/settings.xml
+++ b/settings.xml
@@ -2,8 +2,8 @@
   <servers>
     <server>
       <id>temp</id>
-      <username>${env.MAVEN_USERNAME}</username>
-      <password>${env.MAVEN_PASSWORD}</password>
+      <username>${env.HZ_SNAPSHOT_INTERNAL_USERNAME}</username>
+      <password>${env.HZ_SNAPSHOT_INTERNAL_PASSWORD}</password>
     </server>
   </servers>
 </settings>

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,9 @@
+<settings>
+  <servers>
+    <server>
+      <id>temp</id>
+      <username>${env.MAVEN_USERNAME}</username>
+      <password>${env.MAVEN_PASSWORD}</password>
+    </server>
+  </servers>
+</settings>

--- a/start_rc.py
+++ b/start_rc.py
@@ -10,6 +10,7 @@ RELEASE_REPO = "https://repo1.maven.apache.org/maven2"
 ENTERPRISE_RELEASE_REPO = "https://repository.hazelcast.com/release/"
 SNAPSHOT_REPO = "https://repository.hazelcast.com/snapshot-internal/"
 ENTERPRISE_SNAPSHOT_REPO = "https://repository.hazelcast.com/snapshot/"
+RC_REPO = "https://oss.sonatype.org/content/repositories/snapshots"
 HAZELCAST_GROUP = "com.hazelcast"
 
 if SERVER_VERSION.endswith("-SNAPSHOT"):
@@ -18,11 +19,6 @@ if SERVER_VERSION.endswith("-SNAPSHOT"):
 else:
     REPO = RELEASE_REPO
     ENTERPRISE_REPO = ENTERPRISE_RELEASE_REPO
-
-if RC_VERSION.endswith("-SNAPSHOT"):
-    RC_REPO = SNAPSHOT_REPO
-else:
-    RC_REPO = RELEASE_REPO
 
 IS_ON_WINDOWS = os.name == "nt"
 CLASS_PATH_SEPARATOR = ";" if IS_ON_WINDOWS else ":"

--- a/start_rc.py
+++ b/start_rc.py
@@ -8,7 +8,7 @@ RC_VERSION = "0.8-SNAPSHOT"
 
 RELEASE_REPO = "https://repo1.maven.apache.org/maven2"
 ENTERPRISE_RELEASE_REPO = "https://repository.hazelcast.com/release/"
-SNAPSHOT_REPO = "https://oss.sonatype.org/content/repositories/snapshots"
+SNAPSHOT_REPO = "https://repository.hazelcast.com/snapshot-internal/"
 ENTERPRISE_SNAPSHOT_REPO = "https://repository.hazelcast.com/snapshot/"
 HAZELCAST_GROUP = "com.hazelcast"
 
@@ -46,13 +46,16 @@ def download_if_necessary(repo, group, artifact_id, version, is_test_artifact=Fa
 
     args = [
         "mvn",
-        "-q",
+        "-X",
         "org.apache.maven.plugins:maven-dependency-plugin:2.10:get",
         "-Dtransitive=false",
         "-DremoteRepositories=" + repo,
         "-Dartifact=" + artifact,
         "-Ddest=" + dest_file_name,
+        "--settings=settings.xml",
     ]
+
+    print("Maven Args:", args)
 
     process = subprocess.run(args, shell=IS_ON_WINDOWS)
     if process.returncode != 0:

--- a/tests/integration/backward_compatible/proxy/cp/atomic_long_test.py
+++ b/tests/integration/backward_compatible/proxy/cp/atomic_long_test.py
@@ -1,3 +1,5 @@
+import pytest
+
 from hazelcast.errors import DistributedObjectDestroyedError
 from hazelcast.serialization.api import IdentifiedDataSerializable
 from tests.integration.backward_compatible.proxy.cp import CPTestCase
@@ -21,6 +23,7 @@ class Multiplication(IdentifiedDataSerializable):
         return 16
 
 
+@pytest.mark.enterprise
 class AtomicLongTest(CPTestCase):
     def setUp(self):
         self.atomic_long = self.client.cp_subsystem.get_atomic_long("long").blocking()

--- a/tests/integration/backward_compatible/proxy/cp/atomic_reference_test.py
+++ b/tests/integration/backward_compatible/proxy/cp/atomic_reference_test.py
@@ -1,3 +1,5 @@
+import pytest
+
 from hazelcast.errors import DistributedObjectDestroyedError, ClassCastError
 from hazelcast.serialization.api import IdentifiedDataSerializable
 
@@ -23,6 +25,7 @@ class AppendString(IdentifiedDataSerializable):
         return 17
 
 
+@pytest.mark.enterprise
 class AtomicReferenceTest(CPTestCase):
     def setUp(self):
         self.ref = self.client.cp_subsystem.get_atomic_reference("ref").blocking()

--- a/tests/integration/backward_compatible/proxy/cp/count_down_latch_test.py
+++ b/tests/integration/backward_compatible/proxy/cp/count_down_latch_test.py
@@ -1,6 +1,8 @@
 import os
 from threading import Thread
 
+import pytest
+
 from hazelcast.errors import DistributedObjectDestroyedError, OperationTimeoutError
 from hazelcast.future import ImmediateExceptionFuture
 from hazelcast.util import AtomicInteger
@@ -11,6 +13,7 @@ from tests.util import get_current_timestamp, random_string
 inf = 2**31 - 1
 
 
+@pytest.mark.enterprise
 class CountDownLatchTest(CPTestCase):
     def test_latch_in_another_group(self):
         latch = self.get_latch()

--- a/tests/integration/backward_compatible/proxy/cp/fenced_lock_test.py
+++ b/tests/integration/backward_compatible/proxy/cp/fenced_lock_test.py
@@ -1,5 +1,7 @@
 import time
 
+import pytest
+
 from hazelcast import HazelcastClient
 from hazelcast.errors import (
     DistributedObjectDestroyedError,
@@ -10,6 +12,7 @@ from tests.integration.backward_compatible.proxy.cp import CPTestCase
 from tests.util import random_string
 
 
+@pytest.mark.enterprise
 class FencedLockTest(CPTestCase):
     def setUp(self):
         self.lock = self.client.cp_subsystem.get_lock(random_string()).blocking()

--- a/tests/integration/backward_compatible/proxy/cp/semaphore_test.py
+++ b/tests/integration/backward_compatible/proxy/cp/semaphore_test.py
@@ -1,6 +1,7 @@
 import threading
 import time
 
+import pytest
 from parameterized import parameterized
 
 from hazelcast import HazelcastClient
@@ -17,6 +18,7 @@ SEMAPHORE_TYPES = [
 ]
 
 
+@pytest.mark.enterprise
 class SemaphoreTest(CPTestCase):
     def setUp(self):
         self.semaphore = None

--- a/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
+++ b/tests/integration/backward_compatible/serialization/compact_compatibility/compact_compatibility_test.py
@@ -3,6 +3,8 @@ import enum
 import typing
 import unittest
 
+import pytest
+
 from hazelcast.errors import NullPointerError, IllegalMonitorStateError
 from hazelcast.predicate import Predicate, paging
 from tests.base import HazelcastTestCase
@@ -333,6 +335,7 @@ class CompactCompatibilityBase(HazelcastTestCase):
         self.shutdown_all_clients()
 
 
+@pytest.mark.enterprise
 class AtomicLongCompactCompatibilityTest(CompactCompatibilityBase):
     def setUp(self) -> None:
         super().setUp()
@@ -358,6 +361,7 @@ class AtomicLongCompactCompatibilityTest(CompactCompatibilityBase):
         self.assertEqual(OUTER_COMPACT_INSTANCE, self.atomic_long.apply(CompactReturningFunction()))
 
 
+@pytest.mark.enterprise
 class AtomicReferenceCompactCompatibilityTest(CompactCompatibilityBase):
     def setUp(self) -> None:
         super().setUp()


### PR DESCRIPTION
* Updates the artifact downloader to use snapshots from the private repo.
* Mark more CP tests as enterprise

The tests fail since the artifacts cannot be downloaded.
Once the PR is merged, H workflow updates will be in-effect, and the artifacts will be downloaded fine.
