### PR TITLE
Upgrading JVector version to v.3 [AI-155] [AI-133]

### DIFF
--- a/hazelcast/vector.py
+++ b/hazelcast/vector.py
@@ -121,7 +121,7 @@ class IndexConfig:
     name: str
     metric: Metric
     dimension: int
-    max_degree: int = 16
+    max_degree: int = 32
     ef_construction: int = 100
     use_deduplication: bool = True
 


### PR DESCRIPTION
With the update to version 3 of the jVector library, the maxBean parameter now represents the maximum degree of the graph, rather than half of the maximum degree.

see - https://github.com/jbellis/jvector/blob/main/UPGRADING.md?plain=1#L7