### PR TITLE
Fix broken entry processor documentation link

### DIFF
--- a/docs/using_python_client_with_hazelcast.rst
+++ b/docs/using_python_client_with_hazelcast.rst
@@ -1401,7 +1401,7 @@ The code that runs on the entries is implemented in Java on the server
 side. The client side entry processor is used to specify which entry
 processor should be called. For more details about the Java
 implementation of the entry processor, see the `Entry Processor section
-<https://docs.hazelcast.com/hazelcast/latest/computing/entry-processor>`__
+<https://docs.hazelcast.com/hazelcast/latest/data-structures/entry-processor>`__
 in the Hazelcast Reference Manual.
 
 After the above implementations and configuration are done and you start


### PR DESCRIPTION
The PR builder is failing for unrelated PRs because a link in the documentation is dead.

Fixes: https://github.com/hazelcast/hazelcast-python-client/pull/689#issuecomment-2264537706