### PR TITLE
[HZ-5397] Asyncio Client Fixes (1)

### DIFF
--- a/hazelcast/cluster.py
+++ b/hazelcast/cluster.py
@@ -140,7 +140,7 @@ class _InternalClusterService:
             self.add_listener(*listener)
 
     def get_member(self, member_uuid):
-        check_not_none(uuid, "UUID must not be null")
+        check_not_none(member_uuid, "UUID must not be null")
         snapshot = self._member_list_snapshot
         return snapshot.members.get(member_uuid, None)
 

--- a/hazelcast/internal/asyncio_client.py
+++ b/hazelcast/internal/asyncio_client.py
@@ -64,7 +64,7 @@ class HazelcastClient:
 
         from hazelcast.asyncio import HazelcastClient
 
-        client = await HazelcastClient.crate_and_start(
+        client = await HazelcastClient.create_and_start(
             cluster_name="a-cluster",
         )
 

--- a/hazelcast/internal/asyncio_cluster.py
+++ b/hazelcast/internal/asyncio_cluster.py
@@ -144,7 +144,7 @@ class _InternalClusterService:
             self.add_listener(*listener)
 
     def get_member(self, member_uuid):
-        check_not_none(uuid, "UUID must not be null")
+        check_not_none(member_uuid, "UUID must not be null")
         snapshot = self._member_list_snapshot
         return snapshot.members.get(member_uuid, None)
 

--- a/hazelcast/internal/asyncio_cluster.py
+++ b/hazelcast/internal/asyncio_cluster.py
@@ -134,6 +134,9 @@ class _InternalClusterService:
         self._listeners = {}
         self._member_list_snapshot = _EMPTY_SNAPSHOT
         self._initial_list_fetched = asyncio.Event()
+        # asyncio tasks are weakly referenced; keep strong refs until they finish.
+        # see: https://docs.python.org/3/library/asyncio-task.html#creating-tasks
+        self._close_tasks: typing.Set[asyncio.Task] = set()
 
     def start(self, connection_manager, membership_listeners):
         self._connection_manager = connection_manager
@@ -282,14 +285,18 @@ class _InternalClusterService:
         for dead_member in dead_members:
             connection = self._connection_manager.get_connection(dead_member.uuid)
             if connection:
-                connection.close_connection(
-                    None,
-                    TargetDisconnectedError(
-                        "The client has closed the connection to this member, "
-                        "after receiving a member left event from the cluster. "
-                        "%s" % connection
-                    ),
+                task = asyncio.create_task(
+                    connection.close_connection(
+                        None,
+                        TargetDisconnectedError(
+                            "The client has closed the connection to this member, "
+                            "after receiving a member left event from the cluster. "
+                            "%s" % connection
+                        ),
+                    )
                 )
+                self._close_tasks.add(task)
+                task.add_done_callback(self._close_tasks.discard)
 
         if (len(new_members) + len(dead_members)) > 0:
             if len(current_members) > 0:

--- a/hazelcast/internal/asyncio_compact.py
+++ b/hazelcast/internal/asyncio_compact.py
@@ -102,6 +102,7 @@ class CompactSchemaService:
             # is not known to be replicated yet. We should retry
             # sending it in a random member.
             await asyncio.sleep(self._invocation_retry_pause)
+            remaining_retries -= 1
 
         # We tried to send it a couple of times, but the member list
         # in our local and the member list returned by the initiator

--- a/hazelcast/internal/asyncio_discovery.py
+++ b/hazelcast/internal/asyncio_discovery.py
@@ -53,6 +53,6 @@ class HazelcastCloudAddressProvider:
     async def refresh(self):
         """Refreshes the internal lookup table if necessary."""
         try:
-            self._private_to_public = self.cloud_discovery.discover_nodes()
+            self._private_to_public = await asyncio.to_thread(self.cloud_discovery.discover_nodes)
         except Exception as e:
             _logger.warning("Failed to load addresses from Hazelcast Cloud: %s", e)

--- a/hazelcast/internal/asyncio_listener.py
+++ b/hazelcast/internal/asyncio_listener.py
@@ -82,51 +82,54 @@ class ListenerService:
                         tg.create_task(task)
                 return registration_id
             except Exception:
-                await self.deregister_listener(registration_id)
+                await self._deregister_listener_unsafe(registration_id)
                 raise HazelcastError("Listener cannot be added")
 
     async def deregister_listener(self, user_registration_id):
         check_not_none(user_registration_id, "None user_registration_id is not allowed!")
         async with self._registration_lock:
-            listener_registration = self._active_registrations.pop(user_registration_id, None)
-            if not listener_registration:
-                return False
+            return await self._deregister_listener_unsafe(user_registration_id)
 
-            async def handle(inv: Invocation, conn: AsyncioConnection):
-                try:
-                    await inv.future
-                except Exception as e:
-                    if not isinstance(
-                        e, (HazelcastClientNotActiveError, IOError, TargetDisconnectedError)
-                    ):
-                        _logger.warning(
-                            "Deregistration of listener with ID %s has failed for address %s: %s",
-                            user_registration_id,
-                            conn.remote_address,
-                            e,
-                        )
+    async def _deregister_listener_unsafe(self, user_registration_id):
+        listener_registration = self._active_registrations.pop(user_registration_id, None)
+        if not listener_registration:
+            return False
 
-            async with asyncio.TaskGroup() as tg:
-                items = listener_registration.connection_registrations.items()
-                for connection, event_registration in items:
-                    # Remove local handler
-                    self.remove_event_handler(event_registration.correlation_id)
-                    # The rest is for deleting the remote registration
-                    server_registration_id = event_registration.server_registration_id
-                    deregister_request = listener_registration.encode_deregister_request(
-                        server_registration_id
+        async def handle(inv: Invocation, conn: AsyncioConnection):
+            try:
+                await inv.future
+            except Exception as e:
+                if not isinstance(
+                    e, (HazelcastClientNotActiveError, IOError, TargetDisconnectedError)
+                ):
+                    _logger.warning(
+                        "Deregistration of listener with ID %s has failed for address %s: %s",
+                        user_registration_id,
+                        conn.remote_address,
+                        e,
                     )
-                    if deregister_request is None:
-                        # None means no remote registration (e.g. for backup acks)
-                        continue
-                    invocation = Invocation(
-                        deregister_request, connection=connection, timeout=sys.maxsize, urgent=True
-                    )
-                    self._invocation_service.invoke(invocation)
-                    tg.create_task(handle(invocation, connection))
 
-            listener_registration.connection_registrations.clear()
-            return True
+        async with asyncio.TaskGroup() as tg:
+            items = listener_registration.connection_registrations.items()
+            for connection, event_registration in items:
+                # Remove local handler
+                self.remove_event_handler(event_registration.correlation_id)
+                # The rest is for deleting the remote registration
+                server_registration_id = event_registration.server_registration_id
+                deregister_request = listener_registration.encode_deregister_request(
+                    server_registration_id
+                )
+                if deregister_request is None:
+                    # None means no remote registration (e.g. for backup acks)
+                    continue
+                invocation = Invocation(
+                    deregister_request, connection=connection, timeout=sys.maxsize, urgent=True
+                )
+                self._invocation_service.invoke(invocation)
+                tg.create_task(handle(invocation, connection))
+
+        listener_registration.connection_registrations.clear()
+        return True
 
     def handle_client_message(self, message: InboundMessage, correlation_id: int):
         handler = self._event_handlers.get(correlation_id, None)

--- a/hazelcast/internal/asyncio_proxy/vector_collection.py
+++ b/hazelcast/internal/asyncio_proxy/vector_collection.py
@@ -390,7 +390,7 @@ class VectorCollection(Proxy, typing.Generic[KeyType, ValueType]):
             key_data = self._to_data(key)
             value_data = self._to_data(document.value)
         except SchemaNotReplicatedError as e:
-            return await self._send_schema_and_retry(e, self.set, key, document)
+            return await self._send_schema_and_retry(e, self.put, key, document)
         document = copy.copy(document)
         document.value = value_data
         request = vector_collection_put_codec.encode_request(
@@ -409,7 +409,7 @@ class VectorCollection(Proxy, typing.Generic[KeyType, ValueType]):
             key_data = self._to_data(key)
             value_data = self._to_data(document.value)
         except SchemaNotReplicatedError as e:
-            return await self._send_schema_and_retry(e, self.set, key, document)
+            return await self._send_schema_and_retry(e, self.put_if_absent, key, document)
         document.value = value_data
         request = vector_collection_put_if_absent_codec.encode_request(
             self.name,

--- a/hazelcast/internal/asyncio_statistics.py
+++ b/hazelcast/internal/asyncio_statistics.py
@@ -182,7 +182,7 @@ class Statistics:
                 self._add_system_or_process_metric(
                     attributes, compressor, gauge_name, value, value_type
                 )
-            except:
+            except Exception:
                 _logger.exception("Error while collecting '%s'.", gauge_name)
 
         if not self._registered_process_gauges:
@@ -197,7 +197,7 @@ class Statistics:
                 self._add_system_or_process_metric(
                     attributes, compressor, gauge_name, value, value_type
                 )
-            except:
+            except Exception:
                 _logger.exception("Error while collecting '%s'.", gauge_name)
 
     def _add_system_or_process_metric(self, attributes, compressor, gauge_name, value, value_type):
@@ -343,7 +343,7 @@ class Statistics:
         try:
             self._add_metric(compressor, descriptor, value, value_type)
             self._add_attribute(attributes, metric, value, nc_name_with_prefix)
-        except:
+        except Exception:
             _logger.exception(
                 "Error while collecting %s metric for near cache '%s'.", metric, nc_name
             )
@@ -362,7 +362,7 @@ class Statistics:
         )
         try:
             self._add_metric(compressor, descriptor, value, value_type)
-        except:
+        except Exception:
             _logger.exception("Error while collecting '%s.%s'.", _TCP_METRICS_PREFIX, metric)
 
     def _add_metric(self, compressor, descriptor, value, value_type):

--- a/hazelcast/proxy/vector_collection.py
+++ b/hazelcast/proxy/vector_collection.py
@@ -391,7 +391,7 @@ class VectorCollection(Proxy["BlockingVectorCollection"]):
             key_data = self._to_data(key)
             value_data = self._to_data(document.value)
         except SchemaNotReplicatedError as e:
-            return self._send_schema_and_retry(e, self.set, key, document)
+            return self._send_schema_and_retry(e, self.put, key, document)
         document = copy.copy(document)
         document.value = value_data
         request = vector_collection_put_codec.encode_request(
@@ -410,7 +410,7 @@ class VectorCollection(Proxy["BlockingVectorCollection"]):
             key_data = self._to_data(key)
             value_data = self._to_data(document.value)
         except SchemaNotReplicatedError as e:
-            return self._send_schema_and_retry(e, self.set, key, document)
+            return self._send_schema_and_retry(e, self.put_if_absent, key, document)
         document.value = value_data
         request = vector_collection_put_if_absent_codec.encode_request(
             self.name,


### PR DESCRIPTION
This PR fixes the following issues with the asyncio and asyncore clients:
1. Create tasks for conn.close_connection calls.
2. Cluster `get_member` must use the correct variable
3. Fix the deadlock in asyncio listener
4. Wrong retry methods in VectorCollection
5. Remaining retries in schema replicaiton
6. Blocking cloud discovery refresh