### PR TITLE
Improve GitHub Actions `hazelcast` membership check

### DIFF
--- a/.github/workflows/coverage_runner.yml
+++ b/.github/workflows/coverage_runner.yml
@@ -27,7 +27,7 @@ jobs:
         uses: hazelcast/hazelcast-tpm/membership@main
         with:
           organization-name: 'hazelcast'
-          member-name: ${{ github.event.pull_request.head.repo.owner.login }}
+          member-name: ${{ github.actor }}
           token: ${{ secrets.PAT }}
           
   python-versions:


### PR DESCRIPTION
We restrict actions' execution to members of the `hazelcast` organisation using `hazelcast/hazelcast-tpm/membership`, passing in the user derviced from `github.event.pull_request.head.repo.owner.login`.

This is the owner of the repository, _not_ the user itself.

In the case of a non-fork PR - i.e. one in the `hazelcast` original repo - the `owner` will be `hazelcast` (which _isn't_ a GitHub user, and _isn't_ a member of the `hazelcast` organisation) and will fail.

This nuance prevented https://github.com/hazelcast/hazelcast-python-client/pull/720 from being merged.

Instead we should query `github.actor` as [already used in the C++ client](https://github.com/hazelcast/hazelcast-cpp-client/blame/b63e40748aa8e06f790510d86e1eae87cc36925a/.github/workflows/build-pr.yml#L50).