### PR TITLE
Send UUID in vector collection optimization request [AI-148]

### DIFF
--- a/hazelcast/protocol/codec/vector_collection_optimize_codec.py
+++ b/hazelcast/protocol/codec/vector_collection_optimize_codec.py
@@ -1,3 +1,5 @@
+from hazelcast.serialization.bits import *
+from hazelcast.protocol.builtin import FixSizedTypesCodec
 from hazelcast.protocol.client_message import OutboundMessage, REQUEST_HEADER_SIZE, create_initial_buffer
 from hazelcast.protocol.builtin import StringCodec
 from hazelcast.protocol.builtin import CodecUtil
@@ -7,11 +9,13 @@ _REQUEST_MESSAGE_TYPE = 2361600
 # hex: 0x240901
 _RESPONSE_MESSAGE_TYPE = 2361601
 
-_REQUEST_INITIAL_FRAME_SIZE = REQUEST_HEADER_SIZE
+_REQUEST_UUID_OFFSET = REQUEST_HEADER_SIZE
+_REQUEST_INITIAL_FRAME_SIZE = _REQUEST_UUID_OFFSET + UUID_SIZE_IN_BYTES
 
 
-def encode_request(name, index_name):
+def encode_request(name, index_name, uuid):
     buf = create_initial_buffer(_REQUEST_INITIAL_FRAME_SIZE, _REQUEST_MESSAGE_TYPE)
+    FixSizedTypesCodec.encode_uuid(buf, _REQUEST_UUID_OFFSET, uuid)
     StringCodec.encode(buf, name)
     CodecUtil.encode_nullable(buf, index_name, StringCodec.encode, True)
     return OutboundMessage(buf, True)

--- a/hazelcast/proxy/vector_collection.py
+++ b/hazelcast/proxy/vector_collection.py
@@ -1,4 +1,5 @@
 import copy
+import uuid
 from typing import Any, Dict, List, Optional, Tuple
 
 from hazelcast.future import Future, ImmediateFuture, combine_futures
@@ -282,7 +283,9 @@ class VectorCollection(Proxy["BlockingVectorCollection"]):
                 for the collection will be used. Must be specified if the collection has more than
                 one index.
         """
-        request = vector_collection_optimize_codec.encode_request(self.name, index_name)
+        request = vector_collection_optimize_codec.encode_request(
+            self.name, index_name, uuid.uuid4()
+        )
         return self._invoke(request)
 
     def clear(self) -> Future[None]:


### PR DESCRIPTION
Add support for [UUID for `optimize` operation](https://github.com/hazelcast/hazelcast-client-protocol/pull/535) which fixes some [optimization operation retry scenarios](https://github.com/hazelcast/hazelcast-mono/pull/3428).