### PR TITLE
Removed pypy from nightlies

### DIFF
--- a/.github/workflows/nightly_runner.yml
+++ b/.github/workflows/nightly_runner.yml
@@ -9,7 +9,7 @@ jobs:
     name: Run tests with Python ${{ matrix.python-version }} on ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.9']
+        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         os: [ ubuntu-20.04, windows-latest ]
         exclude:
           - os: windows-latest


### PR DESCRIPTION
This PR removes PyPy 3.9 from nightly tests, since Thrift compilaiton fails during pre--test setup , which in turn causes the failure of nightly tests:
https://github.com/hazelcast/hazelcast-python-client/actions/runs/10500661230/job/29089388966

Note that PyPy was never advertised as a supported Python variant. Removal of this test setup doesn't preclude unofficial PyPy support.