### PR TITLE
[TRIVIAL] Skip test_ensure_on_messsage_is_not_none test for older clients

### DIFF
--- a/tests/integration/asyncio/proxy/topic_test.py
+++ b/tests/integration/asyncio/proxy/topic_test.py
@@ -83,5 +83,6 @@ class TopicTest(SingleMemberTestCase):
             await self.topic.publish_all(messages)
 
     async def test_ensure_on_messsage_is_not_none(self):
+        skip_if_client_version_older_than(self, "5.7.0")
         with self.assertRaises(AssertionError):
             await self.topic.add_listener(None)

--- a/tests/integration/backward_compatible/proxy/topic_test.py
+++ b/tests/integration/backward_compatible/proxy/topic_test.py
@@ -81,5 +81,6 @@ class TopicTest(SingleMemberTestCase):
             self.topic.publish_all(messages)
 
     def test_ensure_on_messsage_is_not_none(self):
+        skip_if_client_version_older_than(self, "5.7.0")
         with self.assertRaises(AssertionError):
             self.topic.add_listener(None)


### PR DESCRIPTION
Recently we added a check for the `on_message` parameter in the  `Topic.add_listener` message.
Since that check doesn't exist in the released versions of the client, the corresponding test fails for them in the Client compatibility test suite:
https://github.com/hazelcast/client-compatibility-suites/actions/runs/25483639833/job/74776163020

This PR updates the test to skip it for older versions of the client.