### PR TITLE
Remove Python `3.7` from GitHub Actions

### DIFF
--- a/.github/workflows/coverage_runner.yml
+++ b/.github/workflows/coverage_runner.yml
@@ -37,13 +37,13 @@ jobs:
     name: Run tests with Python ${{ matrix.python-version }} on ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ '3.7', '3.12' ]
+        python-version: [ '3.8', '3.12' ]
         os: [ ubuntu-latest, windows-latest ]
       fail-fast: false
       
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           

--- a/.github/workflows/nightly_runner.yml
+++ b/.github/workflows/nightly_runner.yml
@@ -9,7 +9,7 @@ jobs:
     name: Run tests with Python ${{ matrix.python-version }} on ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12']
         os: [ ubuntu-latest, windows-latest ]
         exclude:
           - os: windows-latest
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install JDK


### PR DESCRIPTION
In https://github.com/hazelcast/hazelcast-python-client/pull/717 the runner images were upgraded from Ubuntu `20` to Ubuntu `24` (implicit).

[Ubuntu `24` does not have an available Python `3.7` installation](https://github.com/actions/setup-python/issues/962), so the [actions fail](https://github.com/hazelcast/hazelcast-python-client/actions/runs/13270208556).

Changes:
- removed Python `3.7` from GitHub Actions
- upgraded `setup-python` action to latest (while investigating)