### PR TITLE
Upgrade version in documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,9 +72,9 @@ author = "Hazelcast Inc. Developers"
 # built documents.
 #
 # The short X.Y version.
-version = "5.3.0"
+version = "5.4.0"
 # The full version, including alpha/beta/rc tags.
-release = "5.3.0"
+release = "5.4.0"
 
 autodoc_member_order = "bysource"
 autoclass_content = "both"


### PR DESCRIPTION
The latest `hazelcast-python-client` release is `5.4.0`, but the Sphinx configuration has not been updated so it's still labelled `5.3.0` in the documentation.

![image](https://github.com/user-attachments/assets/96f39c24-887a-4b60-b221-11974a7de011)

Post Merge:
- [ ] Add to [the documentation](https://hazelcast.atlassian.net/wiki/spaces/HZC/pages/115376462/Python+Client+Release+Procedure)