### PR TITLE
Migrate GitHub Actions off of outdate `ubuntu-20.04` runner image

### DIFF
--- a/.github/workflows/coverage_runner.yml
+++ b/.github/workflows/coverage_runner.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ '3.7', '3.12' ]
-        os: [ ubuntu-20.04, windows-latest ]
+        os: [ ubuntu-latest, windows-latest ]
       fail-fast: false
       
     steps:
@@ -81,20 +81,20 @@ jobs:
         run: python run_tests.py
             
       - name: Publish results to Codecov for PR coming from hazelcast organization
-        if: ${{ matrix.python-version == '3.12' && matrix.os == 'ubuntu-20.04' &&  github.event_name == 'pull_request_target' }}
+        if: ${{ matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest' &&  github.event_name == 'pull_request_target' }}
         uses: codecov/codecov-action@v1
         with:
           files: ./coverage.xml
           override_pr: ${{ github.event.pull_request.number }}
           
       - name: Publish results to Codecov for Push
-        if: ${{ matrix.python-version == '3.12' && matrix.os == 'ubuntu-20.04' &&  github.event_name == 'push' }}
+        if: ${{ matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest' &&  github.event_name == 'push' }}
         uses: codecov/codecov-action@v1
         with:
           files: ./coverage.xml
           
       - name: Publish result to Codecov for PR coming from community
-        if: ${{ matrix.python-version == '3.12' && matrix.os == 'ubuntu-20.04' && github.event_name == 'workflow_dispatch' }}
+        if: ${{ matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest' && github.event_name == 'workflow_dispatch' }}
         uses: codecov/codecov-action@v1
         with:
           files: ./coverage.xml

--- a/.github/workflows/nightly_runner.yml
+++ b/.github/workflows/nightly_runner.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
-        os: [ ubuntu-20.04, windows-latest ]
+        os: [ ubuntu-latest, windows-latest ]
         exclude:
           - os: windows-latest
             python-version: pypy-3.9


### PR DESCRIPTION
> The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using Ubuntu 20.04. Builds that are scheduled to run during the brownout periods will fail.

I have not tested this change, if problems are reported we can address them as they occur - but we must upgrade to ensure the builds _actually work_.