### PR TITLE
Upgrade actions/upload-artifact so nightly tests can be run

### DIFF
--- a/.github/workflows/coverage_runner.yml
+++ b/.github/workflows/coverage_runner.yml
@@ -101,7 +101,7 @@ jobs:
           override_pr: ${{ github.event.inputs.pr_number }}
           
       - name: Upload remote controller logs if test run fails
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: rc-logs-${{ matrix.python-version }}-${{ matrix.os }}

--- a/.github/workflows/nightly_runner.yml
+++ b/.github/workflows/nightly_runner.yml
@@ -37,7 +37,7 @@ jobs:
           HZ_SNAPSHOT_INTERNAL_PASSWORD: ${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
         run: python run_tests.py
       - name: Upload remote controller logs on test failure
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: rc-logs-${{ matrix.python-version }}-${{ matrix.os }}


### PR DESCRIPTION
Tests cannot be started because `actions/upload-artifact@v2` was deprecated.
Upgrading to `v4`.

The tests in this PR fail, since they run using the v2 action.