### PR TITLE
Add Python `3.13` to GitHub Actions

### DIFF
--- a/.github/workflows/get-python-versions.yml
+++ b/.github/workflows/get-python-versions.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - id: extract-versions
         run: |
-          python_versions='[ "3.8", "3.9", "3.10", "3.11", "3.12" ]'
+          python_versions='[ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]'
 
           echo "python-versions=${python_versions}" >> $GITHUB_OUTPUT
           echo "earliest-python-version=$(echo "${python_versions}" | jq --raw-output '.[0]')" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Addresses https://github.com/hazelcast/hazelcast-python-client/pull/719#pullrequestreview-2622720438.

Will also require updating branch protection rules.