### PR TITLE
Updated test workflow

### DIFF
--- a/.github/workflows/coverage_runner.yml
+++ b/.github/workflows/coverage_runner.yml
@@ -45,7 +45,7 @@ jobs:
           - ${{ needs.python-versions.outputs.earliest-python-version }}
           - ${{ needs.python-versions.outputs.latest-python-version }}
         os: [ ubuntu-latest, windows-latest ]
-        hz_version: [ "5.6.0" ]
+        hz_version: [ "5.7.0" ]
       fail-fast: false
       
     steps:

--- a/.github/workflows/coverage_runner.yml
+++ b/.github/workflows/coverage_runner.yml
@@ -100,20 +100,24 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         working-directory: certs
         run: |
-          zip -r -j certs.jar $GITHUB_WORKSPACE/tests/integration/backward_compatible/ssl_tests/hostname_verification/*.p12
-          cp certs.jar ../hazelcast-enterprise-${{ matrix.hz_version }}-tests.jar            
+#          zip -r -j certs.jar $GITHUB_WORKSPACE/tests/integration/backward_compatible/ssl_tests/hostname_verification/*.p12
+          cp $GITHUB_WORKSPACE/tests/integration/backward_compatible/ssl_tests/hostname_verification/*.p12 .
+          jar uf certs.jar *.p12
+          cp certs.jar ../hazelcast-enterprise-${{ matrix.hz_version }}-tests.jar
 
       - name: Create the test jar with certificates (Windows)
         if: matrix.os == 'windows-latest'
         working-directory: certs
         run: |
-          $compress = @{
-            Path = "../tests/integration/backward_compatible/ssl_tests/hostname_verification/*.p12"
-            CompressionLevel = "Fastest"
-            DestinationPath = "certs.jar"
-          }
-          Compress-Archive -Update @compress
-          cp certs.jar ../hazelcast-enterprise-${{ matrix.hz_version }}-tests.jar            
+#          $compress = @{
+#            Path = "../hazelcast-enterprise-5.7.0-tests.jar"
+#            CompressionLevel = "Fastest"
+#            DestinationPath = "certs.jar"
+#          }
+#          Compress-Archive -Update @compress
+          cp $GITHUB_WORKSPACE/tests/integration/backward_compatible/ssl_tests/hostname_verification/*.p12 .
+          jar uf certs.jar *.p12
+          cp certs.jar ../hazelcast-enterprise-${{ matrix.hz_version }}-tests.jar
 
       - name: Download RCD (Linux)
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/coverage_runner.yml
+++ b/.github/workflows/coverage_runner.yml
@@ -154,6 +154,10 @@ jobs:
           cat rcd-stdout.log
           cat rcd-stderr.log
           pytest --verbose --cov=hazelcast --cov-report=xml
+          echo "RCD STDOUT:"
+          cat rcd-stdout.log
+          echo "RCD STDERR:"
+          cat rcd-stderr.log
 
       - name: Publish results to Codecov for PR coming from hazelcast organization
         if: ${{ matrix.python-version == needs.python-versions.outputs.latest-python-version && matrix.os == 'ubuntu-latest' &&  github.event_name == 'pull_request_target' }}

--- a/.github/workflows/coverage_runner.yml
+++ b/.github/workflows/coverage_runner.yml
@@ -108,7 +108,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         working-directory: certs
         run: |
-          cp $GITHUB_WORKSPACE/tests/integration/backward_compatible/ssl_tests/hostname_verification/*.p12 .
+          cp $Env:GITHUB_WORKSPACE/tests/integration/backward_compatible/ssl_tests/hostname_verification/*.p12 .
           jar uf certs.jar *.p12
           cp certs.jar ../hazelcast-enterprise-${{ matrix.hz_version }}-tests.jar
 

--- a/.github/workflows/coverage_runner.yml
+++ b/.github/workflows/coverage_runner.yml
@@ -100,7 +100,6 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         working-directory: certs
         run: |
-#          zip -r -j certs.jar $GITHUB_WORKSPACE/tests/integration/backward_compatible/ssl_tests/hostname_verification/*.p12
           cp $GITHUB_WORKSPACE/tests/integration/backward_compatible/ssl_tests/hostname_verification/*.p12 .
           jar uf certs.jar *.p12
           cp certs.jar ../hazelcast-enterprise-${{ matrix.hz_version }}-tests.jar
@@ -109,12 +108,6 @@ jobs:
         if: matrix.os == 'windows-latest'
         working-directory: certs
         run: |
-#          $compress = @{
-#            Path = "../hazelcast-enterprise-5.7.0-tests.jar"
-#            CompressionLevel = "Fastest"
-#            DestinationPath = "certs.jar"
-#          }
-#          Compress-Archive -Update @compress
           cp $GITHUB_WORKSPACE/tests/integration/backward_compatible/ssl_tests/hostname_verification/*.p12 .
           jar uf certs.jar *.p12
           cp certs.jar ../hazelcast-enterprise-${{ matrix.hz_version }}-tests.jar

--- a/.github/workflows/coverage_runner.yml
+++ b/.github/workflows/coverage_runner.yml
@@ -158,6 +158,8 @@ jobs:
           cat rcd-stdout.log
           echo "RCD STDERR:"
           cat rcd-stderr.log
+          echo "TEST JAR"
+          dir hazelcast-enterprise-5.7.0-tests.jar          
 
       - name: Publish results to Codecov for PR coming from hazelcast organization
         if: ${{ matrix.python-version == needs.python-versions.outputs.latest-python-version && matrix.os == 'ubuntu-latest' &&  github.event_name == 'pull_request_target' }}

--- a/.github/workflows/coverage_runner.yml
+++ b/.github/workflows/coverage_runner.yml
@@ -151,12 +151,6 @@ jobs:
           cat rcd-stdout.log
           cat rcd-stderr.log
           pytest --verbose --cov=hazelcast --cov-report=xml
-          echo "RCD STDOUT:"
-          cat rcd-stdout.log
-          echo "RCD STDERR:"
-          cat rcd-stderr.log
-          echo "TEST JAR"
-          dir hazelcast-enterprise-5.7.0-tests.jar          
 
       - name: Publish results to Codecov for PR coming from hazelcast organization
         if: ${{ matrix.python-version == needs.python-versions.outputs.latest-python-version && matrix.os == 'ubuntu-latest' &&  github.event_name == 'pull_request_target' }}

--- a/tests/integration/asyncio/proxy/fenced_lock_test.py
+++ b/tests/integration/asyncio/proxy/fenced_lock_test.py
@@ -16,7 +16,7 @@ class FencedLockTest(CPTestCase):
         self.lock = await self.client.cp_subsystem.get_lock(random_string())
         self.initial_acquire_count = self.get_initial_acquire_count()
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         await self.lock.destroy()
         await super().asyncTearDown()
 


### PR DESCRIPTION
- Fixed certs.jar generation for Windows
- Bumped hz version used in the test workflow
- use `asyncTearDown` for the FencedLock tests

Passing run:
https://github.com/hazelcast/hazelcast-python-client/actions/runs/27819155786/job/82327764139