### PR TITLE
Fix ReadTheDocs by adding configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: latest
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: requirements-dev.txt


### PR DESCRIPTION
The documentation is failing to upload to ReadTheDocs [because it doesn't build](https://app.readthedocs.org/projects/hazelcast/builds/25183105/):
> Config file not found at default path The required .readthedocs.yaml configuration file was not found at repository's root.

This means that the [latest available version](https://hazelcast.readthedocs.io/en/latest/) listed is `v5.3.0`, `v5.4.0` is missing:
![image](https://github.com/user-attachments/assets/dfc91853-8988-43d4-a429-03f401147edb)

I've created a simple configuration [based on their documentation](https://docs.readthedocs.io/en/stable/config-file/index.html) to address this.

I've [built this on ReadTheDocs](https://app.readthedocs.org/projects/hazelcast/builds/25186169/) to create a public-but-unlisted site [here](https://hazelcast.readthedocs.io/en/fix-readthedocs-3/).

Discovered by [PR feedback](https://github.com/hazelcast/rel-scripts/pull/22#discussion_r1700399305).