### PR TITLE
[HZ-5406] Ringbuffer for Asyncio

### DIFF
--- a/hazelcast/internal/asyncio_client.py
+++ b/hazelcast/internal/asyncio_client.py
@@ -7,7 +7,7 @@ from hazelcast.internal.asyncio_cluster import ClusterService, _InternalClusterS
 from hazelcast.internal.asyncio_compact import CompactSchemaService
 from hazelcast.config import Config, IndexConfig
 from hazelcast.internal.asyncio_connection import ConnectionManager, DefaultAsyncioAddressProvider
-from hazelcast.core import DistributedObjectEvent, DistributedObjectInfo
+from hazelcast.core import DistributedObjectEvent
 from hazelcast.discovery import HazelcastCloudAddressProvider
 from hazelcast.errors import IllegalStateError, InvalidConfigurationError
 from hazelcast.internal.asyncio_invocation import InvocationService, Invocation
@@ -18,7 +18,6 @@ from hazelcast.near_cache import NearCacheManager
 from hazelcast.internal.asyncio_partition import PartitionService, InternalPartitionService
 from hazelcast.protocol.codec import (
     client_add_distributed_object_listener_codec,
-    client_get_distributed_objects_codec,
     client_remove_distributed_object_listener_codec,
     dynamic_config_add_vector_collection_config_codec,
 )
@@ -27,12 +26,13 @@ from hazelcast.internal.asyncio_proxy.manager import (
     MAP_SERVICE,
     ProxyManager,
     REPLICATED_MAP_SERVICE,
+    RINGBUFFER_SERVICE,
     VECTOR_SERVICE,
 )
-from hazelcast.internal.asyncio_proxy.base import Proxy
 from hazelcast.internal.asyncio_proxy.list import List
 from hazelcast.internal.asyncio_proxy.map import Map
 from hazelcast.internal.asyncio_proxy.replicated_map import ReplicatedMap
+from hazelcast.internal.asyncio_proxy.ringbuffer import Ringbuffer
 from hazelcast.internal.asyncio_reactor import AsyncioReactor
 from hazelcast.serialization import SerializationServiceV1
 from hazelcast.internal.asyncio_statistics import Statistics
@@ -285,6 +285,17 @@ class HazelcastClient:
             Distributed ReplicatedMap instance with the specified name.
         """
         return await self._proxy_manager.get_or_create(REPLICATED_MAP_SERVICE, name)
+
+    async def get_ringbuffer(self, name: str) -> Ringbuffer:
+        """Returns the distributed Ringbuffer instance with the specified name.
+
+        Args:
+            name: Name of the distributed ringbuffer.
+
+        Returns:
+            Distributed Ringbuffer instance with the specified name.
+        """
+        return await self._proxy_manager.get_or_create(RINGBUFFER_SERVICE, name)
 
     async def create_vector_collection_config(
         self,

--- a/hazelcast/internal/asyncio_client.py
+++ b/hazelcast/internal/asyncio_client.py
@@ -42,7 +42,7 @@ from hazelcast.internal.asyncio_proxy.set import Set
 from hazelcast.internal.asyncio_reactor import AsyncioReactor
 from hazelcast.serialization import SerializationServiceV1
 from hazelcast.internal.asyncio_statistics import Statistics
-from hazelcast.types import KeyType, ValueType
+from hazelcast.types import KeyType, ValueType, ItemType
 from hazelcast.util import AtomicInteger, RoundRobinLB
 
 __all__ = ("HazelcastClient",)
@@ -325,7 +325,7 @@ class HazelcastClient:
         """
         return await self._proxy_manager.get_or_create(REPLICATED_MAP_SERVICE, name)
 
-    async def get_ringbuffer(self, name: str) -> Ringbuffer:
+    async def get_ringbuffer(self, name: str) -> Ringbuffer[ItemType]:
         """Returns the distributed Ringbuffer instance with the specified name.
 
         Args:

--- a/hazelcast/internal/asyncio_proxy/manager.py
+++ b/hazelcast/internal/asyncio_proxy/manager.py
@@ -11,11 +11,13 @@ from hazelcast.internal.asyncio_invocation import Invocation
 from hazelcast.internal.asyncio_proxy.base import Proxy
 from hazelcast.internal.asyncio_proxy.map import create_map_proxy
 from hazelcast.internal.asyncio_proxy.replicated_map import create_replicated_map_proxy
+from hazelcast.internal.asyncio_proxy.ringbuffer import create_ringbuffer_proxy
 from hazelcast.util import to_list
 
 LIST_SERVICE = "hz:impl:listService"
 MAP_SERVICE = "hz:impl:mapService"
 REPLICATED_MAP_SERVICE = "hz:impl:replicatedMapService"
+RINGBUFFER_SERVICE = "hz:impl:ringbufferService"
 VECTOR_SERVICE = "hz:service:vector"
 
 _proxy_init: typing.Dict[
@@ -25,6 +27,7 @@ _proxy_init: typing.Dict[
     LIST_SERVICE: create_list_proxy,
     MAP_SERVICE: create_map_proxy,
     REPLICATED_MAP_SERVICE: create_replicated_map_proxy,
+    RINGBUFFER_SERVICE: create_ringbuffer_proxy,
     VECTOR_SERVICE: create_vector_collection_proxy,
 }
 

--- a/hazelcast/internal/asyncio_proxy/ringbuffer.py
+++ b/hazelcast/internal/asyncio_proxy/ringbuffer.py
@@ -153,7 +153,7 @@ class Ringbuffer(PartitionSpecificProxy, typing.Generic[ItemType]):
         items: typing.Sequence[ItemType],
         overflow_policy: int = OVERFLOW_POLICY_OVERWRITE,
     ) -> int:
-        """Adds all of the item in the specified collection to the tail of the
+        """Adds all items in the specified collection to the tail of the
         Ringbuffer.
 
         This is likely to outperform multiple calls to :func:`add` due
@@ -194,7 +194,7 @@ class Ringbuffer(PartitionSpecificProxy, typing.Generic[ItemType]):
         """Reads one item from the Ringbuffer.
 
         If the sequence is one beyond the current tail, this call blocks until
-        an item  is added. Currently it isn't possible to control how long
+        an item  is added. Currently, it isn't possible to control how long
         this call is going to block.
 
         Args:
@@ -217,21 +217,20 @@ class Ringbuffer(PartitionSpecificProxy, typing.Generic[ItemType]):
         """Reads a batch of items from the Ringbuffer.
 
         If the number of available items after the first read item is smaller
-        than the ``max_count``, these items are returned. So it could be the
-        number of items read is smaller than the ``max_count``. If there are
-        less items available than ``min_count``, then this call blocks.
+        than ``max_count``, these items are returned. So, number of items
+        read may be smaller than ``max_count``. If there are
+        fewer items available than ``min_count``, then this call blocks.
 
         Warnings:
             These blocking calls consume server memory and if there are many
-            calls, it can be possible to see leaking memory or
-            ``OutOfMemoryError`` s on the server.
+            calls, an ``OutOfMemoryError`` may be thrown on server-side.
 
         Reading a batch of items is likely to perform better because less
         overhead is involved.
 
-        A filter can be provided to only select items that need to be read. If
+        A filter can be provided to select items that need to be read. If
         the filter is ``None``, all items are read. If the filter is not
-        ``None``, only items where the filter function returns true are
+        ``None``, items where the filter function returns true are
         returned. Using  filters is a good way to prevent getting items that
         are of no value to the receiver. This reduces the amount of IO and the
         number of operations being executed, and can result in a significant

--- a/hazelcast/internal/asyncio_proxy/ringbuffer.py
+++ b/hazelcast/internal/asyncio_proxy/ringbuffer.py
@@ -1,7 +1,5 @@
 import typing
-from collections.abc import Sequence, Iterable
 
-from hazelcast.future import ImmediateFuture, Future
 from hazelcast.protocol.codec import (
     ringbuffer_add_all_codec,
     ringbuffer_add_codec,
@@ -13,7 +11,8 @@ from hazelcast.protocol.codec import (
     ringbuffer_size_codec,
     ringbuffer_tail_sequence_codec,
 )
-from hazelcast.proxy.base import PartitionSpecificProxy
+from hazelcast.internal.asyncio_proxy.base import PartitionSpecificProxy
+from hazelcast.proxy.ringbuffer import ReadResult, OVERFLOW_POLICY_OVERWRITE, MAX_BATCH_SIZE
 from hazelcast.types import ItemType
 from hazelcast.serialization.compact import SchemaNotReplicatedError
 from hazelcast.util import (
@@ -24,130 +23,8 @@ from hazelcast.util import (
     deserialize_list_in_place,
 )
 
-OVERFLOW_POLICY_OVERWRITE = 0
-"""
-Configuration property for DEFAULT overflow policy. When an item is tried to be added on full Ringbuffer, oldest item in
-the Ringbuffer is overwritten and item is added.
-"""
 
-OVERFLOW_POLICY_FAIL = 1
-"""
-Configuration property for overflow policy. When an item is tried to be added on full Ringbuffer, the call fails and
-item is not added.
-
-The reason that FAIL exist is to give the opportunity to obey the ttl. If blocking behavior is required, this can be
-implemented using retrying in combination with an exponential backoff.
-
-    >>> sleepMS = 100;
-    >>> while true:
-    >>>     result = ringbuffer.add(item, -1)
-    >>>     if result != -1:
-    >>>         break
-    >>>     sleep(sleepMS / 1000)
-    >>>     sleepMS *= 2
-"""
-
-MAX_BATCH_SIZE = 1000
-"""
-The maximum number of items to be added to RingBuffer or read from RingBuffer at a time.
-"""
-
-
-class ReadResult(Sequence):
-    """Defines the result of a :func:`Ringbuffer.read_many` operation."""
-
-    SEQUENCE_UNAVAILABLE = -1
-    """Value returned from methods returning a sequence number when the
-    information is not available (e.g. because of rolling upgrade and some
-    members not returning the sequence).
-    """
-
-    def __init__(self, read_count, next_seq, item_seqs, items):
-        super(ReadResult, self).__init__()
-        self._read_count = read_count
-        self._next_seq = next_seq
-        self._item_seqs = item_seqs
-        self._items = items
-
-    @property
-    def read_count(self) -> int:
-        """The number of items that have been read before filtering.
-
-        If no filter is set, then the :attr:`read_count` will be equal to
-        :attr:`size`.
-
-        But if a filter is applied, it could be that items are read, but are
-        filtered out. So, if you are trying to make another read based on
-        this, then you should increment the sequence by :attr:`read_count` and
-        not by :attr:`size`.
-
-        Otherwise, you will be re-reading the same filtered messages.
-        """
-        return self._read_count
-
-    @property
-    def size(self) -> int:
-        """The result set size.
-
-        See Also:
-            :attr:`read_count`
-        """
-        return len(self._items)
-
-    @property
-    def next_sequence_to_read_from(self) -> int:
-        """The sequence of the item following the last read item.
-
-        This sequence can then be used to read items following the ones
-        returned by this result set.
-
-        Usually this sequence is equal to the sequence used to retrieve this
-        result set incremented by the :attr:`read_count`. In cases when the
-        reader tolerates lost items, this is not the case.
-
-        For instance, if the reader requests an item with a stale sequence (one
-        which has already been overwritten), the read will jump to the oldest
-        sequence and read from there.
-
-        Similarly, if the reader requests an item in the future (e.g. because
-        the partition was lost and the reader was unaware of this), the read
-        method will jump back to the newest available sequence.
-
-        Because of these jumps and only in the case when the reader is loss
-        tolerant, the next sequence must be retrieved using this method.
-        A return value of :const:`SEQUENCE_UNAVAILABLE` means that the
-        information is not available.
-        """
-        return self._next_seq
-
-    def get_sequence(self, index: int) -> int:
-        """Return the sequence number for the item at the given index.
-
-        Args:
-            index: The index.
-
-        Returns:
-            The sequence number for the ringbuffer item.
-        """
-        return self._item_seqs[index]
-
-    def __getitem__(self, index: typing.Union[int, slice]) -> typing.Any:
-        return self._items[index]
-
-    def __len__(self) -> int:
-        return len(self._items)
-
-    def __eq__(self, other) -> bool:
-        # This implementation is copied from the
-        # now removed super class. It is implemented
-        # to maintain backward compatibility.
-        if not isinstance(other, Iterable):
-            return False
-
-        return self._items == other
-
-
-class Ringbuffer(PartitionSpecificProxy["BlockingRingbuffer"], typing.Generic[ItemType]):
+class Ringbuffer(PartitionSpecificProxy, typing.Generic[ItemType]):
     """A Ringbuffer is an append-only data-structure where the content is
     stored in a ring like structure.
 
@@ -170,20 +47,25 @@ class Ringbuffer(PartitionSpecificProxy["BlockingRingbuffer"], typing.Generic[It
 
     A Ringbuffer currently is a replicated, but not partitioned data structure.
     So all data is stored in a single partition, similarly to the
-    :class:`hazelcast.proxy.queue.Queue` implementation.
+    :class:`hazelcast.internal.asyncio_proxy.queue.Queue` implementation.
 
     A Ringbuffer can be used in a way similar to the Queue, but one of the key
-    differences is that a :func:`hazelcast.proxy.queue.Queue.take` is destructive,
-    meaning that only 1 thread is able to take an item. A :func:`read_one` is not
-    destructive, so you can have multiple threads reading the same item multiple
-    times.
+    differences is that a :func:`hazelcast.internal.asyncio_proxy.queue.Queue.take`
+    is destructive, meaning that only 1 consumer is able to take an item.
+    A :func:`read_one` is not destructive, so you can have multiple consumers reading the
+    same item multiple times.
+
+    Example:
+        >>> rb = await client.get_ringbuffer("my_ringbuffer")
+        >>> await rb.add("item")
+        >>> print("read_one", await rb.read_one(0))
     """
 
     def __init__(self, service_name, name, context):
         super(Ringbuffer, self).__init__(service_name, name, context)
         self._capacity = None
 
-    def capacity(self) -> Future[int]:
+    async def capacity(self) -> int:
         """Returns the capacity of this Ringbuffer.
 
         Returns:
@@ -196,20 +78,20 @@ class Ringbuffer(PartitionSpecificProxy["BlockingRingbuffer"], typing.Generic[It
                 return self._capacity
 
             request = ringbuffer_capacity_codec.encode_request(self.name)
-            return self._invoke(request, handler)
+            return await self._invoke(request, handler)
 
-        return ImmediateFuture(self._capacity)
+        return self._capacity
 
-    def size(self) -> Future[int]:
+    async def size(self) -> int:
         """Returns number of items in the Ringbuffer.
 
         Returns:
             The size of Ringbuffer.
         """
         request = ringbuffer_size_codec.encode_request(self.name)
-        return self._invoke(request, ringbuffer_size_codec.decode_response)
+        return await self._invoke(request, ringbuffer_size_codec.decode_response)
 
-    def tail_sequence(self) -> Future[int]:
+    async def tail_sequence(self) -> int:
         """Returns the sequence of the tail.
 
         The tail is the side of the Ringbuffer where the items are added to.
@@ -219,9 +101,9 @@ class Ringbuffer(PartitionSpecificProxy["BlockingRingbuffer"], typing.Generic[It
             The sequence of the tail.
         """
         request = ringbuffer_tail_sequence_codec.encode_request(self.name)
-        return self._invoke(request, ringbuffer_tail_sequence_codec.decode_response)
+        return await self._invoke(request, ringbuffer_tail_sequence_codec.decode_response)
 
-    def head_sequence(self) -> Future[int]:
+    async def head_sequence(self) -> int:
         """Returns the sequence of the head.
 
         The head is the side of the Ringbuffer where the oldest items in the
@@ -233,18 +115,18 @@ class Ringbuffer(PartitionSpecificProxy["BlockingRingbuffer"], typing.Generic[It
             The sequence of the head.
         """
         request = ringbuffer_head_sequence_codec.encode_request(self.name)
-        return self._invoke(request, ringbuffer_head_sequence_codec.decode_response)
+        return await self._invoke(request, ringbuffer_head_sequence_codec.decode_response)
 
-    def remaining_capacity(self) -> Future[int]:
+    async def remaining_capacity(self) -> int:
         """Returns the remaining capacity of the Ringbuffer.
 
         Returns:
             The remaining capacity of Ringbuffer.
         """
         request = ringbuffer_remaining_capacity_codec.encode_request(self.name)
-        return self._invoke(request, ringbuffer_remaining_capacity_codec.decode_response)
+        return await self._invoke(request, ringbuffer_remaining_capacity_codec.decode_response)
 
-    def add(self, item, overflow_policy: int = OVERFLOW_POLICY_OVERWRITE) -> Future[int]:
+    async def add(self, item, overflow_policy: int = OVERFLOW_POLICY_OVERWRITE) -> int:
         """Adds the specified item to the tail of the Ringbuffer.
 
         If there is no space in the Ringbuffer, the action is determined by
@@ -261,16 +143,16 @@ class Ringbuffer(PartitionSpecificProxy["BlockingRingbuffer"], typing.Generic[It
         try:
             item_data = self._to_data(item)
         except SchemaNotReplicatedError as e:
-            return self._send_schema_and_retry(e, self.add, item, overflow_policy)
+            return await self._send_schema_and_retry(e, self.add, item, overflow_policy)
 
         request = ringbuffer_add_codec.encode_request(self.name, overflow_policy, item_data)
-        return self._invoke(request, ringbuffer_add_codec.decode_response)
+        return await self._invoke(request, ringbuffer_add_codec.decode_response)
 
-    def add_all(
+    async def add_all(
         self,
         items: typing.Sequence[ItemType],
         overflow_policy: int = OVERFLOW_POLICY_OVERWRITE,
-    ) -> Future[int]:
+    ) -> int:
         """Adds all of the item in the specified collection to the tail of the
         Ringbuffer.
 
@@ -301,14 +183,14 @@ class Ringbuffer(PartitionSpecificProxy["BlockingRingbuffer"], typing.Generic[It
                 check_not_none(item, "item can't be None")
                 item_data_list.append(self._to_data(item))
         except SchemaNotReplicatedError as e:
-            return self._send_schema_and_retry(e, self.add_all, items, overflow_policy)
+            return await self._send_schema_and_retry(e, self.add_all, items, overflow_policy)
 
         request = ringbuffer_add_all_codec.encode_request(
             self.name, item_data_list, overflow_policy
         )
-        return self._invoke(request, ringbuffer_add_all_codec.decode_response)
+        return await self._invoke(request, ringbuffer_add_all_codec.decode_response)
 
-    def read_one(self, sequence: int) -> Future[ItemType]:
+    async def read_one(self, sequence: int) -> ItemType:
         """Reads one item from the Ringbuffer.
 
         If the sequence is one beyond the current tail, this call blocks until
@@ -327,11 +209,11 @@ class Ringbuffer(PartitionSpecificProxy["BlockingRingbuffer"], typing.Generic[It
             return self._to_object(ringbuffer_read_one_codec.decode_response(message))
 
         request = ringbuffer_read_one_codec.encode_request(self.name, sequence)
-        return self._invoke(request, handler)
+        return await self._invoke(request, handler)
 
-    def read_many(
+    async def read_many(
         self, start_sequence: int, min_count: int, max_count: int, filter: typing.Any = None
-    ) -> Future[ReadResult]:
+    ) -> ReadResult:
         """Reads a batch of items from the Ringbuffer.
 
         If the number of available items after the first read item is smaller
@@ -386,9 +268,17 @@ class Ringbuffer(PartitionSpecificProxy["BlockingRingbuffer"], typing.Generic[It
         try:
             filter_data = self._to_data(filter)
         except SchemaNotReplicatedError as e:
-            return self._send_schema_and_retry(
+            return await self._send_schema_and_retry(
                 e, self.read_many, start_sequence, min_count, max_count, filter
             )
+
+        # Since the first call to capacity is cached on the client-side,
+        # doing a capacity check each time should not be a problem.
+        capacity = await self.capacity()
+        check_true(
+            max_count <= capacity,
+            "max count: %d should be smaller or equal to capacity: %d" % (max_count, capacity),
+        )
 
         request = ringbuffer_read_many_codec.encode_request(
             self.name, start_sequence, min_count, max_count, filter_data
@@ -400,96 +290,10 @@ class Ringbuffer(PartitionSpecificProxy["BlockingRingbuffer"], typing.Generic[It
             read_count = response["read_count"]
             next_seq = response["next_seq"]
             item_seqs = response["item_seqs"]
-
             return ReadResult(read_count, next_seq, item_seqs, items)
 
-        def continuation(future):
-            # Since the first call to capacity
-            # is cached on the client-side, doing
-            # a capacity check each time should not
-            # be a problem
-            capacity = future.result()
-
-            check_true(
-                max_count <= capacity,
-                "max count: %d should be smaller or equal to capacity: %d" % (max_count, capacity),
-            )
-
-            return self._invoke(request, handler)
-
-        return self.capacity().continue_with(continuation)
-
-    def blocking(self) -> "BlockingRingbuffer[ItemType]":
-        return BlockingRingbuffer(self)
+        return await self._invoke(request, handler)
 
 
-class BlockingRingbuffer(Ringbuffer[ItemType]):
-    __slots__ = ("_wrapped", "name", "service_name")
-
-    def __init__(self, wrapped: Ringbuffer[ItemType]):
-        self.name = wrapped.name
-        self.service_name = wrapped.service_name
-        self._wrapped = wrapped
-
-    def capacity(  # type: ignore[override]
-        self,
-    ) -> int:
-        return self._wrapped.capacity().result()
-
-    def size(  # type: ignore[override]
-        self,
-    ) -> int:
-        return self._wrapped.size().result()
-
-    def tail_sequence(  # type: ignore[override]
-        self,
-    ) -> int:
-        return self._wrapped.tail_sequence().result()
-
-    def head_sequence(  # type: ignore[override]
-        self,
-    ) -> int:
-        return self._wrapped.head_sequence().result()
-
-    def remaining_capacity(  # type: ignore[override]
-        self,
-    ) -> int:
-        return self._wrapped.remaining_capacity().result()
-
-    def add(  # type: ignore[override]
-        self,
-        item,
-        overflow_policy: int = OVERFLOW_POLICY_OVERWRITE,
-    ) -> int:
-        return self._wrapped.add(item, overflow_policy).result()
-
-    def add_all(  # type: ignore[override]
-        self,
-        items: typing.Sequence[ItemType],
-        overflow_policy: int = OVERFLOW_POLICY_OVERWRITE,
-    ) -> int:
-        return self._wrapped.add_all(items, overflow_policy).result()
-
-    def read_one(  # type: ignore[override]
-        self,
-        sequence: int,
-    ) -> ItemType:
-        return self._wrapped.read_one(sequence).result()
-
-    def read_many(  # type: ignore[override]
-        self,
-        start_sequence: int,
-        min_count: int,
-        max_count: int,
-        filter: typing.Any = None,
-    ) -> ReadResult:
-        return self._wrapped.read_many(start_sequence, min_count, max_count, filter).result()
-
-    def destroy(self) -> bool:
-        return self._wrapped.destroy()
-
-    def blocking(self) -> "BlockingRingbuffer[ItemType]":
-        return self
-
-    def __repr__(self) -> str:
-        return self._wrapped.__repr__()
+async def create_ringbuffer_proxy(service_name, name, context):
+    return Ringbuffer(service_name, name, context)

--- a/hazelcast/proxy/ringbuffer.py
+++ b/hazelcast/proxy/ringbuffer.py
@@ -271,7 +271,7 @@ class Ringbuffer(PartitionSpecificProxy["BlockingRingbuffer"], typing.Generic[It
         items: typing.Sequence[ItemType],
         overflow_policy: int = OVERFLOW_POLICY_OVERWRITE,
     ) -> Future[int]:
-        """Adds all of the item in the specified collection to the tail of the
+        """Adds all items in the specified collection to the tail of the
         Ringbuffer.
 
         This is likely to outperform multiple calls to :func:`add` due
@@ -312,7 +312,7 @@ class Ringbuffer(PartitionSpecificProxy["BlockingRingbuffer"], typing.Generic[It
         """Reads one item from the Ringbuffer.
 
         If the sequence is one beyond the current tail, this call blocks until
-        an item  is added. Currently it isn't possible to control how long
+        an item  is added. Currently, it isn't possible to control how long
         this call is going to block.
 
         Args:
@@ -335,21 +335,20 @@ class Ringbuffer(PartitionSpecificProxy["BlockingRingbuffer"], typing.Generic[It
         """Reads a batch of items from the Ringbuffer.
 
         If the number of available items after the first read item is smaller
-        than the ``max_count``, these items are returned. So it could be the
-        number of items read is smaller than the ``max_count``. If there are
-        less items available than ``min_count``, then this call blocks.
+        than ``max_count``, these items are returned. So, number of items
+        read may be smaller than ``max_count``. If there are
+        fewer items available than ``min_count``, then this call blocks.
 
         Warnings:
             These blocking calls consume server memory and if there are many
-            calls, it can be possible to see leaking memory or
-            ``OutOfMemoryError`` s on the server.
+            calls, an ``OutOfMemoryError`` may be thrown on server-side.
 
         Reading a batch of items is likely to perform better because less
         overhead is involved.
 
-        A filter can be provided to only select items that need to be read. If
+        A filter can be provided to select items that need to be read. If
         the filter is ``None``, all items are read. If the filter is not
-        ``None``, only items where the filter function returns true are
+        ``None``, items where the filter function returns true are
         returned. Using  filters is a good way to prevent getting items that
         are of no value to the receiver. This reduces the amount of IO and the
         number of operations being executed, and can result in a significant
@@ -404,10 +403,8 @@ class Ringbuffer(PartitionSpecificProxy["BlockingRingbuffer"], typing.Generic[It
             return ReadResult(read_count, next_seq, item_seqs, items)
 
         def continuation(future):
-            # Since the first call to capacity
-            # is cached on the client-side, doing
-            # a capacity check each time should not
-            # be a problem
+            # Since the first call to capacity is cached on the client-side,
+            # doing a capacity check each time should not be a problem.
             capacity = future.result()
 
             check_true(

--- a/tests/integration/asyncio/proxy/ringbuffer_test.py
+++ b/tests/integration/asyncio/proxy/ringbuffer_test.py
@@ -176,11 +176,6 @@ class RingbufferReadManyTest(SingleMemberTestCase):
         task = asyncio.create_task(self.ringbuffer.read_many(CAPACITY + 1, 1, CAPACITY))
         await asyncio.sleep(0.5)
         self.assertFalse(task.done())
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
 
     async def test_when_min_count_items_are_not_available_then_blocks(self):
         await self.fill_ringbuffer()
@@ -188,11 +183,6 @@ class RingbufferReadManyTest(SingleMemberTestCase):
         task = asyncio.create_task(self.ringbuffer.read_many(CAPACITY - 1, 2, 3))
         await asyncio.sleep(0.5)
         self.assertFalse(task.done())
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
 
     async def test_when_some_waiting_needed(self):
         await self.fill_ringbuffer()

--- a/tests/integration/asyncio/proxy/ringbuffer_test.py
+++ b/tests/integration/asyncio/proxy/ringbuffer_test.py
@@ -1,0 +1,307 @@
+import asyncio
+import os
+import unittest
+
+from hazelcast.proxy.ringbuffer import OVERFLOW_POLICY_FAIL, MAX_BATCH_SIZE
+from hazelcast.serialization.api import IdentifiedDataSerializable
+from tests.integration.asyncio.base import SingleMemberTestCase
+from tests.util import random_string, compare_client_version
+
+CAPACITY = 10
+
+
+class RingBufferTest(SingleMemberTestCase):
+    @classmethod
+    def configure_client(cls, config):
+        config["cluster_name"] = cls.cluster.id
+        return config
+
+    @classmethod
+    def configure_cluster(cls):
+        path = os.path.abspath(__file__)
+        dir_path = os.path.dirname(path)
+        xml_path = os.path.join(
+            dir_path, "../../backward_compatible/proxy/hazelcast.xml"
+        )
+        with open(xml_path) as f:
+            return f.read()
+
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        self.ringbuffer = await self.client.get_ringbuffer(
+            "ClientRingbufferTestWithTTL-" + random_string()
+        )
+
+    async def asyncTearDown(self):
+        await self.ringbuffer.destroy()
+        await super().asyncTearDown()
+
+    async def test_capacity(self):
+        self.assertEqual(await self.ringbuffer.capacity(), CAPACITY)
+
+    async def test_add_size(self):
+        self.assertEqual(0, await self.ringbuffer.add("value"))
+        self.assertEqual(1, await self.ringbuffer.add("value"))
+        self.assertEqual(2, await self.ringbuffer.add("value"))
+
+        self.assertEqual(3, await self.ringbuffer.size())
+
+    async def test_add_when_full(self):
+        await self.fill_ringbuffer()
+
+        self.assertEqual(-1, await self.ringbuffer.add(CAPACITY + 1, OVERFLOW_POLICY_FAIL))
+
+    async def test_add_all(self):
+        self.assertEqual(CAPACITY - 1, await self.ringbuffer.add_all(list(range(0, CAPACITY))))
+
+    async def test_add_all_when_full(self):
+        self.assertEqual(
+            -1, await self.ringbuffer.add_all(list(range(0, CAPACITY * 2)), OVERFLOW_POLICY_FAIL)
+        )
+
+    async def test_add_all_when_empty_list(self):
+        with self.assertRaises(AssertionError):
+            await self.ringbuffer.add_all([])
+
+    async def test_add_all_when_too_large_batch(self):
+        with self.assertRaises(AssertionError):
+            await self.ringbuffer.add_all(list(range(0, MAX_BATCH_SIZE + 1)))
+
+    async def test_head_sequence(self):
+        await self.fill_ringbuffer(CAPACITY * 2)
+
+        self.assertEqual(CAPACITY, await self.ringbuffer.head_sequence())
+
+    async def test_tail_sequence(self):
+        await self.fill_ringbuffer(CAPACITY * 2)
+
+        self.assertEqual(CAPACITY * 2 - 1, await self.ringbuffer.tail_sequence())
+
+    async def test_remaining_capacity(self):
+        await self.fill_ringbuffer(CAPACITY // 2)
+
+        self.assertEqual(CAPACITY // 2, await self.ringbuffer.remaining_capacity())
+
+    async def test_read_one(self):
+        await self.ringbuffer.add("item")
+        await self.ringbuffer.add("item-2")
+        await self.ringbuffer.add("item-3")
+        self.assertEqual("item", await self.ringbuffer.read_one(0))
+        self.assertEqual("item-2", await self.ringbuffer.read_one(1))
+        self.assertEqual("item-3", await self.ringbuffer.read_one(2))
+
+    async def test_read_one_negative_sequence(self):
+        with self.assertRaises(AssertionError):
+            await self.ringbuffer.read_one(-1)
+
+    async def test_read_many(self):
+        await self.fill_ringbuffer(CAPACITY)
+        items = await self.ringbuffer.read_many(0, 0, CAPACITY)
+        self.assertEqual(items, list(range(0, CAPACITY)))
+
+    async def test_read_many_when_negative_start_seq(self):
+        with self.assertRaises(AssertionError):
+            await self.ringbuffer.read_many(-1, 0, CAPACITY)
+
+    async def test_read_many_when_min_count_greater_than_max_count(self):
+        with self.assertRaises(AssertionError):
+            await self.ringbuffer.read_many(0, CAPACITY, 0)
+
+    async def test_read_many_when_min_count_greater_than_capacity(self):
+        with self.assertRaises(AssertionError):
+            await self.ringbuffer.read_many(0, CAPACITY + 1, CAPACITY + 1)
+
+    async def test_read_many_when_max_count_greater_than_batch_size(self):
+        with self.assertRaises(AssertionError):
+            await self.ringbuffer.read_many(0, 0, MAX_BATCH_SIZE + 1)
+
+    async def fill_ringbuffer(self, n=CAPACITY):
+        for x in range(0, n):
+            await self.ringbuffer.add(x)
+
+    async def test_str(self):
+        self.assertTrue(str(self.ringbuffer).startswith("Ringbuffer"))
+
+
+@unittest.skipIf(
+    compare_client_version("4.1") < 0, "Tests the features added in 4.1 version of the client"
+)
+class RingbufferReadManyTest(SingleMemberTestCase):
+    @classmethod
+    def configure_client(cls, config):
+        config["cluster_name"] = cls.cluster.id
+        return config
+
+    @classmethod
+    def configure_cluster(cls):
+        path = os.path.abspath(__file__)
+        dir_path = os.path.dirname(path)
+        xml_path = os.path.join(
+            dir_path, "../../backward_compatible/proxy/hazelcast.xml"
+        )
+        with open(xml_path) as f:
+            return f.read()
+
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        self.ringbuffer = await self.client.get_ringbuffer(
+            "ClientRingbufferTestWithTTL-" + random_string()
+        )
+
+    async def asyncTearDown(self):
+        await self.ringbuffer.destroy()
+        await super().asyncTearDown()
+
+    async def test_when_start_sequence_is_no_longer_available_gets_clamped(self):
+        await self.fill_ringbuffer(item_count=CAPACITY + 1)
+
+        result_set = await self.ringbuffer.read_many(0, 1, CAPACITY)
+        self.assertEqual(CAPACITY, result_set.read_count)
+        self.assertEqual(CAPACITY, result_set.size)
+        self.assertEqual(CAPACITY + 1, result_set.next_sequence_to_read_from)
+
+        for i in range(1, CAPACITY + 1):
+            self.assertEqual(i, result_set[i - 1])
+            self.assertEqual(i, result_set.get_sequence(i - 1))
+
+    async def test_when_start_sequence_is_equal_to_tail_sequence(self):
+        await self.fill_ringbuffer()
+
+        result_set = await self.ringbuffer.read_many(CAPACITY - 1, 1, CAPACITY)
+        self.assertEqual(1, result_set.read_count)
+        self.assertEqual(1, result_set.size)
+        self.assertEqual(CAPACITY, result_set.next_sequence_to_read_from)
+        self.assertEqual(CAPACITY - 1, result_set[0])
+        self.assertEqual(CAPACITY - 1, result_set.get_sequence(0))
+
+    async def test_when_start_sequence_is_beyond_tail_sequence_then_blocks(self):
+        await self.fill_ringbuffer()
+
+        task = asyncio.create_task(self.ringbuffer.read_many(CAPACITY + 1, 1, CAPACITY))
+        await asyncio.sleep(0.5)
+        self.assertFalse(task.done())
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    async def test_when_min_count_items_are_not_available_then_blocks(self):
+        await self.fill_ringbuffer()
+
+        task = asyncio.create_task(self.ringbuffer.read_many(CAPACITY - 1, 2, 3))
+        await asyncio.sleep(0.5)
+        self.assertFalse(task.done())
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    async def test_when_some_waiting_needed(self):
+        await self.fill_ringbuffer()
+
+        task = asyncio.create_task(self.ringbuffer.read_many(CAPACITY - 1, 2, 3))
+        await asyncio.sleep(0.5)
+        self.assertFalse(task.done())
+
+        await self.ringbuffer.add(CAPACITY)
+
+        await self.assertTrueEventually(lambda: self.assertTrue(task.done()))
+
+        result_set = task.result()
+        self.assertEqual(2, result_set.read_count)
+        self.assertEqual(2, result_set.size)
+        self.assertEqual(CAPACITY + 1, result_set.next_sequence_to_read_from)
+        self.assertEqual(CAPACITY - 1, result_set[0])
+        self.assertEqual(CAPACITY - 1, result_set.get_sequence(0))
+        self.assertEqual(CAPACITY, result_set[1])
+        self.assertEqual(CAPACITY, result_set.get_sequence(1))
+
+    async def test_min_zero_when_item_available(self):
+        await self.fill_ringbuffer()
+
+        result_set = await self.ringbuffer.read_many(0, 0, 1)
+
+        self.assertEqual(1, result_set.read_count)
+        self.assertEqual(1, result_set.size)
+
+    async def test_min_zero_when_no_item_available(self):
+        result_set = await self.ringbuffer.read_many(0, 0, 1)
+
+        self.assertEqual(0, result_set.read_count)
+        self.assertEqual(0, result_set.size)
+
+    async def test_max_count(self):
+        # If more results are available than needed, the surplus results
+        # should not be read.
+        await self.fill_ringbuffer()
+
+        max_count = CAPACITY // 2
+        result_set = await self.ringbuffer.read_many(0, 0, max_count)
+        self.assertEqual(max_count, result_set.read_count)
+        self.assertEqual(max_count, result_set.size)
+        self.assertEqual(max_count, result_set.next_sequence_to_read_from)
+
+        for i in range(max_count):
+            self.assertEqual(i, result_set[i])
+            self.assertEqual(i, result_set.get_sequence(i))
+
+    async def test_filter(self):
+        def item_factory(i):
+            if i % 2 == 0:
+                return "good%s" % i
+            return "bad%s" % i
+
+        await self.fill_ringbuffer(item_factory)
+
+        expected_size = CAPACITY // 2
+
+        result_set = await self.ringbuffer.read_many(0, 0, CAPACITY, PrefixFilter("good"))
+        self.assertEqual(CAPACITY, result_set.read_count)
+        self.assertEqual(expected_size, result_set.size)
+        self.assertEqual(CAPACITY, result_set.next_sequence_to_read_from)
+
+        for i in range(expected_size):
+            self.assertEqual(item_factory(i * 2), result_set[i])
+            self.assertEqual(i * 2, result_set.get_sequence(i))
+
+    async def test_filter_with_max_count(self):
+        def item_factory(i):
+            if i % 2 == 0:
+                return "good%s" % i
+            return "bad%s" % i
+
+        await self.fill_ringbuffer(item_factory)
+
+        expected_size = 3
+
+        result_set = await self.ringbuffer.read_many(0, 0, expected_size, PrefixFilter("good"))
+        self.assertEqual(expected_size * 2 - 1, result_set.read_count)
+        self.assertEqual(expected_size, result_set.size)
+        self.assertEqual(expected_size * 2 - 1, result_set.next_sequence_to_read_from)
+
+        for i in range(expected_size):
+            self.assertEqual(item_factory(i * 2), result_set[i])
+            self.assertEqual(i * 2, result_set.get_sequence(i))
+
+    async def fill_ringbuffer(self, item_factory=lambda i: i, item_count=CAPACITY):
+        for i in range(0, item_count):
+            await self.ringbuffer.add(item_factory(i))
+
+
+class PrefixFilter(IdentifiedDataSerializable):
+    def __init__(self, prefix):
+        self.prefix = prefix
+
+    def write_data(self, object_data_output):
+        object_data_output.write_string(self.prefix)
+
+    def read_data(self, object_data_input):
+        self.prefix = object_data_input.read_string()
+
+    def get_factory_id(self):
+        return 666
+
+    def get_class_id(self):
+        return 14

--- a/tests/integration/asyncio/proxy/ringbuffer_test.py
+++ b/tests/integration/asyncio/proxy/ringbuffer_test.py
@@ -20,9 +20,7 @@ class RingBufferTest(SingleMemberTestCase):
     def configure_cluster(cls):
         path = os.path.abspath(__file__)
         dir_path = os.path.dirname(path)
-        xml_path = os.path.join(
-            dir_path, "../../backward_compatible/proxy/hazelcast.xml"
-        )
+        xml_path = os.path.join(dir_path, "../../backward_compatible/proxy/hazelcast.xml")
         with open(xml_path) as f:
             return f.read()
 
@@ -136,9 +134,7 @@ class RingbufferReadManyTest(SingleMemberTestCase):
     def configure_cluster(cls):
         path = os.path.abspath(__file__)
         dir_path = os.path.dirname(path)
-        xml_path = os.path.join(
-            dir_path, "../../backward_compatible/proxy/hazelcast.xml"
-        )
+        xml_path = os.path.join(dir_path, "../../backward_compatible/proxy/hazelcast.xml")
         with open(xml_path) as f:
             return f.read()
 


### PR DESCRIPTION
Straightforward port of `Ringbuffer` and its tests to asyncio.
Also improved some documentation.

Proxy port:
* Asyncore: https://github.com/hazelcast/hazelcast-python-client/blob/master/hazelcast/proxy/ringbuffer.py
* Asyncio: https://github.com/yuce/hazelcast-python-client/blob/asyncio-ringbuffer/hazelcast/internal/asyncio_proxy/ringbuffer.py

Test port:
* Asyncore: https://github.com/hazelcast/hazelcast-python-client/blob/master/tests/integration/backward_compatible/proxy/ringbuffer_test.py
* Asyncio: https://github.com/yuce/hazelcast-python-client/blob/asyncio-ringbuffer/tests/integration/asyncio/proxy/ringbuffer_test.py